### PR TITLE
ci: bump softprops/action-gh-release to v3 (Node 24 runtime)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
           cat checksums.txt
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: release/*
           generate_release_notes: true


### PR DESCRIPTION
## What

Bumps `softprops/action-gh-release` in `.github/workflows/release.yml` from `v2.2.2` → `v3.0.0` (pinned by commit SHA `b4309332981a82ec1c5618f44dd2e27cc8bfbfda`).

## Why

The **v0.7.0** release run logged a deprecation warning:

> Node.js 20 actions are deprecated... `softprops/action-gh-release@da05d55...` ... Actions will be forced to run with Node.js 24 by default starting **June 16th, 2026**. Node.js 20 will be removed from the runner on September 16th, 2026.

`action-gh-release@v3.0.0` is a major release whose sole change is moving the action runtime from Node 20 to Node 24, clearing this warning before the GitHub-enforced cutoff. v3 runs fine on current GitHub-hosted runners.

## How

- Updated the pinned SHA to v3.0.0's commit, keeping the `# v3.0.0` comment to match the repo's SHA-pinning convention from the CI hardening (#52).
- No behavioral change to release publishing; `files`, `generate_release_notes`, `draft`, `prerelease` inputs are all still supported in v3.

## Testing

CI workflows (type-check + build) run on this PR. The release workflow itself only triggers on `v*.*.*` tags, so it will be exercised on the next release.

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)