### PR TITLE
Add Homebrew formula update to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,5 +91,6 @@ jobs:
     uses: shaharia-lab/actions-library/.github/workflows/update-homebrew-formula.yml@main
     with:
       formula-name: slackcli
+      tag-name: ${{ github.ref_name }}
     secrets:
       tap-token: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds automatic Homebrew formula update when a new release is published
- Uses reusable workflow from `shaharia-lab/actions-library`
- Updates the `slackcli` formula in `shaharia-lab/homebrew-tap`

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Test by creating a new release

🤖 Generated with [Claude Code](https://claude.com/claude-code)