### PR TITLE
feat: add Linux arm64 binary to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
           - os: ubuntu-latest
             target: bun-linux-x64
             artifact: slackcli-linux
+          - os: ubuntu-latest
+            target: bun-linux-arm64
+            artifact: slackcli-linux-arm64
           - os: macos-latest
             target: bun-darwin-x64
             artifact: slackcli-macos
@@ -70,7 +73,7 @@ jobs:
       - name: Organize artifacts
         run: |
           mkdir -p release
-          find dist -type f \( -name 'slackcli-linux' -o -name 'slackcli-macos' -o -name 'slackcli-macos-arm64' -o -name 'slackcli-windows.exe' \) -exec cp {} release/ \;
+          find dist -type f \( -name 'slackcli-linux' -o -name 'slackcli-linux-arm64' -o -name 'slackcli-macos' -o -name 'slackcli-macos-arm64' -o -name 'slackcli-windows.exe' \) -exec cp {} release/ \;
           ls -la release/
 
       - name: Generate SHA256 checksums
@@ -107,9 +110,11 @@ jobs:
           SHA_MACOS_X86=$(curl -sL "https://github.com/shaharia-lab/slackcli/releases/download/${VERSION}/slackcli-macos" | sha256sum | cut -d' ' -f1)
           SHA_MACOS_ARM=$(curl -sL "https://github.com/shaharia-lab/slackcli/releases/download/${VERSION}/slackcli-macos-arm64" | sha256sum | cut -d' ' -f1)
           SHA_LINUX=$(curl -sL "https://github.com/shaharia-lab/slackcli/releases/download/${VERSION}/slackcli-linux" | sha256sum | cut -d' ' -f1)
+          SHA_LINUX_ARM=$(curl -sL "https://github.com/shaharia-lab/slackcli/releases/download/${VERSION}/slackcli-linux-arm64" | sha256sum | cut -d' ' -f1)
           echo "SHA256 macOS x86_64: ${SHA_MACOS_X86}"
           echo "SHA256 macOS arm64: ${SHA_MACOS_ARM}"
-          echo "SHA256 Linux: ${SHA_LINUX}"
+          echo "SHA256 Linux x86_64: ${SHA_LINUX}"
+          echo "SHA256 Linux arm64: ${SHA_LINUX_ARM}"
 
           # Main formula content
           MAIN_FORMULA="# typed: false
@@ -141,11 +146,21 @@ jobs:
             end
 
             on_linux do
-              url \"https://github.com/shaharia-lab/slackcli/releases/download/${VERSION}/slackcli-linux\"
-              sha256 \"${SHA_LINUX}\"
+              if Hardware::CPU.intel?
+                url \"https://github.com/shaharia-lab/slackcli/releases/download/${VERSION}/slackcli-linux\"
+                sha256 \"${SHA_LINUX}\"
 
-              def install
-                bin.install \"slackcli-linux\" => \"slackcli\"
+                def install
+                  bin.install \"slackcli-linux\" => \"slackcli\"
+                end
+              end
+              if Hardware::CPU.arm?
+                url \"https://github.com/shaharia-lab/slackcli/releases/download/${VERSION}/slackcli-linux-arm64\"
+                sha256 \"${SHA_LINUX_ARM}\"
+
+                def install
+                  bin.install \"slackcli-linux-arm64\" => \"slackcli\"
+                end
               end
             end
 
@@ -186,11 +201,21 @@ jobs:
             end
 
             on_linux do
-              url \"https://github.com/shaharia-lab/slackcli/releases/download/${VERSION}/slackcli-linux\"
-              sha256 \"${SHA_LINUX}\"
+              if Hardware::CPU.intel?
+                url \"https://github.com/shaharia-lab/slackcli/releases/download/${VERSION}/slackcli-linux\"
+                sha256 \"${SHA_LINUX}\"
 
-              def install
-                bin.install \"slackcli-linux\" => \"slackcli\"
+                def install
+                  bin.install \"slackcli-linux\" => \"slackcli\"
+                end
+              end
+              if Hardware::CPU.arm?
+                url \"https://github.com/shaharia-lab/slackcli/releases/download/${VERSION}/slackcli-linux-arm64\"
+                sha256 \"${SHA_LINUX_ARM}\"
+
+                def install
+                  bin.install \"slackcli-linux-arm64\" => \"slackcli\"
+                end
               end
             end
 

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -63,7 +63,7 @@ function getBinaryName(): string {
   const platform = process.platform;
   const arch = process.arch;
 
-  if (platform === 'linux') return 'slackcli-linux';
+  if (platform === 'linux') return arch === 'arm64' ? 'slackcli-linux-arm64' : 'slackcli-linux';
   if (platform === 'darwin') return arch === 'arm64' ? 'slackcli-macos-arm64' : 'slackcli-macos';
   if (platform === 'win32') return 'slackcli-windows.exe';
 


### PR DESCRIPTION
## Summary

Closes #35

- Add `bun-linux-arm64` build target to the release CI matrix (cross-compiled from `ubuntu-latest`, no arm64 runner needed)
- Include `slackcli-linux-arm64` in the artifact collection and GitHub release upload
- Update `getBinaryName()` in the self-updater to select `slackcli-linux-arm64` on Linux arm64 hosts
- Update both Homebrew formula templates (`slackcli.rb` and versioned) with a `Hardware::CPU.arm?` branch inside `on_linux`, matching the existing macOS pattern

## Test plan

- [x] Verify CI build matrix produces a `slackcli-linux-arm64` artifact on next release tag
- [x] Verify `slackcli update` picks the correct binary on a Linux arm64 host (e.g. AWS Graviton, Docker on Apple Silicon)
- [x] Verify Homebrew installs the arm64 binary on a Linux arm64 machine after next release