### PR TITLE
feat: show update notification after command output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { createCanvasCommand } from './commands/canvas.ts';
 import { createUpdateCommand } from './commands/update.ts';
 import { createSavedCommand } from './commands/saved.ts';
 import { createSearchCommand } from './commands/search.ts';
-import { checkForUpdates } from './lib/updater.ts';
+import { notifyIfUpdateAvailable } from './lib/updater.ts';
 import chalk from 'chalk';
 
 const program = new Command();
@@ -30,10 +30,8 @@ program.addCommand(createSavedCommand());
 program.addCommand(createSearchCommand());
 program.addCommand(createUpdateCommand());
 
-// Check for updates asynchronously (non-blocking)
-checkForUpdates(true).catch(() => {
-  // Silently fail update check
-});
+// Show update notification after command output if a newer version is cached
+notifyIfUpdateAvailable();
 
 // Parse arguments
 program.parse(process.argv);

--- a/src/lib/updater.test.ts
+++ b/src/lib/updater.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'bun:test';
+import { isNewerVersion, isInstalledViaHomebrew, getUpdateCommand } from './updater.ts';
+
+describe('isNewerVersion', () => {
+  it('returns true when latest is newer', () => {
+    expect(isNewerVersion('v0.5.0', '0.4.0')).toBe(true);
+  });
+
+  it('returns false when already on latest', () => {
+    expect(isNewerVersion('v0.4.0', '0.4.0')).toBe(false);
+  });
+
+  it('returns false when current is newer', () => {
+    expect(isNewerVersion('v0.3.0', '0.4.0')).toBe(false);
+  });
+
+  it('handles patch version bumps', () => {
+    expect(isNewerVersion('v0.4.1', '0.4.0')).toBe(true);
+    expect(isNewerVersion('v0.4.0', '0.4.1')).toBe(false);
+  });
+
+  it('handles major version bumps', () => {
+    expect(isNewerVersion('v1.0.0', '0.9.9')).toBe(true);
+  });
+});
+
+describe('isInstalledViaHomebrew', () => {
+  const originalExecPath = process.execPath;
+
+  it('detects macOS Homebrew Cellar path', () => {
+    Object.defineProperty(process, 'execPath', { value: '/usr/local/Cellar/slackcli/0.4.0/bin/slackcli', configurable: true });
+    expect(isInstalledViaHomebrew()).toBe(true);
+    Object.defineProperty(process, 'execPath', { value: originalExecPath, configurable: true });
+  });
+
+  it('detects macOS Apple Silicon Homebrew path', () => {
+    Object.defineProperty(process, 'execPath', { value: '/opt/homebrew/bin/slackcli', configurable: true });
+    expect(isInstalledViaHomebrew()).toBe(true);
+    Object.defineProperty(process, 'execPath', { value: originalExecPath, configurable: true });
+  });
+
+  it('detects Linux Homebrew path', () => {
+    Object.defineProperty(process, 'execPath', { value: '/home/linuxbrew/.linuxbrew/bin/slackcli', configurable: true });
+    expect(isInstalledViaHomebrew()).toBe(true);
+    Object.defineProperty(process, 'execPath', { value: originalExecPath, configurable: true });
+  });
+
+  it('returns false for direct binary install', () => {
+    Object.defineProperty(process, 'execPath', { value: '/usr/local/bin/slackcli', configurable: true });
+    expect(isInstalledViaHomebrew()).toBe(false);
+    Object.defineProperty(process, 'execPath', { value: originalExecPath, configurable: true });
+  });
+
+  it('returns false for path in home directory', () => {
+    Object.defineProperty(process, 'execPath', { value: '/home/user/bin/slackcli', configurable: true });
+    expect(isInstalledViaHomebrew()).toBe(false);
+    Object.defineProperty(process, 'execPath', { value: originalExecPath, configurable: true });
+  });
+});
+
+describe('getUpdateCommand', () => {
+  const originalExecPath = process.execPath;
+
+  it('returns brew command for Homebrew installs', () => {
+    Object.defineProperty(process, 'execPath', { value: '/opt/homebrew/bin/slackcli', configurable: true });
+    expect(getUpdateCommand()).toBe('brew upgrade slackcli');
+    Object.defineProperty(process, 'execPath', { value: originalExecPath, configurable: true });
+  });
+
+  it('returns slackcli update for direct installs', () => {
+    Object.defineProperty(process, 'execPath', { value: '/usr/local/bin/slackcli', configurable: true });
+    expect(getUpdateCommand()).toBe('slackcli update');
+    Object.defineProperty(process, 'execPath', { value: originalExecPath, configurable: true });
+  });
+});

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,7 +1,18 @@
 import { writeFile, chmod, rename, unlink } from 'fs/promises';
-import { tmpdir } from 'os';
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { tmpdir, homedir } from 'os';
 import { join } from 'path';
+import chalk from 'chalk';
 import { info, success, error as logError } from './formatter.ts';
+
+const CONFIG_DIR = join(homedir(), '.config', 'slackcli');
+const UPDATE_CACHE_FILE = join(CONFIG_DIR, 'update-check.json');
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+interface UpdateCache {
+  checkedAt: number;
+  latestVersion: string;
+}
 
 const GITHUB_REPO = 'shaharia-lab/slackcli';
 // @ts-ignore - This will be replaced at build time
@@ -163,4 +174,72 @@ export async function performUpdate(): Promise<void> {
     logError(`Update failed: ${error.message}`);
     throw error;
   }
+}
+
+// Read cached update check result synchronously
+function readUpdateCache(): UpdateCache | null {
+  try {
+    const data = readFileSync(UPDATE_CACHE_FILE, 'utf-8');
+    return JSON.parse(data) as UpdateCache;
+  } catch {
+    return null;
+  }
+}
+
+// Write update check result to cache
+function writeUpdateCache(cache: UpdateCache): void {
+  try {
+    if (!existsSync(CONFIG_DIR)) {
+      mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
+    }
+    writeFileSync(UPDATE_CACHE_FILE, JSON.stringify(cache, null, 2));
+  } catch {
+    // Silently fail — cache is best-effort
+  }
+}
+
+// Detect if the binary was installed via Homebrew
+export function isInstalledViaHomebrew(): boolean {
+  const execPath = process.execPath;
+  return execPath.includes('homebrew') || execPath.includes('Cellar') || execPath.includes('linuxbrew');
+}
+
+// Return the appropriate update command for this installation
+export function getUpdateCommand(): string {
+  return isInstalledViaHomebrew() ? 'brew upgrade slackcli' : 'slackcli update';
+}
+
+// Show a one-line update notification after the command finishes (via beforeExit),
+// and refresh the cache in the background if it is stale.
+export function notifyIfUpdateAvailable(): void {
+  const cache = readUpdateCache();
+  const now = Date.now();
+
+  // Trigger a background cache refresh if missing or older than 24h
+  if (!cache || (now - cache.checkedAt) > CHECK_INTERVAL_MS) {
+    fetchLatestRelease()
+      .then(release => {
+        if (release) {
+          writeUpdateCache({ checkedAt: now, latestVersion: release.tag_name });
+        }
+      })
+      .catch(() => {});
+  }
+
+  // Nothing to show if cache is empty or already on latest
+  if (!cache || !isNewerVersion(cache.latestVersion, CURRENT_VERSION)) {
+    return;
+  }
+
+  const updateCmd = getUpdateCommand();
+  let printed = false;
+
+  process.on('beforeExit', () => {
+    if (printed) return;
+    printed = true;
+    process.stderr.write(
+      chalk.yellow(`\n  Update available: v${CURRENT_VERSION} → ${cache.latestVersion}\n`) +
+      chalk.dim(`  Run: ${updateCmd}\n`),
+    );
+  });
 }


### PR DESCRIPTION
## Summary

When a newer version of slackcli is available, users now see a one-line notification at the bottom of every command's output — after the command finishes, never in the middle.

```
$ slackcli conversations list
...command output...

  Update available: v0.4.0 → v0.5.0
  Run: brew upgrade slackcli
```

## How it works

- **Cache-based, zero latency** — result is stored in `~/.config/slackcli/update-check.json`. The notification is a synchronous read of that file; no network call on the critical path.
- **Background refresh** — GitHub API is called at most once per 24h. The cache is updated silently in the background; the user sees the result on the _next_ run.
- **Correct update command** — detects Homebrew installs via `process.execPath` (checks for `homebrew`, `Cellar`, `linuxbrew` in path):
  - Homebrew install → `brew upgrade slackcli`
  - Direct binary install → `slackcli update`
- **Stderr output** — notification goes to stderr so piped commands (`slackcli conversations list --json | jq`) are unaffected.
- **Predictable placement** — uses `process.on('beforeExit', ...)` so it always appears after all command output.

## Changes

- `src/lib/updater.ts` — adds `readUpdateCache`, `writeUpdateCache`, `isInstalledViaHomebrew`, `getUpdateCommand`, `notifyIfUpdateAvailable`
- `src/index.ts` — replaces silent `checkForUpdates(true)` call with `notifyIfUpdateAvailable()`
- `src/lib/updater.test.ts` — new test file covering version comparison, Homebrew detection, and update command selection

## Test plan

- [x] Run any command with a stale version in cache — confirm notification appears after output
- [x] Run on a Homebrew install — confirm `brew upgrade slackcli` is shown
- [x] Run on a direct install — confirm `slackcli update` is shown
- [x] Confirm `slackcli conversations list --json | jq` output is clean (notification on stderr only)
- [x] Confirm no notification when already on latest version