### PR TITLE
Docs: add unofficial disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SlackCLI
 
+> **Disclaimer:** This is an unofficial, open-source CLI tool for interacting with Slack. It is not affiliated with, endorsed by, or supported by Slack Technologies. Slack has an official CLI — see the [Slack CLI documentation](https://docs.slack.dev/tools/slack-cli/) for the officially supported tooling.
+
 A fast, developer-friendly command-line interface tool for interacting with Slack workspaces. Built with TypeScript and Bun, it enables AI agents, automation tools, and developers to access Slack functionality directly from the terminal.
 
 ## Features


### PR DESCRIPTION
## Summary

Adds a disclaimer at the top of the README to make it clear that this is an unofficial, community-maintained open source tool — not affiliated with or endorsed by Slack Technologies.

Also links to the [official Slack CLI](https://docs.slack.dev/tools/slack-cli/) so users who are looking for Slack's supported tooling can find it easily.

## Changes
- Added a blockquote disclaimer below the title in `README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)