### PR TITLE
feat: include attachments in JSON output for conversations read

### DIFF
--- a/src/commands/conversations.ts
+++ b/src/commands/conversations.ts
@@ -153,6 +153,7 @@ export function createConversationsCommand(): Command {
               reactions: msg.reactions,
               bot_id: msg.bot_id,
               blocks: msg.blocks,
+              attachments: msg.attachments,
               ...(msg.files?.length ? { files: msg.files.map(f => ({
                 id: f.id,
                 name: f.name,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -88,6 +88,7 @@ export interface SlackMessage {
     users: string[];
   }>;
   blocks?: Array<Record<string, unknown>>;
+  attachments?: Array<Record<string, unknown>>;
   files?: SlackFile[];
 }
 

--- a/src/types/slack-message.test.ts
+++ b/src/types/slack-message.test.ts
@@ -79,6 +79,85 @@ describe('SlackMessage', () => {
     expect(parsed.blocks[1].type).toBe('context');
   });
 
+  it('includes attachments in JSON serialization when present', () => {
+    const msg: SlackMessage = {
+      type: 'message',
+      bot_id: 'B0578EJQBFH',
+      text: '',
+      ts: '1234567890.000400',
+      attachments: [
+        {
+          title: 'New error: ConfirmDraft OnSched update failed',
+          fallback: '<https://app.example.com/items/1552|#1552 New error: ConfirmDraft OnSched update failed>',
+          color: '#D00000',
+          title_link: 'https://app.example.com/items/1552',
+        },
+      ],
+    };
+
+    const output = JSON.stringify({
+      ts: msg.ts,
+      bot_id: msg.bot_id,
+      text: msg.text,
+      type: msg.type,
+      attachments: msg.attachments,
+    });
+
+    const parsed = JSON.parse(output);
+    expect(parsed.attachments).toBeDefined();
+    expect(parsed.attachments).toHaveLength(1);
+    expect((parsed.attachments[0] as any).title).toBe('New error: ConfirmDraft OnSched update failed');
+    expect((parsed.attachments[0] as any).fallback).toContain('#1552');
+  });
+
+  it('omits attachments from JSON output when not present', () => {
+    const msg: SlackMessage = {
+      type: 'message',
+      user: 'U789',
+      text: 'Plain message without attachments.',
+      ts: '1234567890.000500',
+    };
+
+    const output = JSON.stringify({
+      ts: msg.ts,
+      user: msg.user,
+      text: msg.text,
+      type: msg.type,
+      attachments: msg.attachments,
+    });
+
+    const parsed = JSON.parse(output);
+    expect(parsed.attachments).toBeUndefined();
+  });
+
+  it('preserves multiple attachments with nested fields in serialization', () => {
+    const msg: SlackMessage = {
+      type: 'message',
+      bot_id: 'B002',
+      text: '',
+      ts: '1234567890.000600',
+      attachments: [
+        {
+          title: 'First error',
+          fields: [
+            { title: 'Environment', value: 'production', short: true },
+            { title: 'Occurrences', value: '42', short: true },
+          ],
+        },
+        {
+          title: 'Second error',
+          fallback: '#1553 Another error',
+        },
+      ],
+    };
+
+    const parsed = JSON.parse(JSON.stringify({ attachments: msg.attachments }));
+    expect(parsed.attachments).toHaveLength(2);
+    expect((parsed.attachments[0] as any).title).toBe('First error');
+    expect((parsed.attachments[0] as any).fields).toHaveLength(2);
+    expect((parsed.attachments[1] as any).fallback).toBe('#1553 Another error');
+  });
+
   it('includes files in JSON serialization when present', () => {
     const msg: SlackMessage = {
       type: 'message',
@@ -147,6 +226,7 @@ describe('SlackMessage', () => {
         reactions: msg.reactions,
         bot_id: msg.bot_id,
         blocks: msg.blocks,
+        attachments: msg.attachments,
         ...(msg.files?.length ? { files: msg.files.map(f => ({
           id: f.id,
           name: f.name,


### PR DESCRIPTION
## Summary

- Adds `attachments?: Array<Record<string, unknown>>` to the `SlackMessage` interface in `src/types/index.ts`
- Includes `attachments` in the `--json` output of `conversations read` (`src/commands/conversations.ts`)
- Adds unit tests covering presence, absence, and nested attachment structures in `src/types/slack-message.test.ts`

No changes to `slack-client.ts` were needed — the Slack API already returns `attachments` in raw responses; it was only being dropped in the JSON serialization mapping. Same shape as #23 did for `blocks`.

This PR is to closes issue #37, hope you can take a look @shahariaazam, thank you

## Why

Legacy Slack **attachments** are the primary content channel for most third-party integrations — Rollbar, Sentry, GitHub notifications, email-to-Slack bridges, Datadog, PagerDuty, etc. These bots typically leave `text` empty and put the real title/body inside `attachments[].title` / `attachments[].fallback` / `attachments[].fields`.

Currently, reading such a message via `slackcli conversations read --json` yields an empty `text` and no attachments field at all, which makes the tool unusable for alerting/monitoring workflows and for AI agents summarizing integration channels.

### Before

```json
{
  "ts": "1776063385.720429",
  "user": "U0581KR4M5F",
  "text": "",
  "type": "message",
  "bot_id": "B0578EJQBFH"
}
```

### After

```json
{
  "ts": "1776063385.720429",
  "user": "U0581KR4M5F",
  "text": "",
  "type": "message",
  "bot_id": "B0578EJQBFH",
  "attachments": [
    {
      "title": "New error: ConfirmDraft OnSched update failed",
      "fallback": "<https://app.rollbar.com/.../item/1552|#1552 ...>",
      "title_link": "https://app.rollbar.com/.../item/1552",
      "fields": [...]
    }
  ]
}
```

## Backward compatibility / safety

- **Purely additive.** The JSON output mapping gains one optional field; no existing fields are renamed, reshaped, or removed.
- **Messages without attachments are unchanged.** `JSON.stringify` drops `undefined` values, so the output for a plain message is byte-identical to today.
- **Formatter output is unchanged.** Only the `--json` branch in `conversations.ts` is touched. The human-readable `formatConversationHistory` path is not modified.
- **No new dependencies.** Same `Array<Record<string, unknown>>` shape already used for `blocks`.
- **Type-only change in `index.ts`.** The new field is optional (`attachments?`), so no existing call sites need updates.

## Test plan

- [x] `bun test` — all 112 tests pass (109 pre-existing + 3 new attachment tests)
- [x] New tests cover: presence with title/fallback, absence (undefined), and multiple attachments with nested `fields`
- [x] Pre-existing `type-check` error in `src/lib/workspaces.ts` (unrelated `fs/promises.exists`) reproduces on unmodified upstream `main` — not introduced by this PR
- [x] Manually verified against a real Rollbar notification — the full attachment is now surfaced in `--json` output

## Files changed

| File | Change |
|------|--------|
| `src/types/index.ts` | +1 line: add `attachments?` to `SlackMessage` |
| `src/commands/conversations.ts` | +1 line: add `attachments: msg.attachments` to JSON mapping |
| `src/types/slack-message.test.ts` | +79 lines: 3 unit tests mirroring the `blocks` suite |

Total: **+81, −0**.