### PR TITLE
fix: update version to 0.0.2 in all files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slackcli",
-  "version": "0.1.0",
+  "version": "0.0.2",
   "description": "A fast, developer-friendly CLI tool for interacting with Slack workspaces",
   "main": "src/index.ts",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ const program = new Command();
 program
   .name('slackcli')
   .description('A fast, developer-friendly CLI tool for interacting with Slack workspaces')
-  .version('0.1.0');
+  .version('0.0.2');
 
 // Add commands
 program.addCommand(createAuthCommand());

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { info, success, error as logError } from './formatter.ts';
 
 const GITHUB_REPO = 'shaharia-lab/slackcli';
-const CURRENT_VERSION = '0.1.0';
+const CURRENT_VERSION = '0.0.2';
 
 interface GitHubRelease {
   tag_name: string;


### PR DESCRIPTION
## Problem
The binary was reporting version `v0.1.0` instead of the actual release version `v0.0.2`.

## Changes
- Updated `package.json` version to `0.0.2`
- Updated CLI version in `src/index.ts` to `0.0.2`
- Updated `CURRENT_VERSION` in `src/lib/updater.ts` to `0.0.2`

## Testing
✅ Built binary now reports: `0.0.2`
✅ Update checker will now correctly detect newer versions

This ensures the binary reports the correct version matching the release tag.