### PR TITLE
Enable github-maintenance plugin from claude-power-user marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "shaharia-lab": {
+      "source": {
+        "source": "github",
+        "repo": "shaharia-lab/claude-power-user"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "github-maintenance@shaharia-lab": true
+  }
+}


### PR DESCRIPTION
Adds `.claude/settings.json` to register the `shaharia-lab/claude-power-user` marketplace and enable the `github-maintenance@shaharia-lab` plugin.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3LgHFg3upbBneSQAnTJCf)_