### PR TITLE
fix: use correct binary for macOS arm64 in self-updater

### DIFF
--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -61,9 +61,10 @@ export function isNewerVersion(latest: string, current: string): boolean {
 // Get platform-specific binary name
 function getBinaryName(): string {
   const platform = process.platform;
+  const arch = process.arch;
 
   if (platform === 'linux') return 'slackcli-linux';
-  if (platform === 'darwin') return 'slackcli-macos';
+  if (platform === 'darwin') return arch === 'arm64' ? 'slackcli-macos-arm64' : 'slackcli-macos';
   if (platform === 'win32') return 'slackcli-windows.exe';
 
   throw new Error(`Unsupported platform: ${platform}`);


### PR DESCRIPTION
## Summary
- `getBinaryName()` in the self-updater ignored CPU architecture, always returning `slackcli-macos` (x64) on all macOS machines
- On arm64 Macs this caused Bun to emit an AVX warning and risk crashes, since the x64 binary was replacing the arm64 one
- Now checks `process.arch` and returns `slackcli-macos-arm64` on Apple Silicon

## Test plan
- [x] Verified `process.platform` / `process.arch` resolves to `slackcli-macos-arm64` on darwin/arm64
- [x] Verified the matching asset exists in the latest GitHub release
- [x] All existing tests pass (`bun test` — 109 tests)
- [x] Type-check passes (`bun run type-check`)