### PR TITLE
feat: add --file arg in slack client

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,9 @@ slackcli messages send --recipient-id=U9876543210 --message="Hey there!"
 # Reply to a thread
 slackcli messages send --recipient-id=C1234567890 --thread-ts=1234567890.123456 --message="Great idea!"
 
+# Send a message with a file attachment
+slackcli messages send --recipient-id=C1234567890 --message="Here is the file" --file=./report.pdf
+
 # Create a draft message in a channel (only works with browser session tokens)
 slackcli messages draft --recipient-id=C1234567890 --message="Hello team!"
 
@@ -212,6 +215,8 @@ slackcli messages react --channel-id=C1234567890 --timestamp=1234567890.123456 -
 slackcli messages react --channel-id=C1234567890 --timestamp=1234567890.123456 --emoji=fire
 slackcli messages react --channel-id=C1234567890 --timestamp=1234567890.123456 --emoji=eyes
 ```
+
+File uploads require Slack workspace permissions that allow file upload, such as `files:write` for standard Slack app tokens.
 
 **Common emoji names:**
 - `+1` or `thumbsup` - 👍

--- a/src/commands/messages.test.ts
+++ b/src/commands/messages.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'bun:test';
+import { createMessagesCommand } from './messages.ts';
+
+describe('messages command', () => {
+  it('exposes a file option on messages send', () => {
+    const messages = createMessagesCommand();
+    const send = messages.commands.find((command) => command.name() === 'send');
+
+    expect(send?.options.some((option) => option.long === '--file')).toBe(true);
+  });
+});

--- a/src/commands/messages.ts
+++ b/src/commands/messages.ts
@@ -14,6 +14,7 @@ export function createMessagesCommand(): Command {
     .requiredOption('--recipient-id <id>', 'Channel ID or User ID')
     .requiredOption('--message <text>', 'Message text content')
     .option('--thread-ts <timestamp>', 'Send as reply to thread')
+    .option('--file <path>', 'Attach a file to the message')
     .option('--workspace <id|name>', 'Workspace to use')
     .action(async (options) => {
       const spinner = ora('Sending message...').start();
@@ -30,6 +31,17 @@ export function createMessagesCommand(): Command {
         }
 
         spinner.text = 'Sending message...';
+        if (options.file) {
+          await client.uploadFileExternal(channelId, options.file, {
+            initial_comment: options.message,
+            thread_ts: options.threadTs,
+          });
+
+          spinner.succeed('Message sent successfully!');
+          success('File uploaded successfully');
+          return;
+        }
+
         const response = await client.postMessage(channelId, options.message, {
           thread_ts: options.threadTs,
         });

--- a/src/lib/slack-client.test.ts
+++ b/src/lib/slack-client.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SlackClient } from './slack-client.ts';
+
+class TestSlackClient extends SlackClient {
+  public readonly calls: Array<{ method: string; params: Record<string, unknown> }> = [];
+
+  constructor() {
+    super({
+      workspace_id: 'T123',
+      workspace_name: 'Test Workspace',
+      auth_type: 'browser',
+      xoxd_token: 'xoxd-test',
+      xoxc_token: 'xoxc-test',
+      workspace_url: 'https://example.slack.com',
+    });
+  }
+
+  override async request(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+    this.calls.push({ method, params });
+
+    if (method === 'files.getUploadURLExternal') {
+      return {
+        ok: true,
+        upload_url: 'https://uploads.slack.test/file',
+        file_id: 'F123',
+      };
+    }
+
+    if (method === 'files.completeUploadExternal') {
+      return {
+        ok: true,
+        files: [{ id: 'F123' }],
+      };
+    }
+
+    throw new Error(`Unexpected method: ${method}`);
+  }
+}
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('SlackClient.uploadFileExternal', () => {
+  it('uploads a local file and shares it with the message as the initial comment', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'slackcli-upload-'));
+    const filePath = join(dir, 'report.txt');
+    await Bun.write(filePath, 'Quarterly report');
+
+    let uploadRequest: { url: string; bodyText: string; contentType?: string } | undefined;
+    globalThis.fetch = (async (input, init) => {
+      const body = init?.body;
+      expect(body).toBeInstanceOf(Uint8Array);
+      uploadRequest = {
+        url: String(input),
+        bodyText: new TextDecoder().decode(body as Uint8Array),
+        contentType: init?.headers instanceof Headers
+          ? init.headers.get('Content-Type') ?? undefined
+          : (init?.headers as Record<string, string> | undefined)?.['Content-Type'],
+      };
+
+      return new Response('', { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      const client = new TestSlackClient();
+
+      await client.uploadFileExternal('C123', filePath, {
+        initial_comment: 'Here is the file',
+      });
+
+      expect(client.calls).toEqual([
+        {
+          method: 'files.getUploadURLExternal',
+          params: {
+            filename: 'report.txt',
+            length: 16,
+          },
+        },
+        {
+          method: 'files.completeUploadExternal',
+          params: {
+            files: JSON.stringify([{ id: 'F123', title: 'report.txt' }]),
+            channel_id: 'C123',
+            initial_comment: 'Here is the file',
+          },
+        },
+      ]);
+      expect(uploadRequest).toEqual({
+        url: 'https://uploads.slack.test/file',
+        bodyText: 'Quarterly report',
+        contentType: 'application/octet-stream',
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws a clear error when the file does not exist', async () => {
+    const client = new TestSlackClient();
+
+    await expect(
+      client.uploadFileExternal('C123', '/tmp/slackcli-missing-file.txt', {
+        initial_comment: 'Here is the file',
+      }),
+    ).rejects.toThrow('File not found: /tmp/slackcli-missing-file.txt');
+
+    expect(client.calls).toEqual([]);
+  });
+});

--- a/src/lib/slack-client.ts
+++ b/src/lib/slack-client.ts
@@ -1,6 +1,13 @@
 import { WebClient } from '@slack/web-api';
+import { basename } from 'node:path';
+import { readFile, stat } from 'node:fs/promises';
 import type { WorkspaceConfig, SlackAuthTestResponse } from '../types/index.ts';
 import { parseMrkdwn } from './mrkdwn.ts';
+
+interface ExternalUploadUrlResponse {
+  upload_url?: string;
+  file_id?: string;
+}
 
 export class SlackClient {
   private config: WorkspaceConfig;
@@ -142,6 +149,56 @@ export class SlackClient {
     if (options.thread_ts) params.thread_ts = options.thread_ts;
 
     return this.request('chat.postMessage', params);
+  }
+
+  async uploadFileExternal(channel: string, filePath: string, options: {
+    initial_comment?: string;
+    thread_ts?: string;
+  } = {}): Promise<unknown> {
+    const fileStats = await stat(filePath).catch((error: unknown) => {
+      if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+        throw new Error(`File not found: ${filePath}`);
+      }
+      throw error;
+    });
+    if (!fileStats.isFile()) {
+      throw new Error(`Cannot upload non-file path: ${filePath}`);
+    }
+    if (fileStats.size === 0) {
+      throw new Error(`Cannot upload empty file: ${filePath}`);
+    }
+
+    const filename = basename(filePath);
+    const uploadUrlResponse = await this.request('files.getUploadURLExternal', {
+      filename,
+      length: fileStats.size,
+    }) as ExternalUploadUrlResponse;
+
+    if (!uploadUrlResponse.upload_url || !uploadUrlResponse.file_id) {
+      throw new Error('Slack API error: missing upload URL or file ID');
+    }
+
+    const fileBytes = await readFile(filePath);
+    const uploadResponse = await fetch(uploadUrlResponse.upload_url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/octet-stream',
+      },
+      body: fileBytes,
+    });
+
+    if (!uploadResponse.ok) {
+      throw new Error(`File upload failed: HTTP ${uploadResponse.status}`);
+    }
+
+    const params: Record<string, string> = {
+      files: JSON.stringify([{ id: uploadUrlResponse.file_id, title: filename }]),
+      channel_id: channel,
+    };
+    if (options.initial_comment) params.initial_comment = options.initial_comment;
+    if (options.thread_ts) params.thread_ts = options.thread_ts;
+
+    return this.request('files.completeUploadExternal', params);
   }
 
   // Create draft message

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -124,6 +124,7 @@ export interface MessageSendOptions {
   recipientId: string;
   message: string;
   threadTs?: string;
+  file?: string;
   workspace?: string;
 }
 


### PR DESCRIPTION
Add `--file` argument to send single file as attachment in message send

screenshot
<img width="770" height="198" alt="image" src="https://github.com/user-attachments/assets/b74a7152-a5be-4730-bd5f-27b6e80940dc" />
