### PR TITLE
fix: preserve newlines in draft messages

### DIFF
--- a/src/lib/mrkdwn.test.ts
+++ b/src/lib/mrkdwn.test.ts
@@ -98,43 +98,42 @@ describe('parseMrkdwn', () => {
     }]);
   });
 
-  it('splits newlines into separate sections', () => {
+  it('preserves newlines in text elements', () => {
+    // Newlines must be embedded in text, not split into separate sections.
+    // Slack's draft composer renders multiple sections inline (no breaks),
+    // but correctly preserves \n within text elements.
     const result = parseMrkdwn('line one\nline two');
     expect(result).toEqual([{
       type: 'rich_text',
-      elements: [
-        {
-          type: 'rich_text_section',
-          elements: [{ type: 'text', text: 'line one' }],
-        },
-        {
-          type: 'rich_text_section',
-          elements: [{ type: 'text', text: 'line two' }],
-        },
-      ],
+      elements: [{
+        type: 'rich_text_section',
+        elements: [{ type: 'text', text: 'line one\nline two' }],
+      }],
     }]);
   });
 
-  it('handles formatting across multiple lines', () => {
-    const result = parseMrkdwn('*bold line*\n_italic line_');
+  it('preserves newlines with formatting', () => {
+    const result = parseMrkdwn('*bold*\nplain');
     expect(result).toEqual([{
       type: 'rich_text',
-      elements: [
-        {
-          type: 'rich_text_section',
-          elements: [{ type: 'text', text: 'bold line', style: { bold: true } }],
-        },
-        {
-          type: 'rich_text_section',
-          elements: [{ type: 'text', text: 'italic line', style: { italic: true } }],
-        },
-      ],
+      elements: [{
+        type: 'rich_text_section',
+        elements: [
+          { type: 'text', text: 'bold', style: { bold: true } },
+          { type: 'text', text: '\nplain' },
+        ],
+      }],
     }]);
   });
 
-  it('handles empty lines between content', () => {
+  it('preserves multiple newlines', () => {
     const result = parseMrkdwn('above\n\nbelow');
-    expect(result[0].elements).toHaveLength(3);
-    expect(result[0].elements[1].elements).toEqual([{ type: 'text', text: '\n' }]);
+    expect(result).toEqual([{
+      type: 'rich_text',
+      elements: [{
+        type: 'rich_text_section',
+        elements: [{ type: 'text', text: 'above\n\nbelow' }],
+      }],
+    }]);
   });
 });

--- a/src/lib/mrkdwn.ts
+++ b/src/lib/mrkdwn.ts
@@ -95,14 +95,16 @@ function parseInline(text: string): RichTextElement[] {
 }
 
 export function parseMrkdwn(text: string): RichTextBlock[] {
-  const lines = text.split('\n');
-  const sections: RichTextSection[] = lines.map(line => ({
-    type: 'rich_text_section',
-    elements: line.length > 0 ? parseInline(line) : [{ type: 'text', text: '\n' }],
-  }));
+  // Keep newlines embedded in text elements rather than splitting into multiple sections.
+  // Slack's draft composer renders multiple rich_text_section elements inline (no line breaks),
+  // but correctly preserves \n characters within a single text element.
+  const elements = parseInline(text);
 
   return [{
     type: 'rich_text',
-    elements: sections,
+    elements: [{
+      type: 'rich_text_section',
+      elements: elements.length > 0 ? elements : [{ type: 'text', text: '' }],
+    }],
   }];
 }


### PR DESCRIPTION
## Summary
- Fixed `parseMrkdwn()` to preserve newlines embedded in text elements
- Slack's draft composer renders multiple `rich_text_section` elements inline, losing line breaks
- Changed to use a single section with `\n` characters in the text content
- Updated tests to match new behavior

## Reason
When creating a draft message with `slackcli messages draft --message $'Line1\nLine2'`, the newlines were lost and the message appeared as a single line. This was because `parseMrkdwn()` split text by `\n` into separate `rich_text_section` elements, but Slack's draft composer renders multiple sections inline without line breaks.

Fixes #45

## More Details

### Root cause
The original implementation in `src/lib/mrkdwn.ts`:
```typescript
const lines = text.split('\n');
const sections = lines.map(line => ({
  type: 'rich_text_section',
  elements: parseInline(line),
}));
```

Slack's web composer renders each `rich_text_section` inline, not as separate lines.

### Solution
Keep newlines embedded in the text content within a single section:
```typescript
const elements = parseInline(text);
return [{
  type: 'rich_text',
  elements: [{
    type: 'rich_text_section',
    elements: elements,
  }],
}];
```

### Comparison
- `messages send` works correctly (uses raw `text` param to `chat.postMessage`)
- `messages draft` was broken (converted to blocks via `parseMrkdwn`)

Verified via direct curl to `drafts.create` that a single text element with embedded `\n` renders correctly in Slack's draft composer.

## QA
- [x] Draft messages now preserve newlines when viewed in Slack's composer
- [x] Inline formatting (*bold*, _italic_, `code`, ~strike~) still works
- [x] Newlines with mixed formatting preserved
- [x] `bun test src/lib/mrkdwn.test.ts` passes (16 tests)
- [x] Existing tests updated to match new behavior