### PR TITLE
ci: pin Bun to 1.3.13 and ad-hoc sign macOS release binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,10 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          # Pinned: Bun 1.3.12 produced corrupt macOS code signatures
+          # (oven-sh/bun#29120); fixed in 1.3.13. Bump this intentionally
+          # after reviewing Bun release notes.
+          bun-version: 1.3.13
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,11 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          # Pinned: Bun 1.3.12 produced corrupt macOS code signatures that
+          # caused the released binary to be killed on launch on Apple
+          # Silicon (issue #43, oven-sh/bun#29120). Fixed in Bun 1.3.13.
+          # Bump intentionally after reviewing Bun release notes.
+          bun-version: 1.3.13
 
       - name: Install dependencies
         run: bun install
@@ -49,6 +53,12 @@ jobs:
 
       - name: Build binary
         run: bun build --compile --minify --target=${{ matrix.target }} --define __APP_VERSION__='"${{ steps.version.outputs.VERSION }}"' src/index.ts --outfile dist/${{ matrix.artifact }}
+
+      - name: Ad-hoc sign macOS binary
+        if: runner.os == 'macOS'
+        run: |
+          codesign --force --sign - dist/${{ matrix.artifact }}
+          codesign --verify --verbose dist/${{ matrix.artifact }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,9 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          # Pinned: keep CI aligned with release.yml. See release.yml for
+          # details on the 1.3.12 macOS codesign regression.
+          bun-version: 1.3.13
 
       - name: Install dependencies
         run: bun install
@@ -35,7 +37,9 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          # Pinned: keep CI aligned with release.yml. See release.yml for
+          # details on the 1.3.12 macOS codesign regression.
+          bun-version: 1.3.13
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION
## Summary

Fixes #43 — the v0.6.0 macOS binaries (both direct download and Homebrew) are killed on launch on Apple Silicon with SIGKILL (exit 137).

### Root cause

Not a macOS policy change — a **Bun regression**. [Bun 1.3.12](https://bun.com/blog/bun-v1.3.12) (Apr 10, 2026) grew the runtime by ~337 KB, which tripped a latent bug in `src/macho.zig`'s signature-size calculation. The resulting `LC_CODE_SIGNATURE.datasize` is smaller than the SuperBlob Bun actually writes, so the binary ships with a truncated/corrupt ad-hoc signature and AMFI refuses to run it. Even re-signing with `codesign --sign -` fails (`invalid or unsupported format for signature`) because the Mach-O layout itself is malformed.

- Upstream issue: [oven-sh/bun#29120](https://github.com/oven-sh/bun/issues/29120) / [#29361](https://github.com/oven-sh/bun/issues/29361)
- Fix: [oven-sh/bun#29272](https://github.com/oven-sh/bun/pull/29272), shipped in **[Bun 1.3.13](https://bun.com/blog/bun-v1.3.13)** (Apr 20, 2026)

Our workflows all used `bun-version: latest`, so v0.6.0 silently picked up the broken 1.3.12.

### Changes

1. **Pin Bun to `1.3.13` exactly** in all three workflow files:
   - `.github/workflows/release.yml` (the one that actually ships binaries)
   - `.github/workflows/ci.yml`
   - `.github/workflows/test.yml` (two jobs)

   Exact pin (not `"1.3"` floating-patch) so releases are reproducible and a future Bun release has to be adopted intentionally via a PR — `latest`/patch-float is how we got bitten in the first place.

2. **Ad-hoc `codesign` step after the macOS build** in `release.yml` as defense-in-depth:
   ```yaml
   - name: Ad-hoc sign macOS binary
     if: runner.os == 'macOS'
     run: |
       codesign --force --sign - dist/${{ matrix.artifact }}
       codesign --verify --verbose dist/${{ matrix.artifact }}
   ```
   Re-signing a correctly-signed Bun 1.3.13 binary is a no-op, but it means a future Bun signing regression would be caught and overridden at release time rather than shipping broken artifacts.

### Intentionally not changed

- `package.json` `engines.bun: ">=1.0.0"` — this is the **minimum** Bun for users/developers, not a build-time pin. Tightening it would exclude contributors on older Bun for no benefit.
- `README.md` / `CONTRIBUTING.md` / `CLAUDE.md` wording ("Bun v1.0+") — matches the engine field.
- `.pre-commit-config.yaml` — uses the developer's local `bun` binary, not GitHub Actions.

### Release note

After merge, cutting a new tag (e.g. `v0.6.1`) will trigger a rebuild on Bun 1.3.13 and auto-update the Homebrew formula via the existing `update-homebrew` job, fixing both install paths mentioned in #43.

## Test plan

- [ ] CI (`ci.yml`, `test.yml`) passes on this PR — confirms Bun 1.3.13 is usable and `bun install` / `bun test` / `bun run build` all work.
- [ ] After merge, cut a test tag and confirm:
  - [ ] macOS arm64 artifact passes `codesign --verify --verbose` in the release job logs
  - [ ] Download `slackcli-macos-arm64` from the release, run `./slackcli --help` on Apple Silicon — exits 0, no SIGKILL
  - [ ] `brew install shaharia-lab/tap/slackcli` on Apple Silicon — `slackcli --version` works
  - [ ] `slackcli-macos` (x64) also launches under Rosetta

Closes #43

https://claude.ai/code/session_01UXpcmbzVsNJnMkZyrL3RZp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXpcmbzVsNJnMkZyrL3RZp)_