### PR TITLE
chore: Reduce artifact retention to 1 day

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
+          retention-days: 1
           name: ${{ matrix.artifact }}
           path: dist/${{ matrix.artifact }}
 


### PR DESCRIPTION
## Summary
- Updates artifact retention period to 1 day
- Reduces GitHub Actions artifact storage costs

## Changes
- Modified workflow(s) to set `retention-days: 1` for `actions/upload-artifact@v4`

## Rationale
This change helps optimize GitHub Actions storage costs by reducing artifact retention to 1 day, which is sufficient for debugging recent workflow runs while preventing unnecessary long-term storage of build artifacts.