### PR TITLE
feat: display uploaded file metadata in conversation messages

### DIFF
--- a/src/commands/conversations.ts
+++ b/src/commands/conversations.ts
@@ -153,6 +153,17 @@ export function createConversationsCommand(): Command {
               reactions: msg.reactions,
               bot_id: msg.bot_id,
               blocks: msg.blocks,
+              ...(msg.files?.length ? { files: msg.files.map(f => ({
+                id: f.id,
+                name: f.name,
+                title: f.title,
+                mimetype: f.mimetype,
+                filetype: f.filetype,
+                size: f.size,
+                url_private: f.url_private,
+                permalink: f.permalink,
+                mode: f.mode,
+              })) } : {}),
             })),
             users: Array.from(users.values()).map(u => ({
               id: u.id,

--- a/src/lib/formatter.test.ts
+++ b/src/lib/formatter.test.ts
@@ -7,6 +7,7 @@ import {
   formatUnreadChannels,
   formatPaginationHint,
   formatFileSize,
+  formatMessage,
 } from './formatter.ts';
 import type {
   SavedItem,
@@ -15,6 +16,7 @@ import type {
   PeopleSearchResult,
   UnreadChannel,
   SlackUser,
+  SlackMessage,
 } from '../types/index.ts';
 
 describe('formatSavedItems', () => {
@@ -214,6 +216,138 @@ describe('formatPaginationHint', () => {
   it('returns empty string on last page', () => {
     const output = formatPaginationHint(3, 3);
     expect(output).toBe('');
+  });
+});
+
+describe('formatMessage file display', () => {
+  const users = new Map<string, SlackUser>([
+    ['U1', { id: 'U1', name: 'alice', real_name: 'Alice' }],
+  ]);
+
+  it('displays single file with all metadata', () => {
+    const msg: SlackMessage = {
+      type: 'message', user: 'U1', text: 'Here is the doc', ts: '1700000000.000100',
+      files: [{
+        id: 'F1', name: 'doc.pdf', size: 1258291, mimetype: 'application/pdf',
+        url_private: 'https://files.slack.com/doc.pdf',
+      }],
+    };
+    const output = formatMessage(msg, users);
+    expect(output).toContain('doc.pdf');
+    expect(output).toContain('1.2 MB');
+    expect(output).toContain('application/pdf');
+    expect(output).toContain('https://files.slack.com/doc.pdf');
+  });
+
+  it('displays multiple files in order', () => {
+    const msg: SlackMessage = {
+      type: 'message', user: 'U1', text: 'Two files', ts: '1700000000.000100',
+      files: [
+        { id: 'F1', name: 'a.txt', size: 100, url_private: 'https://a.txt' },
+        { id: 'F2', name: 'b.txt', size: 200, url_private: 'https://b.txt' },
+      ],
+    };
+    const output = formatMessage(msg, users);
+    const posA = output.indexOf('a.txt');
+    const posB = output.indexOf('b.txt');
+    expect(posA).toBeGreaterThan(-1);
+    expect(posB).toBeGreaterThan(posA);
+  });
+
+  it('renders nothing when files is undefined', () => {
+    const msg: SlackMessage = {
+      type: 'message', user: 'U1', text: 'No files', ts: '1700000000.000100',
+    };
+    const output = formatMessage(msg, users);
+    expect(output).not.toContain('📎');
+  });
+
+  it('renders nothing when files is empty array', () => {
+    const msg: SlackMessage = {
+      type: 'message', user: 'U1', text: 'Empty', ts: '1700000000.000100',
+      files: [],
+    };
+    const output = formatMessage(msg, users);
+    expect(output).not.toContain('📎');
+  });
+
+  it('shows "(unnamed file)" when name is missing', () => {
+    const msg: SlackMessage = {
+      type: 'message', user: 'U1', text: 'test', ts: '1700000000.000100',
+      files: [{ id: 'F1', size: 100 }],
+    };
+    const output = formatMessage(msg, users);
+    expect(output).toContain('(unnamed file)');
+  });
+
+  it('omits size when undefined', () => {
+    const msg: SlackMessage = {
+      type: 'message', user: 'U1', text: 'test', ts: '1700000000.000100',
+      files: [{ id: 'F1', name: 'a.txt', mimetype: 'text/plain' }],
+    };
+    const output = formatMessage(msg, users);
+    expect(output).toContain('a.txt');
+    expect(output).toContain('text/plain');
+    expect(output).not.toMatch(/\d+\s*B/);
+  });
+
+  it('shows "0 B" when size is 0', () => {
+    const msg: SlackMessage = {
+      type: 'message', user: 'U1', text: 'test', ts: '1700000000.000100',
+      files: [{ id: 'F1', name: 'empty.txt', size: 0 }],
+    };
+    const output = formatMessage(msg, users);
+    expect(output).toContain('0 B');
+  });
+
+  it('omits mimetype when missing', () => {
+    const msg: SlackMessage = {
+      type: 'message', user: 'U1', text: 'test', ts: '1700000000.000100',
+      files: [{ id: 'F1', name: 'a.bin', size: 500 }],
+    };
+    const output = formatMessage(msg, users);
+    expect(output).toContain('a.bin');
+    expect(output).toContain('500 B');
+    expect(output).not.toContain('undefined');
+  });
+
+  it('omits parentheses when both size and mimetype missing', () => {
+    const msg: SlackMessage = {
+      type: 'message', user: 'U1', text: 'test', ts: '1700000000.000100',
+      files: [{ id: 'F1', name: 'a.bin' }],
+    };
+    const output = formatMessage(msg, users);
+    expect(output).toContain('a.bin');
+    expect(output).not.toContain('(');
+  });
+
+  it('omits URL line when no URL available', () => {
+    const msg: SlackMessage = {
+      type: 'message', user: 'U1', text: 'test', ts: '1700000000.000100',
+      files: [{ id: 'F1', name: 'a.txt' }],
+    };
+    const output = formatMessage(msg, users);
+    expect(output).toContain('a.txt');
+    expect(output).not.toContain('https://');
+  });
+
+  it('falls back to permalink when url_private is missing', () => {
+    const msg: SlackMessage = {
+      type: 'message', user: 'U1', text: 'test', ts: '1700000000.000100',
+      files: [{ id: 'F1', name: 'a.txt', permalink: 'https://team.slack.com/files/a.txt' }],
+    };
+    const output = formatMessage(msg, users);
+    expect(output).toContain('https://team.slack.com/files/a.txt');
+  });
+
+  it('displays tombstone as deleted file', () => {
+    const msg: SlackMessage = {
+      type: 'message', user: 'U1', text: 'test', ts: '1700000000.000100',
+      files: [{ id: 'F1', mode: 'tombstone' }],
+    };
+    const output = formatMessage(msg, users);
+    expect(output).toContain('(deleted file)');
+    expect(output).not.toContain('https://');
   });
 });
 

--- a/src/lib/formatter.test.ts
+++ b/src/lib/formatter.test.ts
@@ -245,4 +245,20 @@ describe('formatFileSize', () => {
   it('formats exact 1 GB', () => {
     expect(formatFileSize(1073741824)).toBe('1.0 GB');
   });
+
+  it('handles negative values', () => {
+    expect(formatFileSize(-1)).toBe('0 B');
+  });
+
+  it('handles NaN', () => {
+    expect(formatFileSize(NaN)).toBe('0 B');
+  });
+
+  it('handles Infinity', () => {
+    expect(formatFileSize(Infinity)).toBe('0 B');
+  });
+
+  it('formats 1023 bytes (boundary before KB)', () => {
+    expect(formatFileSize(1023)).toBe('1023 B');
+  });
 });

--- a/src/lib/formatter.test.ts
+++ b/src/lib/formatter.test.ts
@@ -6,6 +6,7 @@ import {
   formatPeopleSearchResults,
   formatUnreadChannels,
   formatPaginationHint,
+  formatFileSize,
 } from './formatter.ts';
 import type {
   SavedItem,
@@ -213,5 +214,35 @@ describe('formatPaginationHint', () => {
   it('returns empty string on last page', () => {
     const output = formatPaginationHint(3, 3);
     expect(output).toBe('');
+  });
+});
+
+describe('formatFileSize', () => {
+  it('formats 0 bytes', () => {
+    expect(formatFileSize(0)).toBe('0 B');
+  });
+
+  it('formats bytes under 1 KB', () => {
+    expect(formatFileSize(500)).toBe('500 B');
+  });
+
+  it('formats exact 1 KB', () => {
+    expect(formatFileSize(1024)).toBe('1.0 KB');
+  });
+
+  it('formats fractional KB', () => {
+    expect(formatFileSize(1536)).toBe('1.5 KB');
+  });
+
+  it('formats exact 1 MB', () => {
+    expect(formatFileSize(1048576)).toBe('1.0 MB');
+  });
+
+  it('formats fractional MB', () => {
+    expect(formatFileSize(1258291)).toBe('1.2 MB');
+  });
+
+  it('formats exact 1 GB', () => {
+    expect(formatFileSize(1073741824)).toBe('1.0 GB');
   });
 });

--- a/src/lib/formatter.ts
+++ b/src/lib/formatter.ts
@@ -341,6 +341,7 @@ export function formatCanvasContent(canvas: SlackCanvas, markdown: string): stri
 
 // Format file size to human-readable string
 export function formatFileSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return '0 B';
   if (bytes === 0) return '0 B';
   const units = ['B', 'KB', 'MB', 'GB'];
   const k = 1024;

--- a/src/lib/formatter.ts
+++ b/src/lib/formatter.ts
@@ -339,6 +339,17 @@ export function formatCanvasContent(canvas: SlackCanvas, markdown: string): stri
   return `${header}\n${chalk.dim('─'.repeat(60))}\n\n${markdown}`;
 }
 
+// Format file size to human-readable string
+export function formatFileSize(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const k = 1024;
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const index = Math.min(i, units.length - 1);
+  if (index === 0) return `${bytes} B`;
+  return `${(bytes / Math.pow(k, index)).toFixed(1)} ${units[index]}`;
+}
+
 // Truncate text with ellipsis
 function truncateText(text: string | undefined, maxLen: number): string {
   if (!text) return '[no text]';

--- a/src/lib/formatter.ts
+++ b/src/lib/formatter.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import type {
-  SlackCanvas, SlackChannel, SlackMessage, SlackUser, WorkspaceConfig,
+  SlackCanvas, SlackChannel, SlackFile, SlackMessage, SlackUser, WorkspaceConfig,
   SavedItem, SearchMatch, ChannelSearchResult, PeopleSearchResult, UnreadChannel,
 } from '../types/index.ts';
 
@@ -116,6 +116,29 @@ export function formatMessage(
       output += chalk.dim(` | thread_ts: ${msg.thread_ts}`);
     }
     output += '\n';
+  }
+
+  // Files
+  if (msg.files && msg.files.length > 0) {
+    msg.files.forEach(file => {
+      if (file.mode === 'tombstone') {
+        output += `${indentStr}  ${chalk.yellow('📎')} ${chalk.dim('(deleted file)')}\n`;
+        return;
+      }
+
+      const name = file.name || '(unnamed file)';
+      const parts: string[] = [];
+      if (file.size !== undefined) parts.push(formatFileSize(file.size));
+      if (file.mimetype) parts.push(file.mimetype);
+      const meta = parts.length > 0 ? ` ${chalk.dim(`(${parts.join(', ')})`)}` : '';
+
+      output += `${indentStr}  ${chalk.yellow('📎')} ${chalk.yellow(name)}${meta}\n`;
+
+      const url = file.url_private || file.permalink;
+      if (url) {
+        output += `${indentStr}     ${chalk.dim(url)}\n`;
+      }
+    });
   }
 
   // Reactions

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -61,6 +61,19 @@ export interface SlackUser {
   };
 }
 
+export interface SlackFile {
+  id: string;
+  name?: string;
+  title?: string;
+  mimetype?: string;
+  filetype?: string;
+  size?: number;
+  url_private?: string;
+  url_private_download?: string;
+  permalink?: string;
+  mode?: string;
+}
+
 export interface SlackMessage {
   type: string;
   user?: string;
@@ -75,6 +88,7 @@ export interface SlackMessage {
     users: string[];
   }>;
   blocks?: Array<Record<string, unknown>>;
+  files?: SlackFile[];
 }
 
 export interface SlackAuthTestResponse {

--- a/src/types/slack-message.test.ts
+++ b/src/types/slack-message.test.ts
@@ -133,4 +133,115 @@ describe('SlackMessage', () => {
     const parsed = JSON.parse(output);
     expect(parsed.files).toBeUndefined();
   });
+
+  describe('conversations read JSON mapping', () => {
+    // Helper that replicates the exact mapping from conversations.ts
+    function mapMessageToJson(msg: SlackMessage) {
+      return {
+        ts: msg.ts,
+        thread_ts: msg.thread_ts,
+        user: msg.user,
+        text: msg.text,
+        type: msg.type,
+        reply_count: msg.reply_count,
+        reactions: msg.reactions,
+        bot_id: msg.bot_id,
+        blocks: msg.blocks,
+        ...(msg.files?.length ? { files: msg.files.map(f => ({
+          id: f.id,
+          name: f.name,
+          title: f.title,
+          mimetype: f.mimetype,
+          filetype: f.filetype,
+          size: f.size,
+          url_private: f.url_private,
+          permalink: f.permalink,
+          mode: f.mode,
+        })) } : {}),
+      };
+    }
+
+    it('includes selected file fields in JSON when message has files', () => {
+      const msg: SlackMessage = {
+        type: 'message',
+        user: 'U123',
+        text: 'See attached',
+        ts: '1234567890.000600',
+        files: [
+          {
+            id: 'F001',
+            name: 'report.pdf',
+            title: 'Quarterly Report',
+            mimetype: 'application/pdf',
+            filetype: 'pdf',
+            size: 2048000,
+            url_private: 'https://files.slack.com/files-pri/T0123/report.pdf',
+            url_private_download: 'https://files.slack.com/files-pri/T0123/download/report.pdf',
+            permalink: 'https://team.slack.com/files/U123/F001/report.pdf',
+            mode: 'hosted',
+          },
+        ],
+      };
+
+      const mapped = mapMessageToJson(msg);
+      expect(mapped.files).toBeDefined();
+      expect(mapped.files).toHaveLength(1);
+      expect(mapped.files![0]).toEqual({
+        id: 'F001',
+        name: 'report.pdf',
+        title: 'Quarterly Report',
+        mimetype: 'application/pdf',
+        filetype: 'pdf',
+        size: 2048000,
+        url_private: 'https://files.slack.com/files-pri/T0123/report.pdf',
+        permalink: 'https://team.slack.com/files/U123/F001/report.pdf',
+        mode: 'hosted',
+      });
+      // url_private_download must NOT be included
+      expect((mapped.files![0] as any).url_private_download).toBeUndefined();
+    });
+
+    it('omits files key from JSON when message has no files', () => {
+      const msg: SlackMessage = {
+        type: 'message',
+        user: 'U456',
+        text: 'No attachments',
+        ts: '1234567890.000700',
+      };
+
+      const mapped = mapMessageToJson(msg);
+      expect('files' in mapped).toBe(false);
+    });
+
+    it('omits files key from JSON when files array is empty', () => {
+      const msg: SlackMessage = {
+        type: 'message',
+        user: 'U789',
+        text: 'Empty files array',
+        ts: '1234567890.000800',
+        files: [],
+      };
+
+      const mapped = mapMessageToJson(msg);
+      expect('files' in mapped).toBe(false);
+    });
+
+    it('maps multiple files correctly', () => {
+      const msg: SlackMessage = {
+        type: 'message',
+        user: 'U123',
+        text: 'Multiple files',
+        ts: '1234567890.000900',
+        files: [
+          { id: 'F001', name: 'a.png', mimetype: 'image/png', filetype: 'png', size: 1024 },
+          { id: 'F002', name: 'b.txt', mimetype: 'text/plain', filetype: 'text', size: 256 },
+        ],
+      };
+
+      const mapped = mapMessageToJson(msg);
+      expect(mapped.files).toHaveLength(2);
+      expect(mapped.files![0].id).toBe('F001');
+      expect(mapped.files![1].id).toBe('F002');
+    });
+  });
 });

--- a/src/types/slack-message.test.ts
+++ b/src/types/slack-message.test.ts
@@ -78,4 +78,59 @@ describe('SlackMessage', () => {
     expect(parsed.blocks[0].type).toBe('section');
     expect(parsed.blocks[1].type).toBe('context');
   });
+
+  it('includes files in JSON serialization when present', () => {
+    const msg: SlackMessage = {
+      type: 'message',
+      user: 'U123',
+      text: 'Here is the document',
+      ts: '1234567890.000400',
+      files: [
+        {
+          id: 'F001',
+          name: 'design.pdf',
+          title: 'Design Doc',
+          mimetype: 'application/pdf',
+          filetype: 'pdf',
+          size: 1258291,
+          url_private: 'https://files.slack.com/files-pri/T0123/design.pdf',
+          permalink: 'https://team.slack.com/files/U123/F001/design.pdf',
+          mode: 'hosted',
+        },
+      ],
+    };
+
+    const output = JSON.stringify({
+      ts: msg.ts,
+      user: msg.user,
+      text: msg.text,
+      files: msg.files,
+    });
+
+    const parsed = JSON.parse(output);
+    expect(parsed.files).toBeDefined();
+    expect(parsed.files).toHaveLength(1);
+    expect(parsed.files[0].id).toBe('F001');
+    expect(parsed.files[0].name).toBe('design.pdf');
+    expect(parsed.files[0].size).toBe(1258291);
+    expect(parsed.files[0].mimetype).toBe('application/pdf');
+  });
+
+  it('omits files from JSON output when not present', () => {
+    const msg: SlackMessage = {
+      type: 'message',
+      user: 'U456',
+      text: 'No files here',
+      ts: '1234567890.000500',
+    };
+
+    const output = JSON.stringify({
+      ts: msg.ts,
+      text: msg.text,
+      files: msg.files,
+    });
+
+    const parsed = JSON.parse(output);
+    expect(parsed.files).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

- Add `SlackFile` type and `files` field to `SlackMessage` interface to capture file metadata from Slack API responses
- Display file metadata (name, size, MIME type, URL) inline in terminal output with `📎` indicator
- Include `files` in `conversations read --json` output (omitted when no files attached)
- Handle edge cases: deleted files (tombstone), missing name/size/mimetype/URL, empty file arrays

## Changes

| File | Change |
|------|--------|
| `src/types/index.ts` | Add `SlackFile` interface, add `files?: SlackFile[]` to `SlackMessage` |
| `src/lib/formatter.ts` | Add `formatFileSize` helper, add file display block in `formatMessage` |
| `src/commands/conversations.ts` | Include `files` in JSON output mapping |

## Terminal output example

[04/08/2026, 10:30:00] @neko-neko
Here's the design doc
📎 design-v2.pdf (1.2 MB, application/pdf)
    https://files.slack.com/files-pri/T0123/design-v2.pdf
ts: 1712345678.000100