### PR TITLE
ci(security): harden CI/CD supply chain & credentials (#52)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Keep GitHub Actions pinned-by-SHA references up to date. Dependabot
+  # rewrites the SHA and the trailing `# vX.Y.Z` version comment together.
+  # No auto-merge: every bump is reviewed before it lands (supply-chain guard).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: ci
+      include: scope
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,20 @@ on:
   pull_request:
     branches: [ main, master ]
 
+# Least-privilege default token for every job in this workflow.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
         with:
           # Pinned: Bun 1.3.12 produced corrupt macOS code signatures
           # (oven-sh/bun#29120); fixed in 1.3.13. Bump this intentionally

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,14 @@ on:
     tags:
       - 'v*.*.*'
 
+# Least-privilege default: jobs are read-only unless they opt into more below.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -33,10 +36,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
         with:
           # Pinned: Bun 1.3.12 produced corrupt macOS code signatures that
           # caused the released binary to be killed on launch on Apple
@@ -61,7 +64,7 @@ jobs:
           codesign --verify --verbose dist/${{ matrix.artifact }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           retention-days: 1
           name: ${{ matrix.artifact }}
@@ -70,13 +73,16 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    # Only this job writes to the repo (creating the GitHub Release).
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: dist
 
@@ -93,7 +99,7 @@ jobs:
           cat checksums.txt
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
         with:
           files: release/*
           generate_release_notes: true
@@ -106,10 +112,26 @@ jobs:
     name: Update Homebrew Formula
     needs: release
     runs-on: ubuntu-latest
+    # No write access to THIS repo is needed; the cross-repo write to
+    # homebrew-tap is authorized solely by the token in GH_TOKEN below.
+    permissions:
+      contents: read
     steps:
+      # Mint a short-lived (≈1h) installation token from a dedicated
+      # GitHub App scoped to the homebrew-tap repo only. Replaces the
+      # long-lived HOMEBREW_TAP_TOKEN PAT (#52).
+      - name: Mint Homebrew tap token
+        id: tap_token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.HOMEBREW_TAP_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: shaharia-lab
+          repositories: homebrew-tap
+
       - name: Update Homebrew formulas
         env:
-          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          GH_TOKEN: ${{ steps.tap_token.outputs.token }}
         run: |
           VERSION="${{ github.ref_name }}"
           VERSION_NUM="${VERSION#v}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,16 +6,20 @@ on:
   pull_request:
     branches: [ main, master ]
 
+# Least-privilege default token for every job in this workflow.
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
         with:
           # Pinned: keep CI aligned with release.yml. See release.yml for
           # details on the 1.3.12 macOS codesign regression.
@@ -32,10 +36,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1.2.2
         with:
           # Pinned: keep CI aligned with release.yml. See release.yml for
           # details on the 1.3.12 macOS codesign regression.


### PR DESCRIPTION
Closes #52

Part of the org-wide CI/CD supply-chain security initiative (credentials → pinning → provenance).

## What changed

### Credentials
- **Replaced the long-lived `HOMEBREW_TAP_TOKEN` PAT** with a short-lived (~1h) GitHub App installation token, minted in-workflow via `actions/create-github-app-token`.
  - The App is scoped to the tap repository only, with just the permission needed to publish formula updates.
  - The token is requested for that single repository — blast radius is the tap repo and nothing else.

### Least-privilege permissions
- `ci.yml` / `test.yml`: top-level `permissions: { contents: read }` (previously the default broad token).
- `release.yml`: top-level `contents: read`; **write granted only to the `release` job** that creates the GitHub Release. The build and homebrew jobs are read-only.

### Action pinning (B1)
All actions SHA-pinned to full 40-char commits with `# vX.Y.Z` comments:
| Action | Pin |
|---|---|
| actions/checkout | v4.2.2 |
| oven-sh/setup-bun | v1.2.2 |
| actions/upload-artifact | v4.6.2 |
| actions/download-artifact | v4.3.0 |
| softprops/action-gh-release | **v1 → v2.2.2** (v1 runs on deprecated Node 16) |
| actions/create-github-app-token | v1.12.0 |

### Dependabot (B1)
- New `.github/dependabot.yml` for the `github-actions` ecosystem, weekly, **no auto-merge** — every action bump is reviewed.

### Not applicable
- **B3 (Docker digest-pinning):** no container images / Dockerfiles in this repo.

## Post-merge follow-up
After the next release tag confirms the App token works end-to-end:
1. Revoke the old `HOMEBREW_TAP_TOKEN` PAT.
2. Delete the now-unused `HOMEBREW_TAP_TOKEN` secret.

## Notes
- `bun-version` was already pinned to exact `1.3.13` (kept as-is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)