### PR TITLE
fix: fetch all saved items and resolve thread replies

### DIFF
--- a/src/commands/saved.ts
+++ b/src/commands/saved.ts
@@ -11,8 +11,8 @@ export function createSavedCommand(): Command {
   saved
     .command('list')
     .description('List saved for later items')
-    .option('--limit <number>', 'Number of items to return', '20')
-    .option('--state <state>', 'Filter by state: saved or completed')
+    .option('--limit <number>', 'Maximum number of items to return')
+    .option('--state <state>', 'Filter by state: saved, to_do, or completed')
     .option('--workspace <id|name>', 'Workspace to use')
     .option('--json', 'Output in JSON format', false)
     .action(async (options) => {
@@ -22,7 +22,7 @@ export function createSavedCommand(): Command {
         const client = await getAuthenticatedClient(options.workspace);
 
         let { items, users } = await enrichSavedItems(client, {
-          count: parseInt(options.limit),
+          limit: options.limit ? parseInt(options.limit) : undefined,
           onProgress: (msg) => { spinner.text = msg; },
         });
 

--- a/src/lib/saved.test.ts
+++ b/src/lib/saved.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from 'bun:test';
+import { enrichSavedItems } from './saved.ts';
+import type { SlackClient } from './slack-client.ts';
+
+// Minimal mock client that returns canned responses
+function createMockClient(overrides: {
+  listSavedItems?: (opts: any) => Promise<any>;
+  listMessages?: (ids: any) => Promise<any>;
+  getConversationInfo?: (ch: string) => Promise<any>;
+  getUsersInfo?: (ids: string[]) => Promise<any>;
+}): SlackClient {
+  return {
+    listSavedItems: overrides.listSavedItems ?? (() => Promise.resolve({ items: [] })),
+    listMessages: overrides.listMessages ?? (() => Promise.resolve({ messages: {} })),
+    getConversationInfo: overrides.getConversationInfo ?? (() => Promise.resolve({ channel: {} })),
+    getUsersInfo: overrides.getUsersInfo ?? (() => Promise.resolve({ users: [] })),
+  } as unknown as SlackClient;
+}
+
+describe('enrichSavedItems', () => {
+  it('returns empty result when no items exist', async () => {
+    const client = createMockClient({
+      listSavedItems: () => Promise.resolve({ items: [] }),
+    });
+
+    const result = await enrichSavedItems(client);
+    expect(result.items).toEqual([]);
+    expect(result.users.size).toBe(0);
+  });
+
+  it('paginates through all pages of saved items (browser auth)', async () => {
+    let callCount = 0;
+    const client = createMockClient({
+      listSavedItems: () => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({
+            saved_items: [
+              { item_type: 'message', item_id: 'C1', ts: '1.1', date_created: '1700000000' },
+            ],
+            response_metadata: { next_cursor: 'page2' },
+          });
+        }
+        return Promise.resolve({
+          saved_items: [
+            { item_type: 'message', item_id: 'C1', ts: '2.2', date_created: '1700000001' },
+          ],
+        });
+      },
+      listMessages: () => Promise.resolve({
+        messages: {
+          C1: [
+            { ts: '1.1', text: 'First message', type: 'message', user: 'U1' },
+            { ts: '2.2', text: 'Second message', type: 'message', user: 'U1' },
+          ],
+        },
+      }),
+      getConversationInfo: () => Promise.resolve({ channel: { name: 'general' } }),
+      getUsersInfo: () => Promise.resolve({ users: [{ id: 'U1', name: 'alice', real_name: 'Alice' }] }),
+    });
+
+    const result = await enrichSavedItems(client);
+    expect(callCount).toBe(2);
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0].message!.text).toBe('First message');
+    expect(result.items[1].message!.text).toBe('Second message');
+  });
+
+  it('respects the limit option and stops pagination early', async () => {
+    let callCount = 0;
+    const client = createMockClient({
+      listSavedItems: () => {
+        callCount++;
+        return Promise.resolve({
+          saved_items: [
+            { item_type: 'message', item_id: 'C1', ts: `${callCount}.0`, date_created: '1700000000' },
+            { item_type: 'message', item_id: 'C1', ts: `${callCount}.1`, date_created: '1700000001' },
+          ],
+          response_metadata: { next_cursor: 'more' },
+        });
+      },
+      listMessages: (ids: any) => {
+        const msgs: Record<string, any[]> = {};
+        for (const group of ids) {
+          msgs[group.channel] = group.timestamps.map((ts: string) => ({
+            ts, text: `msg ${ts}`, type: 'message',
+          }));
+        }
+        return Promise.resolve({ messages: msgs });
+      },
+      getConversationInfo: () => Promise.resolve({ channel: { name: 'general' } }),
+      getUsersInfo: () => Promise.resolve({ users: [] }),
+    });
+
+    const result = await enrichSavedItems(client, { limit: 3 });
+    expect(result.items).toHaveLength(3);
+    // Should have stopped after 2 pages (2 items + 2 items, truncated to 3)
+    expect(callCount).toBe(2);
+  });
+
+  it('resolves thread replies via messages.list (browser auth)', async () => {
+    const client = createMockClient({
+      listSavedItems: () => Promise.resolve({
+        saved_items: [
+          { item_type: 'message', item_id: 'C1', ts: '1.100', date_created: '1700000000' },
+        ],
+      }),
+      listMessages: () => Promise.resolve({
+        messages: {
+          C1: [{ ts: '1.100', text: 'Thread reply', type: 'message', user: 'U1', thread_ts: '1.000' }],
+        },
+      }),
+      getConversationInfo: () => Promise.resolve({ channel: { name: 'dev' } }),
+      getUsersInfo: () => Promise.resolve({ users: [{ id: 'U1', name: 'bob', real_name: 'Bob' }] }),
+    });
+
+    const result = await enrichSavedItems(client);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].message!.text).toBe('Thread reply');
+    expect(result.items[0].channel_name).toBe('dev');
+    expect(result.users.get('U1')?.name).toBe('bob');
+  });
+
+  it('handles non-message saved items (browser auth)', async () => {
+    const client = createMockClient({
+      listSavedItems: () => Promise.resolve({
+        saved_items: [
+          { item_type: 'file', item_id: 'F1', date_created: '1700000000' },
+          { item_type: 'channel', item_id: 'C1', date_created: '1700000001' },
+        ],
+      }),
+      getUsersInfo: () => Promise.resolve({ users: [] }),
+    });
+
+    const result = await enrichSavedItems(client);
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0].type).toBe('file');
+    expect(result.items[1].type).toBe('channel');
+  });
+
+  it('falls back to [message unavailable] when message not found', async () => {
+    const client = createMockClient({
+      listSavedItems: () => Promise.resolve({
+        saved_items: [
+          { item_type: 'message', item_id: 'C1', ts: '1.1', date_created: '1700000000' },
+        ],
+      }),
+      listMessages: () => Promise.resolve({ messages: { C1: [] } }),
+      getConversationInfo: () => Promise.resolve({ channel: { name: 'general' } }),
+      getUsersInfo: () => Promise.resolve({ users: [] }),
+    });
+
+    const result = await enrichSavedItems(client);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].message!.text).toBe('[message unavailable]');
+  });
+
+  it('preserves todo_state from saved items (browser auth)', async () => {
+    const client = createMockClient({
+      listSavedItems: () => Promise.resolve({
+        saved_items: [
+          { item_type: 'message', item_id: 'C1', ts: '1.1', date_created: '1700000000', todo_state: 'to_do' },
+          { item_type: 'message', item_id: 'C1', ts: '2.2', date_created: '1700000001', todo_state: 'completed' },
+        ],
+      }),
+      listMessages: () => Promise.resolve({
+        messages: {
+          C1: [
+            { ts: '1.1', text: 'Task 1', type: 'message' },
+            { ts: '2.2', text: 'Task 2', type: 'message' },
+          ],
+        },
+      }),
+      getConversationInfo: () => Promise.resolve({ channel: { name: 'tasks' } }),
+      getUsersInfo: () => Promise.resolve({ users: [] }),
+    });
+
+    const result = await enrichSavedItems(client);
+    expect(result.items[0].todo_state).toBe('to_do');
+    expect(result.items[1].todo_state).toBe('completed');
+  });
+
+  it('handles standard auth format (stars.list) with inline messages', async () => {
+    const client = createMockClient({
+      listSavedItems: () => Promise.resolve({
+        items: [
+          { type: 'message', message: { text: 'Starred msg', ts: '1.1', type: 'message', user: 'U1' } },
+          { type: 'file', file: { name: 'doc.pdf' } },
+        ],
+      }),
+      getUsersInfo: () => Promise.resolve({ users: [{ id: 'U1', name: 'alice', real_name: 'Alice' }] }),
+    });
+
+    const result = await enrichSavedItems(client);
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0].type).toBe('message');
+    expect(result.items[0].message!.text).toBe('Starred msg');
+    expect(result.users.get('U1')?.real_name).toBe('Alice');
+  });
+
+  it('groups messages by channel and batches requests', async () => {
+    const listMessagesCalls: any[] = [];
+    const client = createMockClient({
+      listSavedItems: () => Promise.resolve({
+        saved_items: [
+          { item_type: 'message', item_id: 'C1', ts: '1.1', date_created: '1700000000' },
+          { item_type: 'message', item_id: 'C1', ts: '1.2', date_created: '1700000001' },
+          { item_type: 'message', item_id: 'C2', ts: '2.1', date_created: '1700000002' },
+        ],
+      }),
+      listMessages: (ids: any) => {
+        listMessagesCalls.push(ids);
+        const msgs: Record<string, any[]> = {};
+        for (const group of ids) {
+          msgs[group.channel] = group.timestamps.map((ts: string) => ({
+            ts, text: `msg-${ts}`, type: 'message',
+          }));
+        }
+        return Promise.resolve({ messages: msgs });
+      },
+      getConversationInfo: (ch: string) => Promise.resolve({ channel: { name: ch } }),
+      getUsersInfo: () => Promise.resolve({ users: [] }),
+    });
+
+    const result = await enrichSavedItems(client);
+    expect(result.items).toHaveLength(3);
+    // Should batch into a single messages.list call (3 items across 2 channels, well under batch size of 10)
+    expect(listMessagesCalls).toHaveLength(1);
+    // The call should group timestamps by channel
+    const batch = listMessagesCalls[0];
+    expect(batch).toHaveLength(2); // 2 channels
+    const c1Group = batch.find((g: any) => g.channel === 'C1');
+    expect(c1Group.timestamps).toEqual(['1.1', '1.2']);
+  });
+
+  it('falls back to channel ID when conversation info fails', async () => {
+    const client = createMockClient({
+      listSavedItems: () => Promise.resolve({
+        saved_items: [
+          { item_type: 'message', item_id: 'C_PRIVATE', ts: '1.1', date_created: '1700000000' },
+        ],
+      }),
+      listMessages: () => Promise.resolve({
+        messages: { C_PRIVATE: [{ ts: '1.1', text: 'secret', type: 'message' }] },
+      }),
+      getConversationInfo: () => Promise.reject(new Error('channel_not_found')),
+      getUsersInfo: () => Promise.resolve({ users: [] }),
+    });
+
+    const result = await enrichSavedItems(client);
+    expect(result.items[0].channel_name).toBe('C_PRIVATE');
+  });
+});

--- a/src/lib/saved.ts
+++ b/src/lib/saved.ts
@@ -4,14 +4,31 @@ import type { SavedItem, SlackUser } from '../types/index.ts';
 export async function enrichSavedItems(
   client: SlackClient,
   options: {
-    count?: number;
+    limit?: number;
     onProgress?: (message: string) => void;
   } = {},
 ): Promise<{ items: SavedItem[]; users: Map<string, SlackUser> }> {
-  const response = await client.listSavedItems({ count: options.count });
+  // Paginate through all saved items
+  const rawItems: any[] = [];
+  let isBrowserFormat = false;
+  let cursor: string | undefined;
+  const pageSize = 100;
 
-  const isBrowserFormat = !!response.saved_items;
-  const rawItems = isBrowserFormat ? response.saved_items : (response.items || []);
+  do {
+    options.onProgress?.(`Fetching saved items${rawItems.length > 0 ? ` (${rawItems.length} so far)` : ''}...`);
+    const response = await client.listSavedItems({ count: pageSize, cursor });
+
+    isBrowserFormat = !!response.saved_items;
+    const pageItems = isBrowserFormat ? response.saved_items : (response.items || []);
+    rawItems.push(...pageItems);
+
+    cursor = response.response_metadata?.next_cursor || undefined;
+
+    if (options.limit && rawItems.length >= options.limit) {
+      rawItems.length = options.limit;
+      break;
+    }
+  } while (cursor);
 
   if (rawItems.length === 0) {
     return { items: [], users: new Map() };
@@ -21,49 +38,83 @@ export async function enrichSavedItems(
   const userIds = new Set<string>();
 
   if (isBrowserFormat) {
-    options.onProgress?.('Fetching message details...');
+    // Split into messages and non-messages
+    const messageItems = rawItems.filter((item: any) => item.item_type === 'message');
+    const otherItems = rawItems.filter((item: any) => item.item_type !== 'message');
 
-    // Fetch all messages in parallel
-    // NOTE: may hit Slack rate limits with many saved items
-    const messagePromises = rawItems.map(async (item: any) => {
-      if (item.item_type !== 'message') {
-        return { type: item.item_type, channel_id: item.item_id, date_saved: item.date_created } as SavedItem;
+    for (const item of otherItems) {
+      items.push({ type: item.item_type, channel_id: item.item_id, date_saved: item.date_created } as SavedItem);
+    }
+
+    if (messageItems.length > 0) {
+      // Group timestamps by channel for batch fetch
+      const channelTimestamps = new Map<string, string[]>();
+      for (const item of messageItems) {
+        const existing = channelTimestamps.get(item.item_id);
+        if (existing) {
+          existing.push(item.ts);
+        } else {
+          channelTimestamps.set(item.item_id, [item.ts]);
+        }
       }
 
-      try {
-        const [history, info] = await Promise.all([
-          client.getConversationHistory(item.item_id, {
-            latest: item.ts,
-            oldest: item.ts,
-            inclusive: true,
-            limit: 1,
-          }),
-          client.getConversationInfo(item.item_id).catch(() => null),
-        ]);
+      const messageIds = Array.from(channelTimestamps.entries()).map(
+        ([channel, timestamps]) => ({ channel, timestamps }),
+      );
 
-        const msg = history.messages?.[0];
+      // Batch-fetch messages (chunk to avoid too_many_channels errors)
+      // and channel info in parallel
+      options.onProgress?.('Fetching message details...');
+      const BATCH_SIZE = 10;
+      const messageLookup = new Map<string, any>();
+
+      const batches: Array<Array<{ channel: string; timestamps: string[] }>> = [];
+      for (let i = 0; i < messageIds.length; i += BATCH_SIZE) {
+        batches.push(messageIds.slice(i, i + BATCH_SIZE));
+      }
+
+      const [batchResponses, ...channelInfos] = await Promise.all([
+        Promise.all(batches.map((batch) => client.listMessages(batch))),
+        ...Array.from(channelTimestamps.keys()).map(
+          (ch) => client.getConversationInfo(ch).catch(() => null),
+        ),
+      ]);
+
+      // Build channel name lookup
+      const channelNames = new Map<string, string>();
+      const channelKeys = Array.from(channelTimestamps.keys());
+      channelInfos.forEach((info, i) => {
+        if (info?.channel?.name) {
+          channelNames.set(channelKeys[i], info.channel.name);
+        }
+      });
+
+      // Build message lookup from messages.list responses
+      // Response format: { messages: { "CHANNEL_ID": [ msg, ... ] } }
+      for (const batchResponse of batchResponses) {
+        const messagesMap = batchResponse.messages || {};
+        for (const [channelId, msgs] of Object.entries(messagesMap) as [string, any[]][]) {
+          for (const msg of msgs) {
+            messageLookup.set(`${channelId}:${msg.ts}`, msg);
+          }
+        }
+      }
+
+      // Map saved items to enriched items
+      for (const item of messageItems) {
+        const msg = messageLookup.get(`${item.item_id}:${item.ts}`);
         if (msg?.user) userIds.add(msg.user);
 
-        return {
+        items.push({
           type: 'message',
           channel_id: item.item_id,
-          channel_name: info?.channel?.name || item.item_id,
+          channel_name: channelNames.get(item.item_id) || item.item_id,
           message: msg || { text: '[message unavailable]', ts: item.ts, type: 'message' },
           date_saved: item.date_created,
           todo_state: item.todo_state,
-        } as SavedItem;
-      } catch {
-        return {
-          type: 'message',
-          channel_id: item.item_id,
-          message: { text: '[message unavailable]', ts: item.ts, type: 'message' },
-          date_saved: item.date_created,
-          todo_state: item.todo_state,
-        } as SavedItem;
+        } as SavedItem);
       }
-    });
-
-    items.push(...await Promise.all(messagePromises));
+    }
   } else {
     // Standard auth (stars.list) — items already have message content
     for (const item of rawItems) {

--- a/src/lib/slack-client.ts
+++ b/src/lib/slack-client.ts
@@ -231,6 +231,15 @@ export class SlackClient {
     return this.request('stars.list', params);
   }
 
+  // Batch-fetch messages by channel + timestamp (browser auth only).
+  // Groups are {channel, timestamps[]} — Slack returns full message objects
+  // regardless of whether they're top-level or thread replies.
+  async listMessages(messageIds: Array<{ channel: string; timestamps: string[] }>): Promise<any> {
+    return this.request('messages.list', {
+      message_ids: JSON.stringify(messageIds),
+    });
+  }
+
   // Search messages
   async searchMessages(query: string, options: {
     count?: number;


### PR DESCRIPTION
## Summary
- Fixed `saved list` returning only 20 items instead of all saved items
- Fixed thread replies showing as "[message unavailable]" in saved items
- Added 10 unit tests for the saved item enrichment logic
- Updated `--state` help text to include `to_do` as a valid filter value

## Reason
The `saved list` command had a hardcoded default limit of 20 and used per-message `conversations.history` calls that can't resolve thread replies (only top-level messages). This meant users with more than 20 saved items only saw a subset, and any saved thread reply showed "[message unavailable]" even when the message was readable.

## More Details

### Pagination
`saved.list` (browser auth) and `stars.list` (standard auth) both support cursor-based pagination. The command now pages through all results with a page size of 100, stopping early if `--limit` is specified. The `--limit` option no longer has a default value.

### Batch message resolution
The original code called `conversations.history` once per saved message to fetch its content. This was both slow (N+1 requests) and broken for thread replies, since `conversations.history` only returns top-level channel messages.

The fix replaces this with Slack's `messages.list` API, which accepts `{channel, timestamps[]}` groups and returns full message objects regardless of whether they're top-level messages or thread replies. Timestamps are grouped by channel and chunked into batches of 10 to avoid `too_many_channels` errors. Channel info is fetched in parallel with the message batches.

### Standard auth path
The `stars.list` API (standard auth) already includes message content inline, so no batch fetch is needed. This path is unchanged.

### Known limitations
- `messages.list` is an internal Slack API only available via browser auth. Standard auth continues to use `stars.list` which includes messages inline.

## QA
Tested manually against a workspace with 60+ saved items including top-level messages, thread replies, reminders (`to_do` state), and completed items. All items render correctly. Automated tests cover pagination, thread resolution, batching, limit truncation, both auth paths, and graceful fallbacks.