### PR TITLE
Fix: Auto-inject version during release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,12 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
       - name: Build binary
-        run: bun build --compile --minify --target=${{ matrix.target }} src/index.ts --outfile dist/${{ matrix.artifact }}
+        run: bun build --compile --minify --target=${{ matrix.target }} --define __APP_VERSION__='"${{ steps.version.outputs.VERSION }}"' src/index.ts --outfile dist/${{ matrix.artifact }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "type": "module",
   "scripts": {
     "dev": "bun run src/index.ts",
-    "build": "bun build --compile --minify --sourcemap src/index.ts --outfile dist/slackcli",
+    "build": "bun build --compile --minify --sourcemap --define __APP_VERSION__='\"0.2.2\"' src/index.ts --outfile dist/slackcli",
     "build:all": "bun run build:linux && bun run build:macos && bun run build:windows",
-    "build:linux": "bun build --compile --minify --target=bun-linux-x64 src/index.ts --outfile dist/slackcli-linux",
-    "build:macos": "bun build --compile --minify --target=bun-darwin-x64 src/index.ts --outfile dist/slackcli-macos",
-    "build:windows": "bun build --compile --minify --target=bun-windows-x64 src/index.ts --outfile dist/slackcli-windows.exe",
+    "build:linux": "bun build --compile --minify --target=bun-linux-x64 --define __APP_VERSION__='\"0.2.2\"' src/index.ts --outfile dist/slackcli-linux",
+    "build:macos": "bun build --compile --minify --target=bun-darwin-x64 --define __APP_VERSION__='\"0.2.2\"' src/index.ts --outfile dist/slackcli-macos",
+    "build:windows": "bun build --compile --minify --target=bun-windows-x64 --define __APP_VERSION__='\"0.2.2\"' src/index.ts --outfile dist/slackcli-windows.exe",
     "test": "bun test",
     "type-check": "bunx tsc --noEmit"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,13 @@ import chalk from 'chalk';
 
 const program = new Command();
 
+// @ts-ignore - This will be replaced at build time
+const APP_VERSION = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev';
+
 program
   .name('slackcli')
   .description('A fast, developer-friendly CLI tool for interacting with Slack workspaces')
-  .version('0.1.1');
+  .version(APP_VERSION);
 
 // Add commands
 program.addCommand(createAuthCommand());

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -4,7 +4,8 @@ import { join } from 'path';
 import { info, success, error as logError } from './formatter.ts';
 
 const GITHUB_REPO = 'shaharia-lab/slackcli';
-const CURRENT_VERSION = '0.1.1';
+// @ts-ignore - This will be replaced at build time
+const CURRENT_VERSION = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev';
 
 interface GitHubRelease {
   tag_name: string;


### PR DESCRIPTION
## Summary
- Automatically inject version from git tags during release builds
- Eliminates manual version updates in code for each release
- Fixes issue where v0.2.2 release showed version 0.1.1

## Changes
- Updated release workflow to extract version from git tag and inject using `--define` flag
- Replaced hardcoded versions in `src/index.ts` and `src/lib/updater.ts` with `__APP_VERSION__` constant
- Updated local build scripts in `package.json` to include version definition
- Version falls back to `'dev'` when running locally without build-time injection

## How it works
1. Release workflow extracts version from tag (e.g., `v0.2.3` → `0.2.3`)
2. Bun build injects version at compile time using `--define __APP_VERSION__="0.2.3"`
3. Version is baked into the compiled binary
4. No manual code changes needed for future releases

## Test plan
- [ ] Wait for CI checks to pass
- [ ] Merge to main
- [ ] Create v0.2.3 release
- [ ] Verify `slackcli --version` shows `0.2.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)