### PR TITLE
Add interactive input and clipboard support for parse-curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ The easiest way to extract browser tokens is to copy a Slack API request as cURL
 # Step 1: In browser DevTools, right-click any Slack API request
 #         → Copy → Copy as cURL
 
-# Step 2: Parse the cURL command (shows tokens without logging in)
-slackcli auth parse-curl "paste-your-curl-command-here"
+# Step 2: Interactive mode (recommended) - just paste and press Enter twice
+slackcli auth parse-curl --login
 
-# Step 3: Or parse and login automatically with --login flag
-slackcli auth parse-curl --login "paste-your-curl-command-here"
+# Alternative: Read directly from clipboard
+slackcli auth parse-curl --from-clipboard --login
 
 # Alternative: Pipe from clipboard or file
 pbpaste | slackcli auth parse-curl --login

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "slackcli",

--- a/src/lib/clipboard.test.ts
+++ b/src/lib/clipboard.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, mock, beforeEach, afterEach } from 'bun:test';
+import { readClipboard, isClipboardAvailable } from './clipboard';
+
+describe('clipboard', () => {
+  describe('readClipboard', () => {
+    it('should return a ClipboardResult object', async () => {
+      const result = await readClipboard();
+
+      // Result should have the correct structure
+      expect(result).toHaveProperty('success');
+      expect(typeof result.success).toBe('boolean');
+
+      if (result.success) {
+        expect(result).toHaveProperty('content');
+        expect(typeof result.content).toBe('string');
+      } else {
+        expect(result).toHaveProperty('error');
+        expect(typeof result.error).toBe('string');
+      }
+    });
+
+    it('should handle platform-specific behavior', async () => {
+      const result = await readClipboard();
+
+      // On Linux without display, it might fail - that's expected
+      if (process.platform === 'linux' && !process.env.DISPLAY) {
+        // Either it works (xclip installed with display) or fails gracefully
+        expect(typeof result.success).toBe('boolean');
+      }
+
+      // On macOS/Windows, it should generally work in a desktop environment
+      // But in CI/headless, it might fail - that's OK
+    });
+
+    it('should not throw exceptions', async () => {
+      // readClipboard should never throw - always returns a result object
+      await expect(readClipboard()).resolves.toBeDefined();
+    });
+  });
+
+  describe('isClipboardAvailable', () => {
+    it('should return a boolean', async () => {
+      const result = await isClipboardAvailable();
+      expect(typeof result).toBe('boolean');
+    });
+
+    it('should not throw exceptions', async () => {
+      await expect(isClipboardAvailable()).resolves.toBeDefined();
+    });
+  });
+
+  describe('error messages', () => {
+    it('should provide helpful error messages on Linux', async () => {
+      // This test verifies the error message format when clipboard fails on Linux
+      if (process.platform === 'linux') {
+        const result = await readClipboard();
+        if (!result.success && result.error?.includes('xclip')) {
+          expect(result.error).toContain('Install with');
+        }
+      }
+    });
+  });
+});

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,0 +1,150 @@
+/**
+ * Cross-platform clipboard reading utility
+ */
+
+import { spawn } from 'child_process';
+
+export interface ClipboardResult {
+  success: boolean;
+  content?: string;
+  error?: string;
+}
+
+/**
+ * Read content from the system clipboard
+ * Works on macOS, Windows, and Linux (with xclip/xsel installed)
+ */
+export async function readClipboard(): Promise<ClipboardResult> {
+  const platform = process.platform;
+
+  try {
+    let command: string;
+    let args: string[];
+
+    switch (platform) {
+      case 'darwin':
+        // macOS
+        command = 'pbpaste';
+        args = [];
+        break;
+
+      case 'win32':
+        // Windows - use PowerShell
+        command = 'powershell';
+        args = ['-NoProfile', '-Command', 'Get-Clipboard'];
+        break;
+
+      case 'linux':
+        // Linux - try xclip first, then xsel
+        const xclipResult = await tryCommand('xclip', ['-selection', 'clipboard', '-o']);
+        if (xclipResult.success) {
+          return xclipResult;
+        }
+
+        const xselResult = await tryCommand('xsel', ['--clipboard', '--output']);
+        if (xselResult.success) {
+          return xselResult;
+        }
+
+        return {
+          success: false,
+          error:
+            'Clipboard access requires xclip or xsel on Linux.\n' +
+            'Install with: sudo apt install xclip (Debian/Ubuntu)\n' +
+            '          or: sudo dnf install xclip (Fedora)',
+        };
+
+      default:
+        return {
+          success: false,
+          error: `Unsupported platform: ${platform}`,
+        };
+    }
+
+    return await tryCommand(command, args);
+  } catch (err: any) {
+    return {
+      success: false,
+      error: err.message || 'Unknown clipboard error',
+    };
+  }
+}
+
+/**
+ * Try to execute a command and capture its output
+ */
+async function tryCommand(command: string, args: string[]): Promise<ClipboardResult> {
+  return new Promise((resolve) => {
+    let resolved = false;
+    const proc = spawn(command, args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    const timeoutId = setTimeout(() => {
+      if (!resolved) {
+        resolved = true;
+        proc.kill();
+        resolve({
+          success: false,
+          error: 'Clipboard read timed out',
+        });
+      }
+    }, 5000);
+
+    proc.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    proc.on('error', (err: any) => {
+      if (!resolved) {
+        resolved = true;
+        clearTimeout(timeoutId);
+        if (err.code === 'ENOENT') {
+          resolve({
+            success: false,
+            error: `Command not found: ${command}`,
+          });
+        } else {
+          resolve({
+            success: false,
+            error: err.message,
+          });
+        }
+      }
+    });
+
+    proc.on('close', (code) => {
+      if (!resolved) {
+        resolved = true;
+        clearTimeout(timeoutId);
+        if (code === 0) {
+          resolve({
+            success: true,
+            content: stdout,
+          });
+        } else {
+          resolve({
+            success: false,
+            error: stderr || `Command exited with code ${code}`,
+          });
+        }
+      }
+    });
+  });
+}
+
+/**
+ * Check if clipboard access is available on this system
+ */
+export async function isClipboardAvailable(): Promise<boolean> {
+  const result = await readClipboard();
+  // Even if clipboard is empty, success means it's available
+  return result.success || !result.error?.includes('not found');
+}

--- a/src/lib/curl-parser.test.ts
+++ b/src/lib/curl-parser.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'bun:test';
+import { parseCurlCommand, CurlParseError, looksLikeCurlCommand } from './curl-parser';
+
+// Sample cURL command with anonymized tokens (based on real Slack API request format)
+const SAMPLE_CURL_COMMAND = `curl 'https://myworkspace.slack.com/api/conversations.view?_x_id=noversion-1770041775.173&_x_version_ts=1770035254&_x_frontend_build_type=current&_x_desktop_ia=4&_x_gantry=true&fp=66&_x_num_retries=0' \\
+  -H 'accept: */*' \\
+  -H 'accept-language: en-US,en-GB;q=0.9,en;q=0.8,de-DE;q=0.7,de;q=0.6' \\
+  -H 'content-type: multipart/form-data; boundary=----WebKitFormBoundaryBPkbAXdra05yI37u' \\
+  -b 'cjConsent=MHxZfDB8Tnww; ssb_instance_id=53f4c0a9-f40a-4a88-9324-d24baa3bff28; d=xoxd-XXXXXXXXXXXXXXXX-XXXXXXXXXXXXXXXX-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX; lc=1770041685' \\
+  -H 'origin: https://app.slack.com' \\
+  -H 'user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36' \\
+  --data-raw $'------WebKitFormBoundaryBPkbAXdra05yI37u\\r\\nContent-Disposition: form-data; name="token"\\r\\n\\r\\nxoxc-XXXXXXXXXX-XXXXXXXXXX-XXXXXXXXXXXXXXXXXX-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\\r\\n------WebKitFormBoundaryBPkbAXdra05yI37u\\r\\nContent-Disposition: form-data; name="channel"\\r\\n\\r\\nC038K56TGNB\\r\\n------WebKitFormBoundaryBPkbAXdra05yI37u--\\r\\n'`;
+
+// Alternative format with -H 'Cookie:' header instead of -b
+const CURL_WITH_COOKIE_HEADER = `curl 'https://testteam.slack.com/api/users.list' \\
+  -H 'Cookie: d=xoxd-AAAABBBBCCCCDDDD-1234567890' \\
+  --data-raw $'------WebKitFormBoundary\\r\\nContent-Disposition: form-data; name="token"\\r\\n\\r\\nxoxc-111222333-444555666-abcdefghij\\r\\n------WebKitFormBoundary--\\r\\n'`;
+
+// Format with --cookie flag
+const CURL_WITH_COOKIE_FLAG = `curl 'https://anotherteam.slack.com/api/channels.list' \\
+  --cookie 'd=xoxd-TESTTOKEN-12345; other=value' \\
+  --data $'------Boundary\\r\\nContent-Disposition: form-data; name="token"\\r\\n\\r\\nxoxc-test-token-123\\r\\n------Boundary--\\r\\n'`;
+
+// URL-encoded xoxd token (common in real requests)
+const CURL_WITH_ENCODED_TOKEN = `curl 'https://encoded.slack.com/api/test' \\
+  -b 'd=xoxd-encoded%2Btoken%2Fwith%3Dspecial' \\
+  --data-raw $'------Boundary\\r\\nContent-Disposition: form-data; name="token"\\r\\n\\r\\nxoxc-encoded-test\\r\\n------Boundary--\\r\\n'`;
+
+// Single line format (no backslashes)
+const CURL_SINGLE_LINE = `curl 'https://singleline.slack.com/api/test' -b 'd=xoxd-single-line-token' --data-raw $'------Boundary\\r\\nContent-Disposition: form-data; name="token"\\r\\n\\r\\nxoxc-single-line\\r\\n------Boundary--\\r\\n'`;
+
+describe('parseCurlCommand', () => {
+  describe('workspace extraction', () => {
+    it('should extract workspace name and URL from standard curl command', () => {
+      const result = parseCurlCommand(SAMPLE_CURL_COMMAND);
+      expect(result.workspaceName).toBe('myworkspace');
+      expect(result.workspaceUrl).toBe('https://myworkspace.slack.com');
+    });
+
+    it('should extract workspace from different team URLs', () => {
+      const result = parseCurlCommand(CURL_WITH_COOKIE_HEADER);
+      expect(result.workspaceName).toBe('testteam');
+      expect(result.workspaceUrl).toBe('https://testteam.slack.com');
+    });
+
+    it('should handle single-line curl commands', () => {
+      const result = parseCurlCommand(CURL_SINGLE_LINE);
+      expect(result.workspaceName).toBe('singleline');
+    });
+
+    it('should throw CurlParseError for missing workspace URL', () => {
+      const invalidCurl = `curl 'https://example.com/api/test' -b 'd=xoxd-token'`;
+      expect(() => parseCurlCommand(invalidCurl)).toThrow(CurlParseError);
+      try {
+        parseCurlCommand(invalidCurl);
+      } catch (e) {
+        expect((e as CurlParseError).field).toBe('workspace');
+      }
+    });
+  });
+
+  describe('xoxd token extraction', () => {
+    it('should extract xoxd token from -b flag', () => {
+      const result = parseCurlCommand(SAMPLE_CURL_COMMAND);
+      expect(result.xoxd).toMatch(/^xoxd-/);
+    });
+
+    it('should extract xoxd token from -H Cookie header', () => {
+      const result = parseCurlCommand(CURL_WITH_COOKIE_HEADER);
+      expect(result.xoxd).toBe('xoxd-AAAABBBBCCCCDDDD-1234567890');
+    });
+
+    it('should extract xoxd token from --cookie flag', () => {
+      const result = parseCurlCommand(CURL_WITH_COOKIE_FLAG);
+      expect(result.xoxd).toBe('xoxd-TESTTOKEN-12345');
+    });
+
+    it('should decode URL-encoded xoxd tokens', () => {
+      const result = parseCurlCommand(CURL_WITH_ENCODED_TOKEN);
+      expect(result.xoxd).toBe('xoxd-encoded+token/with=special');
+    });
+
+    it('should throw CurlParseError for missing xoxd token', () => {
+      const curlWithoutXoxd = `curl 'https://test.slack.com/api/test' -b 'other=value' --data-raw $'------Boundary\\r\\nContent-Disposition: form-data; name="token"\\r\\n\\r\\nxoxc-test\\r\\n------Boundary--\\r\\n'`;
+      expect(() => parseCurlCommand(curlWithoutXoxd)).toThrow(CurlParseError);
+      try {
+        parseCurlCommand(curlWithoutXoxd);
+      } catch (e) {
+        expect((e as CurlParseError).field).toBe('xoxd');
+      }
+    });
+  });
+
+  describe('xoxc token extraction', () => {
+    it('should extract xoxc token from --data-raw', () => {
+      const result = parseCurlCommand(SAMPLE_CURL_COMMAND);
+      expect(result.xoxc).toMatch(/^xoxc-/);
+    });
+
+    it('should extract xoxc token from --data flag', () => {
+      const result = parseCurlCommand(CURL_WITH_COOKIE_FLAG);
+      expect(result.xoxc).toBe('xoxc-test-token-123');
+    });
+
+    it('should handle different token formats', () => {
+      const result = parseCurlCommand(CURL_WITH_COOKIE_HEADER);
+      expect(result.xoxc).toBe('xoxc-111222333-444555666-abcdefghij');
+    });
+
+    it('should throw CurlParseError for missing xoxc token', () => {
+      const curlWithoutXoxc = `curl 'https://test.slack.com/api/test' -b 'd=xoxd-test' --data-raw $'------Boundary\\r\\nContent-Disposition: form-data; name="other"\\r\\n\\r\\nvalue\\r\\n------Boundary--\\r\\n'`;
+      expect(() => parseCurlCommand(curlWithoutXoxc)).toThrow(CurlParseError);
+      try {
+        parseCurlCommand(curlWithoutXoxc);
+      } catch (e) {
+        expect((e as CurlParseError).field).toBe('xoxc');
+      }
+    });
+  });
+
+  describe('complete parsing', () => {
+    it('should parse all tokens from a complete curl command', () => {
+      const result = parseCurlCommand(SAMPLE_CURL_COMMAND);
+
+      expect(result).toHaveProperty('workspaceName');
+      expect(result).toHaveProperty('workspaceUrl');
+      expect(result).toHaveProperty('xoxd');
+      expect(result).toHaveProperty('xoxc');
+
+      expect(result.workspaceName).toBeTruthy();
+      expect(result.workspaceUrl).toContain('slack.com');
+      expect(result.xoxd).toMatch(/^xoxd-/);
+      expect(result.xoxc).toMatch(/^xoxc-/);
+    });
+
+    it('should handle real-world curl command formats', () => {
+      // Test with various real-world formats
+      const formats = [
+        SAMPLE_CURL_COMMAND,
+        CURL_WITH_COOKIE_HEADER,
+        CURL_WITH_COOKIE_FLAG,
+        CURL_SINGLE_LINE,
+      ];
+
+      for (const curl of formats) {
+        const result = parseCurlCommand(curl);
+        expect(result.xoxd).toMatch(/^xoxd-/);
+        expect(result.xoxc).toMatch(/^xoxc-/);
+      }
+    });
+  });
+});
+
+describe('CurlParseError', () => {
+  it('should have correct name and field properties', () => {
+    const error = new CurlParseError('workspace', 'Test error');
+    expect(error.name).toBe('CurlParseError');
+    expect(error.field).toBe('workspace');
+    expect(error.message).toBe('Test error');
+  });
+
+  it('should be an instance of Error', () => {
+    const error = new CurlParseError('xoxd', 'Test');
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(CurlParseError);
+  });
+});
+
+describe('looksLikeCurlCommand', () => {
+  it('should return true for valid curl commands', () => {
+    expect(looksLikeCurlCommand("curl 'https://example.com'")).toBe(true);
+    expect(looksLikeCurlCommand('curl "https://example.com"')).toBe(true);
+    expect(looksLikeCurlCommand('curl https://example.com')).toBe(true);
+    expect(looksLikeCurlCommand('  curl https://example.com')).toBe(true);
+    expect(looksLikeCurlCommand('\ncurl https://example.com')).toBe(true);
+  });
+
+  it('should return false for non-curl content', () => {
+    expect(looksLikeCurlCommand('https://example.com')).toBe(false);
+    expect(looksLikeCurlCommand('wget https://example.com')).toBe(false);
+    expect(looksLikeCurlCommand('some random text')).toBe(false);
+    expect(looksLikeCurlCommand('')).toBe(false);
+    expect(looksLikeCurlCommand('curlhttps://example.com')).toBe(false);
+  });
+
+  it('should handle curl with tab separator', () => {
+    expect(looksLikeCurlCommand('curl\thttps://example.com')).toBe(true);
+  });
+});

--- a/src/lib/curl-parser.ts
+++ b/src/lib/curl-parser.ts
@@ -1,0 +1,85 @@
+/**
+ * Curl command parser for extracting Slack authentication tokens
+ */
+
+export interface ParsedCurlResult {
+  workspaceName: string;
+  workspaceUrl: string;
+  xoxd: string;
+  xoxc: string;
+}
+
+export interface ParseError {
+  field: 'workspace' | 'xoxd' | 'xoxc';
+  message: string;
+}
+
+/**
+ * Parse a cURL command and extract Slack authentication tokens
+ */
+export function parseCurlCommand(curlInput: string): ParsedCurlResult {
+  // Extract workspace URL
+  const urlMatch = curlInput.match(/curl\s+'?(https?:\/\/([^.]+)\.slack\.com[^'"\s]*)/);
+  if (!urlMatch) {
+    throw new CurlParseError('workspace', 'Could not find Slack workspace URL in cURL command');
+  }
+  const workspaceUrl = `https://${urlMatch[2]}.slack.com`;
+  const workspaceName = urlMatch[2];
+
+  // Extract xoxd token from cookie header
+  // Supports: -b 'cookies', --cookie 'cookies', -H 'Cookie: cookies'
+  const cookieMatch = curlInput.match(
+    /-b\s+'([^']+)'|--cookie\s+'([^']+)'|-H\s+'[Cc]ookie:\s*([^']+)'/
+  );
+  const cookieHeader = cookieMatch ? (cookieMatch[1] || cookieMatch[2] || cookieMatch[3]) : '';
+
+  const xoxdMatch = cookieHeader.match(/(?:^|;\s*)d=(xoxd-[^;]+)/);
+  if (!xoxdMatch) {
+    throw new CurlParseError('xoxd', 'Could not find xoxd token in cookie header (d=xoxd-...)');
+  }
+  const xoxdEncoded = xoxdMatch[1];
+  const xoxd = decodeURIComponent(xoxdEncoded);
+
+  // Extract xoxc token from data
+  // Supports: --data-raw 'data', --data-raw $'data', --data 'data', --data $'data'
+  const dataMatch = curlInput.match(
+    /--data-raw\s+\$?'([^']+)'|--data-raw\s+\$?"([^"]+)"|--data\s+\$?'([^']+)'|--data\s+\$?"([^"]+)"/
+  );
+  const dataContent = dataMatch
+    ? (dataMatch[1] || dataMatch[2] || dataMatch[3] || dataMatch[4])
+    : '';
+
+  const xoxcMatch = dataContent.match(/name="token".*?(xoxc-[a-zA-Z0-9-]+)/);
+  if (!xoxcMatch) {
+    throw new CurlParseError('xoxc', 'Could not find xoxc token in request data');
+  }
+  const xoxc = xoxcMatch[1];
+
+  return {
+    workspaceName,
+    workspaceUrl,
+    xoxd,
+    xoxc,
+  };
+}
+
+/**
+ * Custom error class for cURL parsing errors
+ */
+export class CurlParseError extends Error {
+  public field: ParseError['field'];
+
+  constructor(field: ParseError['field'], message: string) {
+    super(message);
+    this.name = 'CurlParseError';
+    this.field = field;
+  }
+}
+
+/**
+ * Validate that a string looks like a cURL command
+ */
+export function looksLikeCurlCommand(input: string): boolean {
+  const trimmed = input.trim();
+  return trimmed.startsWith('curl ') || trimmed.startsWith('curl\t');
+}

--- a/src/lib/interactive-input.test.ts
+++ b/src/lib/interactive-input.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'bun:test';
+import { isInteractiveTerminal, hasPipedInput } from './interactive-input';
+
+describe('interactive-input', () => {
+  describe('isInteractiveTerminal', () => {
+    it('should return a boolean', () => {
+      const result = isInteractiveTerminal();
+      expect(typeof result).toBe('boolean');
+    });
+
+    it('should detect non-TTY in test environment', () => {
+      // In test environment, stdin is typically not a TTY
+      // This might vary depending on how tests are run
+      const result = isInteractiveTerminal();
+      expect(typeof result).toBe('boolean');
+    });
+  });
+
+  describe('hasPipedInput', () => {
+    it('should return a boolean', () => {
+      const result = hasPipedInput();
+      expect(typeof result).toBe('boolean');
+    });
+
+    it('should be opposite of isInteractiveTerminal', () => {
+      // hasPipedInput is defined as !process.stdin.isTTY
+      // isInteractiveTerminal is defined as Boolean(process.stdin.isTTY)
+      // They should be logical opposites (though hasPipedInput doesn't use Boolean())
+      const interactive = isInteractiveTerminal();
+      const piped = hasPipedInput();
+
+      // If interactive, then not piped; if piped, then not interactive
+      if (interactive) {
+        expect(piped).toBe(false);
+      }
+      if (piped) {
+        expect(interactive).toBe(false);
+      }
+    });
+  });
+
+  describe('readInteractiveInput', () => {
+    // Note: readInteractiveInput is difficult to test in automated tests
+    // because it requires actual TTY interaction or piped input.
+    // The function itself handles both cases:
+    // - TTY: Prompts user and waits for Enter twice
+    // - Piped: Reads all stdin until EOF
+
+    it('should be importable', async () => {
+      const { readInteractiveInput } = await import('./interactive-input');
+      expect(typeof readInteractiveInput).toBe('function');
+    });
+  });
+});

--- a/src/lib/interactive-input.ts
+++ b/src/lib/interactive-input.ts
@@ -1,0 +1,105 @@
+/**
+ * Interactive input handling for multi-line input
+ */
+
+import * as readline from 'readline';
+import chalk from 'chalk';
+
+export interface InteractiveInputOptions {
+  prompt?: string;
+  hint?: string;
+  /**
+   * Number of consecutive empty lines to trigger completion
+   * Default: 2 (press Enter twice)
+   */
+  emptyLinesToComplete?: number;
+}
+
+/**
+ * Read multi-line input from the user interactively
+ * Completes when user presses Enter twice or Ctrl+D
+ */
+export async function readInteractiveInput(
+  options: InteractiveInputOptions = {}
+): Promise<string> {
+  const {
+    prompt = 'Paste your input (press Enter twice when done):',
+    hint = 'Tip: You can also press Ctrl+D to finish',
+    emptyLinesToComplete = 2,
+  } = options;
+
+  return new Promise((resolve, reject) => {
+    const lines: string[] = [];
+    let consecutiveEmptyLines = 0;
+
+    // Check if stdin is a TTY (interactive terminal)
+    if (!process.stdin.isTTY) {
+      // Not interactive, read all stdin
+      const chunks: Buffer[] = [];
+      process.stdin.on('data', (chunk) => chunks.push(chunk));
+      process.stdin.on('end', () => {
+        resolve(Buffer.concat(chunks).toString('utf-8'));
+      });
+      process.stdin.on('error', reject);
+      return;
+    }
+
+    console.log(chalk.bold(`\n${prompt}`));
+    console.log(chalk.gray(hint));
+    console.log();
+
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+      terminal: true,
+    });
+
+    rl.on('line', (line) => {
+      if (line.trim() === '') {
+        consecutiveEmptyLines++;
+        if (consecutiveEmptyLines >= emptyLinesToComplete) {
+          rl.close();
+          // Remove trailing empty lines
+          while (lines.length > 0 && lines[lines.length - 1].trim() === '') {
+            lines.pop();
+          }
+          resolve(lines.join('\n'));
+          return;
+        }
+      } else {
+        consecutiveEmptyLines = 0;
+      }
+      lines.push(line);
+    });
+
+    rl.on('close', () => {
+      // Remove trailing empty lines
+      while (lines.length > 0 && lines[lines.length - 1].trim() === '') {
+        lines.pop();
+      }
+      resolve(lines.join('\n'));
+    });
+
+    rl.on('error', reject);
+
+    // Handle Ctrl+C
+    rl.on('SIGINT', () => {
+      rl.close();
+      process.exit(130);
+    });
+  });
+}
+
+/**
+ * Check if we're running in an interactive terminal
+ */
+export function isInteractiveTerminal(): boolean {
+  return Boolean(process.stdin.isTTY);
+}
+
+/**
+ * Check if there's piped input available
+ */
+export function hasPipedInput(): boolean {
+  return !process.stdin.isTTY;
+}


### PR DESCRIPTION
## Summary

- Add **interactive mode** as the default input method for `parse-curl` - users can paste cURL and press Enter twice
- Add **`--from-clipboard`** flag to read directly from system clipboard (supports macOS, Windows, Linux)
- Extract curl parsing logic into a testable `curl-parser` module
- Add 31 unit tests covering parsing, clipboard, and input handling

## New Usage

```bash
# Interactive mode (recommended)
slackcli auth parse-curl --login
# Prompts: "Paste your cURL command (press Enter twice when done):"

# From clipboard
slackcli auth parse-curl --from-clipboard --login

# Existing methods still work
pbpaste | slackcli auth parse-curl --login
```

## Test plan

- [x] Unit tests pass (`bun test` - 31 tests)
- [x] Type checking passes (`bun run type-check`)
- [ ] Manual test: Interactive mode on terminal
- [ ] Manual test: `--from-clipboard` on Linux with xclip
- [ ] Manual test: Piped input still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)