### PR TITLE
feat: add video transcript support

### DIFF
--- a/src/lib/formatter.ts
+++ b/src/lib/formatter.ts
@@ -114,7 +114,16 @@ export function formatMessage(
     }
     output += '\n';
   }
-  
+
+  // Video transcript
+  if (msg.transcript) {
+    output += `${indentStr}  ${chalk.magenta('📹 Video Transcript:')}\n`;
+    const transcriptLines = msg.transcript.split('\n');
+    transcriptLines.forEach(line => {
+      output += `${indentStr}    ${chalk.italic(line)}\n`;
+    });
+  }
+
   // Reactions
   if (msg.reactions && msg.reactions.length > 0) {
     const reactionsStr = msg.reactions

--- a/src/lib/slack-client.ts
+++ b/src/lib/slack-client.ts
@@ -171,5 +171,40 @@ export class SlackClient {
   async openConversation(users: string): Promise<any> {
     return this.request('conversations.open', { users });
   }
+
+  // Fetch file content (for VTT transcripts, etc.)
+  async fetchFileContent(url: string): Promise<string> {
+    try {
+      let headers: Record<string, string>;
+
+      if (this.config.auth_type === 'standard') {
+        // Standard auth: use Bearer token
+        headers = {
+          'Authorization': `Bearer ${this.config.token}`,
+          'User-Agent': 'Mozilla/5.0 (compatible; SlackCLI/0.1.0)',
+        };
+      } else {
+        // Browser auth: use Cookie header with xoxd token
+        const encodedXoxdToken = encodeURIComponent(this.config.xoxd_token);
+        headers = {
+          'Cookie': `d=${encodedXoxdToken}`,
+          'User-Agent': 'Mozilla/5.0 (compatible; SlackCLI/0.1.0)',
+        };
+      }
+
+      const response = await fetch(url, {
+        method: 'GET',
+        headers,
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      return await response.text();
+    } catch (error: any) {
+      throw new Error(`Failed to fetch file: ${error.message}`);
+    }
+  }
 }
 

--- a/src/lib/vtt-parser.ts
+++ b/src/lib/vtt-parser.ts
@@ -1,0 +1,17 @@
+// Parse WebVTT content and extract plain text
+export function parseVttToText(vttContent: string): string {
+  return vttContent
+    .split('\n')
+    .filter(line => {
+      const trimmed = line.trim();
+      return (
+        trimmed &&
+        !trimmed.startsWith('WEBVTT') &&
+        !trimmed.includes('-->') &&
+        !/^\d+$/.test(trimmed)
+      );
+    })
+    .map(line => line.replace(/<[^>]+>/g, '').trim())
+    .filter(Boolean)
+    .join(' ');
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -61,6 +61,30 @@ export interface SlackUser {
   };
 }
 
+// Video transcription types
+export interface SlackTranscription {
+  status: 'processing' | 'complete' | 'error' | 'none';
+  locale?: string;
+  preview?: {
+    content: string;
+    has_more: boolean;
+  };
+}
+
+export interface SlackFile {
+  id: string;
+  name?: string;
+  title?: string;
+  mimetype?: string;
+  filetype?: string;
+  subtype?: string;
+  pretty_type?: string;
+  url_private?: string;
+  url_private_download?: string;
+  vtt?: string;
+  transcription?: SlackTranscription;
+}
+
 export interface SlackMessage {
   type: string;
   user?: string;
@@ -69,6 +93,8 @@ export interface SlackMessage {
   ts: string;
   thread_ts?: string;
   reply_count?: number;
+  files?: SlackFile[];
+  transcript?: string;
   reactions?: Array<{
     name: string;
     count: number;
@@ -102,6 +128,7 @@ export interface ConversationReadOptions {
   oldest?: string;
   latest?: string;
   workspace?: string;
+  includeTranscripts?: boolean;
 }
 
 export interface MessageSendOptions {


### PR DESCRIPTION
 ### Summary
 
This PR gives SlackCLI the ability to read video transcript text from Slack messages. The CLI was already fetching messages that may have contained video file metadata (including the VTT URL) but wasn't making the extra request to fetch or display that data. Now video transcripts are fetched and displayed inline with conversation output.
____

   ### Changes

  Video Transcripts in Conversation Read

  - Automatically fetches VTT transcripts for videos with completed transcriptions
  - Parses WebVTT format and displays plain text in conversation output
  - Enabled by default, can be disabled with --no-include-transcripts
  - Works with both standard and browser authentication methods

 ### Usage:

  ```bash
  # Read conversation data, including video transcripts (default)**
  slackcli conversations read C1234567890

  # Disable transcripts
  slackcli conversations read C1234567890 --no-include-transcripts

 # JSON output includes transcript field
 slackcli conversations read C1234567890 --json
 ```

 ### Benefits:

  - Makes video content searchable and readable in CLI output
  - Agentic workflows using SlackCLI can now read transcripts from video messages

 ### Technical Details

  Files Modified

  - src/commands/conversations.ts - Added transcript fetching logic and CLI flags
  - src/lib/slack-client.ts - Added fetchFileContent method for VTT retrieval
  - src/lib/formatter.ts - Added transcript display formatting
  - src/lib/vtt-parser.ts - New file for WebVTT parsing
  - src/types/index.ts - Added SlackFile and SlackTranscription types

  Implementation Notes

  - Only fetches transcripts where transcription.status === 'complete'
  - Videos without audio or failed transcriptions are skipped silently
  - VTT parser strips timestamps and formatting tags, outputs plain text
  - Handles both auth types (Bearer token for standard, Cookie for browser)

  Testing
  
  I locally tested this using SlackCLI and video messages within slack

  Breaking Changes

  None - transcripts are enabled by default but this is additive behavior.

