### PR TITLE
feat: add 'conversations get' command

### DIFF
--- a/src/commands/conversations.ts
+++ b/src/commands/conversations.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander';
 import ora from 'ora';
 import { getAuthenticatedClient } from '../lib/auth.ts';
 import { error, formatChannelList, formatConversationHistory, formatUnreadChannels } from '../lib/formatter.ts';
+import { fetchMessage } from '../lib/message.ts';
 import { fetchUnreadChannels } from '../lib/unread.ts';
 import type { SlackChannel, SlackMessage, SlackUser } from '../types/index.ts';
 
@@ -196,32 +197,7 @@ export function createConversationsCommand(): Command {
       try {
         const client = await getAuthenticatedClient(options.workspace);
 
-        let msg: SlackMessage | undefined;
-
-        if (client.authType === 'browser') {
-          // Single batch call that handles top-level messages and thread replies
-          const response = await client.listMessages([{ channel: channelId, timestamps: [timestamp] }]);
-          const msgs = response.messages?.[channelId] || [];
-          msg = msgs[0];
-        } else {
-          // Standard auth: try channel history first, then thread replies
-          const history = await client.getConversationHistory(channelId, {
-            latest: timestamp,
-            oldest: timestamp,
-            inclusive: true,
-            limit: 1,
-          });
-          msg = history.messages?.[0];
-
-          if (!msg) {
-            // May be a thread reply — try conversations.replies
-            const replies = await client.getConversationReplies(channelId, timestamp, {
-              inclusive: true,
-              limit: 1,
-            });
-            msg = replies.messages?.[0];
-          }
-        }
+        const msg = await fetchMessage(client, channelId, timestamp);
 
         if (!msg) {
           spinner.fail('Message not found');

--- a/src/commands/conversations.ts
+++ b/src/commands/conversations.ts
@@ -182,6 +182,110 @@ export function createConversationsCommand(): Command {
       }
     });
 
+  // Get a single message by channel + timestamp
+  conversations
+    .command('get')
+    .description('Get a specific message by channel ID and timestamp')
+    .argument('<channel-id>', 'Channel ID')
+    .argument('<timestamp>', 'Message timestamp')
+    .option('--workspace <id|name>', 'Workspace to use')
+    .option('--json', 'Output in JSON format', false)
+    .action(async (channelId, timestamp, options) => {
+      const spinner = ora('Fetching message...').start();
+
+      try {
+        const client = await getAuthenticatedClient(options.workspace);
+
+        let msg: SlackMessage | undefined;
+
+        if (client.authType === 'browser') {
+          // Single batch call that handles top-level messages and thread replies
+          const response = await client.listMessages([{ channel: channelId, timestamps: [timestamp] }]);
+          const msgs = response.messages?.[channelId] || [];
+          msg = msgs[0];
+        } else {
+          // Standard auth: try channel history first, then thread replies
+          const history = await client.getConversationHistory(channelId, {
+            latest: timestamp,
+            oldest: timestamp,
+            inclusive: true,
+            limit: 1,
+          });
+          msg = history.messages?.[0];
+
+          if (!msg) {
+            // May be a thread reply — try conversations.replies
+            const replies = await client.getConversationReplies(channelId, timestamp, {
+              inclusive: true,
+              limit: 1,
+            });
+            msg = replies.messages?.[0];
+          }
+        }
+
+        if (!msg) {
+          spinner.fail('Message not found');
+          process.exit(1);
+        }
+
+        // Fetch user info
+        const users = new Map<string, SlackUser>();
+        if (msg.user) {
+          spinner.text = 'Fetching user information...';
+          try {
+            const userResponse = await client.getUserInfo(msg.user);
+            if (userResponse.user) {
+              users.set(userResponse.user.id, userResponse.user);
+            }
+          } catch {
+            // Continue without user info
+          }
+        }
+
+        spinner.succeed('Message found');
+
+        if (options.json) {
+          console.log(JSON.stringify({
+            channel_id: channelId,
+            message: {
+              ts: msg.ts,
+              thread_ts: msg.thread_ts,
+              user: msg.user,
+              text: msg.text,
+              type: msg.type,
+              reply_count: msg.reply_count,
+              reactions: msg.reactions,
+              bot_id: msg.bot_id,
+              blocks: msg.blocks,
+              ...(msg.files?.length ? { files: msg.files.map(f => ({
+                id: f.id,
+                name: f.name,
+                title: f.title,
+                mimetype: f.mimetype,
+                filetype: f.filetype,
+                size: f.size,
+                url_private: f.url_private,
+                permalink: f.permalink,
+                mode: f.mode,
+              })) } : {}),
+            },
+            users: Array.from(users.values()).map(u => ({
+              id: u.id,
+              name: u.name,
+              real_name: u.real_name,
+              email: u.profile?.email,
+            })),
+          }, null, 2));
+        } else {
+          console.log('\n' + formatConversationHistory(channelId, [msg], users));
+        }
+      } catch (err: any) {
+        spinner.fail('Failed to fetch message');
+        error(err.message);
+        process.exit(1);
+      }
+    });
+
   // List unread conversations
   conversations
     .command('unread')

--- a/src/lib/message.test.ts
+++ b/src/lib/message.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'bun:test';
+import { fetchMessage } from './message.ts';
+import type { SlackClient } from './slack-client.ts';
+
+function createMockClient(
+  authType: 'browser' | 'standard',
+  overrides: {
+    listMessages?: (ids: any) => Promise<any>;
+    getConversationHistory?: (channel: string, opts: any) => Promise<any>;
+  } = {},
+): SlackClient {
+  return {
+    authType,
+    listMessages: overrides.listMessages ?? (() => Promise.resolve({ messages: {} })),
+    getConversationHistory: overrides.getConversationHistory ?? (() => Promise.resolve({ messages: [] })),
+  } as unknown as SlackClient;
+}
+
+describe('fetchMessage', () => {
+  describe('browser auth', () => {
+    it('fetches a top-level message via messages.list', async () => {
+      const client = createMockClient('browser', {
+        listMessages: () => Promise.resolve({
+          messages: {
+            C123: [{ ts: '1.1', text: 'Hello', type: 'message', user: 'U1' }],
+          },
+        }),
+      });
+
+      const msg = await fetchMessage(client, 'C123', '1.1');
+      expect(msg).toBeDefined();
+      expect(msg!.text).toBe('Hello');
+      expect(msg!.ts).toBe('1.1');
+    });
+
+    it('fetches a thread reply via messages.list', async () => {
+      const client = createMockClient('browser', {
+        listMessages: () => Promise.resolve({
+          messages: {
+            C123: [{ ts: '1.2', text: 'Reply', type: 'message', user: 'U1', thread_ts: '1.1' }],
+          },
+        }),
+      });
+
+      const msg = await fetchMessage(client, 'C123', '1.2');
+      expect(msg).toBeDefined();
+      expect(msg!.text).toBe('Reply');
+      expect(msg!.thread_ts).toBe('1.1');
+    });
+
+    it('returns undefined when message not found', async () => {
+      const client = createMockClient('browser', {
+        listMessages: () => Promise.resolve({ messages: { C123: [] } }),
+      });
+
+      const msg = await fetchMessage(client, 'C123', '9.9');
+      expect(msg).toBeUndefined();
+    });
+
+    it('returns undefined when channel not in response', async () => {
+      const client = createMockClient('browser', {
+        listMessages: () => Promise.resolve({ messages: {} }),
+      });
+
+      const msg = await fetchMessage(client, 'C_MISSING', '1.1');
+      expect(msg).toBeUndefined();
+    });
+  });
+
+  describe('standard auth', () => {
+    it('fetches a top-level message via conversations.history', async () => {
+      const client = createMockClient('standard', {
+        getConversationHistory: () => Promise.resolve({
+          messages: [{ ts: '1.1', text: 'Hello', type: 'message', user: 'U1' }],
+        }),
+      });
+
+      const msg = await fetchMessage(client, 'C123', '1.1');
+      expect(msg).toBeDefined();
+      expect(msg!.text).toBe('Hello');
+    });
+
+    it('passes correct timestamp range to conversations.history', async () => {
+      let capturedOpts: any;
+      const client = createMockClient('standard', {
+        getConversationHistory: (_channel: string, opts: any) => {
+          capturedOpts = opts;
+          return Promise.resolve({ messages: [] });
+        },
+      });
+
+      await fetchMessage(client, 'C123', '1744346513.339549');
+      expect(capturedOpts.latest).toBe('1744346513.339549');
+      expect(capturedOpts.oldest).toBe('1744346513.339549');
+      expect(capturedOpts.inclusive).toBe(true);
+      expect(capturedOpts.limit).toBe(1);
+    });
+
+    it('returns undefined for thread replies (known limitation)', async () => {
+      const client = createMockClient('standard', {
+        getConversationHistory: () => Promise.resolve({ messages: [] }),
+      });
+
+      // Thread replies don't appear in conversations.history, and we can't
+      // call conversations.replies without the parent thread_ts
+      const msg = await fetchMessage(client, 'C123', '1.2');
+      expect(msg).toBeUndefined();
+    });
+
+    it('returns undefined when no messages match', async () => {
+      const client = createMockClient('standard', {
+        getConversationHistory: () => Promise.resolve({ messages: [] }),
+      });
+
+      const msg = await fetchMessage(client, 'C123', '9.9');
+      expect(msg).toBeUndefined();
+    });
+  });
+
+  it('uses messages.list for browser auth, not conversations.history', async () => {
+    let listMessagesCalled = false;
+    let historyCalled = false;
+
+    const client = createMockClient('browser', {
+      listMessages: () => {
+        listMessagesCalled = true;
+        return Promise.resolve({ messages: {} });
+      },
+      getConversationHistory: () => {
+        historyCalled = true;
+        return Promise.resolve({ messages: [] });
+      },
+    });
+
+    await fetchMessage(client, 'C123', '1.1');
+    expect(listMessagesCalled).toBe(true);
+    expect(historyCalled).toBe(false);
+  });
+
+  it('uses conversations.history for standard auth, not messages.list', async () => {
+    let listMessagesCalled = false;
+    let historyCalled = false;
+
+    const client = createMockClient('standard', {
+      listMessages: () => {
+        listMessagesCalled = true;
+        return Promise.resolve({ messages: {} });
+      },
+      getConversationHistory: () => {
+        historyCalled = true;
+        return Promise.resolve({ messages: [] });
+      },
+    });
+
+    await fetchMessage(client, 'C123', '1.1');
+    expect(listMessagesCalled).toBe(false);
+    expect(historyCalled).toBe(true);
+  });
+});

--- a/src/lib/message.ts
+++ b/src/lib/message.ts
@@ -1,0 +1,34 @@
+import type { SlackClient } from './slack-client.ts';
+import type { SlackMessage } from '../types/index.ts';
+
+/**
+ * Fetch a single message by channel ID and timestamp.
+ *
+ * Browser auth uses messages.list which resolves both top-level messages
+ * and thread replies in a single call.
+ *
+ * Standard auth can only resolve top-level messages via conversations.history.
+ * Thread replies require the parent thread_ts for conversations.replies, which
+ * is not available when you only have the reply's timestamp. There is no public
+ * Slack API to look up an arbitrary reply by timestamp alone.
+ */
+export async function fetchMessage(
+  client: SlackClient,
+  channelId: string,
+  timestamp: string,
+): Promise<SlackMessage | undefined> {
+  if (client.authType === 'browser') {
+    const response = await client.listMessages([{ channel: channelId, timestamps: [timestamp] }]);
+    const msgs = response.messages?.[channelId] || [];
+    return msgs[0];
+  }
+
+  // Standard auth: can only resolve top-level messages.
+  const history = await client.getConversationHistory(channelId, {
+    latest: timestamp,
+    oldest: timestamp,
+    inclusive: true,
+    limit: 1,
+  });
+  return history.messages?.[0];
+}


### PR DESCRIPTION
## Summary
- Added `conversations get <channel-id> <timestamp>` command to fetch a single message
- Supports both `--json` output and formatted terminal output
- Handles top-level messages and thread replies via browser auth
- Added `fetchMessage` shared lib module with 10 unit tests

## Reason
There was no way to retrieve a specific message by its channel ID and timestamp. This is useful when you have a saved reference to a message (e.g. from `saved list --json` or a Slack link) and want to quickly pull up its content without reading the full conversation history.

## More Details

### Dual auth handling
- **Browser auth**: Uses `messages.list` (the same internal API used by `saved list`) which resolves both top-level messages and thread replies in a single call.
- **Standard auth**: Uses `conversations.history` with an exact timestamp range. Can only resolve top-level channel messages.

### Architecture
The fetch logic lives in `src/lib/message.ts` (`fetchMessage`), following the same pattern as `saved.ts` (`enrichSavedItems`) and `unread.ts` (`fetchUnreadChannels`). The command layer in `src/commands/conversations.ts` is thin wiring.

### Output
- Default: reuses the existing `formatConversationHistory` formatter for consistent terminal output
- `--json`: follows the same structure as `conversations read --json` — message fields, file metadata, and resolved user info

### Known limitations
- Standard auth cannot resolve thread replies. The public `conversations.replies` API requires the parent `thread_ts`, which is not available when you only have the reply's own timestamp. There is no public Slack API to look up an arbitrary reply by timestamp alone. Browser auth does not have this limitation.

## QA
Tested manually against a workspace with browser auth:
- [x] Fetch a top-level message by channel + timestamp
- [x] Fetch a thread reply by channel + timestamp
- [x] `--json` output returns valid JSON with message and user data
- [x] Non-existent message shows "Message not found" error
- [x] `bun run type-check` passes
- [x] `bun test` passes (170 tests)