### PR TITLE
feat: add canvas edit and section lookup commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Canvas Edit** (`canvas edit`): Update an existing canvas via `canvases.edit`
+  - Six operations: `insert_at_start`, `insert_at_end`, `insert_after`, `insert_before`, `replace`, `delete`
+  - Content sourced from `--content`, `--file`, or `--stdin` (markdown)
+  - `--section` targets a specific section; `--json` for machine-readable output
+- **Canvas Sections** (`canvas sections`): Look up section IDs via `canvases.sections.lookup`
+  - Filter with `--contains <text>` and `--type <h1|h2|h3|any_header>`
+- `editCanvas` and `lookupCanvasSections` methods on SlackClient
+  - Work with both standard and browser authentication
+
 ## [0.2.0] - 2026-01-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A fast, developer-friendly command-line interface tool for interacting with Slac
 - 🏢 **Multi-Workspace Management**: Manage multiple Slack workspaces with ease
 - 💬 **Conversation Management**: List channels, read messages, send messages
 - 🎉 **Message Reactions**: Add emoji reactions to messages programmatically
-- 📄 **Canvas Support**: List and read Slack canvas documents as markdown
+- 📄 **Canvas Support**: List, read, and edit Slack canvas documents as markdown
 - 🚀 **Fast & Lightweight**: Built with Bun for blazing fast performance
 - 🔄 **Auto-Update**: Built-in self-update mechanism
 - 🎨 **Beautiful Output**: Colorful, user-friendly terminal output
@@ -245,7 +245,35 @@ slackcli canvas read F1234567890 --raw
 
 # Read the canvas associated with a channel
 slackcli canvas read --channel=C1234567890
+
+# Edit a canvas (requires the canvases:write scope)
+slackcli canvas edit F1234567890 --operation insert_at_end --content "## Update"
+slackcli canvas edit F1234567890 --operation insert_at_start --file ./header.md
+cat new.md | slackcli canvas edit F1234567890 --operation replace --stdin
+
+# Look up section IDs, then target a section
+slackcli canvas sections F1234567890 --contains "Action Items" --json
+slackcli canvas edit F1234567890 --operation insert_after --section "temp:C:abc123" --content "- follow up"
+slackcli canvas edit F1234567890 --operation replace --section "temp:C:abc123" --content "## Action Items (done)"
+slackcli canvas edit F1234567890 --operation delete --section "temp:C:abc123"
 ```
+
+**Edit operations** (`--operation`):
+
+| Operation | Requires | Effect |
+|---|---|---|
+| `insert_at_start` | content | Prepend to the canvas |
+| `insert_at_end` | content | Append to the canvas |
+| `insert_after` | content + `--section` | Insert after a section |
+| `insert_before` | content + `--section` | Insert before a section |
+| `replace` | content (+ optional `--section`) | Replace a section, or the whole canvas if no `--section` |
+| `delete` | `--section` | Delete a section |
+
+Content for an edit comes from one of `--content`, `--file`, or `--stdin`. Use `slackcli canvas sections <canvas-id>` to discover the `--section` IDs that the targeted operations need (`--type` accepts `h1`, `h2`, `h3`, or `any_header`; with no filter it lists all headers).
+
+> **Section IDs are ephemeral.** Slack regenerates the `temp:` section IDs every time a canvas is edited. Always run `canvas sections` to fetch a fresh ID immediately before each section-targeted edit (`insert_after`, `insert_before`, `replace --section`, `delete`) — a stale ID from before another edit will fail with `section_not_found`.
+
+> **Token support.** Editing and section-targeted operations require a Standard Slack token (`xoxb`/`xoxp`) with `canvases:write` (and `canvases:read` for `sections`). Browser tokens (`xoxd`/`xoxc`) cannot edit canvases.
 
 ### Update Commands
 

--- a/src/commands/canvas.test.ts
+++ b/src/commands/canvas.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  createCanvasCommand,
+  buildEditChange,
+  buildSectionCriteria,
+  resolveMarkdown,
+  VALID_EDIT_OPERATIONS,
+} from './canvas.ts';
+
+describe('canvas command', () => {
+  it('exposes edit and sections subcommands', () => {
+    const canvas = createCanvasCommand();
+    const names = canvas.commands.map((c) => c.name());
+    expect(names).toContain('edit');
+    expect(names).toContain('sections');
+  });
+
+  it('exposes the operation and section options on edit', () => {
+    const canvas = createCanvasCommand();
+    const edit = canvas.commands.find((c) => c.name() === 'edit');
+    expect(edit?.options.some((o) => o.long === '--operation')).toBe(true);
+    expect(edit?.options.some((o) => o.long === '--section')).toBe(true);
+    expect(edit?.options.some((o) => o.long === '--stdin')).toBe(true);
+  });
+});
+
+describe('buildEditChange', () => {
+  it('builds insert_at_end with document_content and no section', () => {
+    const change = buildEditChange('insert_at_end', '## Update', undefined);
+    expect(change).toEqual({
+      operation: 'insert_at_end',
+      document_content: { type: 'markdown', markdown: '## Update' },
+    });
+  });
+
+  it('builds insert_at_start with document_content', () => {
+    const change = buildEditChange('insert_at_start', '# Top', undefined);
+    expect(change.operation).toBe('insert_at_start');
+    expect(change.document_content).toEqual({ type: 'markdown', markdown: '# Top' });
+    expect(change.section_id).toBeUndefined();
+  });
+
+  it('builds insert_after with content and section', () => {
+    const change = buildEditChange('insert_after', '- item', 'temp:C:abc');
+    expect(change).toEqual({
+      operation: 'insert_after',
+      document_content: { type: 'markdown', markdown: '- item' },
+      section_id: 'temp:C:abc',
+    });
+  });
+
+  it('builds insert_before with content and section', () => {
+    const change = buildEditChange('insert_before', 'before', 'temp:C:xyz');
+    expect(change.operation).toBe('insert_before');
+    expect(change.section_id).toBe('temp:C:xyz');
+  });
+
+  it('builds replace without a section (whole canvas)', () => {
+    const change = buildEditChange('replace', 'new body', undefined);
+    expect(change).toEqual({
+      operation: 'replace',
+      document_content: { type: 'markdown', markdown: 'new body' },
+    });
+  });
+
+  it('builds replace with a section', () => {
+    const change = buildEditChange('replace', 'new section', 'temp:C:sec');
+    expect(change.section_id).toBe('temp:C:sec');
+    expect(change.document_content).toEqual({ type: 'markdown', markdown: 'new section' });
+  });
+
+  it('builds delete with only a section_id', () => {
+    const change = buildEditChange('delete', undefined, 'temp:C:gone');
+    expect(change).toEqual({ operation: 'delete', section_id: 'temp:C:gone' });
+    expect(change.document_content).toBeUndefined();
+  });
+
+  it('throws when a content operation has no content', () => {
+    expect(() => buildEditChange('insert_at_end', undefined, undefined)).toThrow(/requires content/);
+  });
+
+  it('throws when insert_after has no section', () => {
+    expect(() => buildEditChange('insert_after', 'x', undefined)).toThrow(/requires --section/);
+  });
+
+  it('throws when insert_at_start is given a section', () => {
+    expect(() => buildEditChange('insert_at_start', 'x', 'temp:C:abc')).toThrow(/does not accept --section/);
+  });
+
+  it('throws when delete is given content', () => {
+    expect(() => buildEditChange('delete', 'oops', 'temp:C:abc')).toThrow(/does not accept content/);
+  });
+
+  it('throws when delete has no section', () => {
+    expect(() => buildEditChange('delete', undefined, undefined)).toThrow(/requires --section/);
+  });
+
+  it('lists exactly six valid operations', () => {
+    expect(VALID_EDIT_OPERATIONS).toEqual([
+      'insert_at_start',
+      'insert_at_end',
+      'insert_after',
+      'insert_before',
+      'replace',
+      'delete',
+    ]);
+  });
+});
+
+describe('buildSectionCriteria', () => {
+  it('maps --type to section_types array', () => {
+    expect(buildSectionCriteria({ type: 'h2' })).toEqual({ section_types: ['h2'] });
+  });
+
+  it('maps --contains to contains_text', () => {
+    expect(buildSectionCriteria({ contains: 'Action Items' })).toEqual({ contains_text: 'Action Items' });
+  });
+
+  it('maps both type and contains', () => {
+    expect(buildSectionCriteria({ type: 'any_header', contains: 'Notes' })).toEqual({
+      section_types: ['any_header'],
+      contains_text: 'Notes',
+    });
+  });
+
+  it('defaults to any_header when no filters are given (Slack rejects empty criteria)', () => {
+    expect(buildSectionCriteria({})).toEqual({ section_types: ['any_header'] });
+  });
+});
+
+describe('resolveMarkdown', () => {
+  it('returns inline content from --content', async () => {
+    expect(await resolveMarkdown({ content: '# Hi' })).toBe('# Hi');
+  });
+
+  it('returns undefined when no source is given', async () => {
+    expect(await resolveMarkdown({})).toBeUndefined();
+  });
+
+  it('throws when more than one source is supplied', async () => {
+    await expect(resolveMarkdown({ content: 'a', file: 'b.md' })).rejects.toThrow(/only one of/);
+  });
+
+  it('throws a clear error for a missing file', async () => {
+    await expect(resolveMarkdown({ file: '/no/such/file-xyz.md' })).rejects.toThrow(/File not found/);
+  });
+
+  it('reads markdown from a file', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'canvas-test-'));
+    const path = join(dir, 'body.md');
+    await writeFile(path, '# From file\n- bullet', 'utf-8');
+    try {
+      expect(await resolveMarkdown({ file: path })).toBe('# From file\n- bullet');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/commands/canvas.ts
+++ b/src/commands/canvas.ts
@@ -1,16 +1,91 @@
 import { Command } from 'commander';
 import ora from 'ora';
+import { readFile, stat } from 'node:fs/promises';
 import { getAuthenticatedClient } from '../lib/auth.ts';
-import { error, formatCanvasList, formatCanvasContent } from '../lib/formatter.ts';
+import { error, success, formatCanvasList, formatCanvasContent } from '../lib/formatter.ts';
 import { canvasHtmlToMarkdown, isAuthPage } from '../lib/canvas-parser.ts';
-import type { SlackCanvas, SlackUser } from '../types/index.ts';
+import { readInteractiveInput } from '../lib/interactive-input.ts';
+import type { SlackCanvas, SlackUser, CanvasChange, CanvasEditOperation, CanvasSectionCriteria } from '../types/index.ts';
 
 const CANVAS_ID_PATTERN = /^F[A-Z0-9]+$/i;
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 
+export const VALID_EDIT_OPERATIONS: CanvasEditOperation[] = [
+  'insert_at_start',
+  'insert_at_end',
+  'insert_after',
+  'insert_before',
+  'replace',
+  'delete',
+];
+
+export const VALID_SECTION_TYPES = ['h1', 'h2', 'h3', 'any_header'] as const;
+
+// Resolve canvas markdown from exactly one of --content, --file, or --stdin.
+export async function resolveMarkdown(options: { content?: string; file?: string; stdin?: boolean }): Promise<string | undefined> {
+  const sources = [options.content, options.file, options.stdin].filter(Boolean).length;
+  if (sources > 1) {
+    throw new Error('Use only one of --content, --file, or --stdin');
+  }
+  if (options.content) return options.content;
+  if (options.file) {
+    const stats = await stat(options.file).catch((err: any) => {
+      if (err?.code === 'ENOENT') throw new Error(`File not found: ${options.file}`);
+      throw err;
+    });
+    if (!stats.isFile()) throw new Error(`Not a file: ${options.file}`);
+    if (stats.size > MAX_FILE_SIZE) throw new Error(`File too large: ${stats.size} bytes (max ${MAX_FILE_SIZE})`);
+    return await readFile(options.file, 'utf-8');
+  }
+  if (options.stdin) return (await readInteractiveInput()).trim();
+  return undefined;
+}
+
+// Build a single canvases.edit change and validate the operation/argument combo.
+export function buildEditChange(
+  operation: CanvasEditOperation,
+  markdown: string | undefined,
+  sectionId: string | undefined,
+): CanvasChange {
+  const needsContent = operation !== 'delete';
+  const needsSection = operation === 'insert_after' || operation === 'insert_before' || operation === 'delete';
+  const forbidsSection = operation === 'insert_at_start' || operation === 'insert_at_end';
+
+  if (needsContent && !markdown) {
+    throw new Error(`Operation "${operation}" requires content (--content, --file, or --stdin)`);
+  }
+  if (needsSection && !sectionId) {
+    throw new Error(`Operation "${operation}" requires --section`);
+  }
+  if (forbidsSection && sectionId) {
+    throw new Error(`Operation "${operation}" does not accept --section`);
+  }
+  if (operation === 'delete' && markdown) {
+    throw new Error('Operation "delete" does not accept content');
+  }
+
+  const change: CanvasChange = { operation };
+  if (needsContent && markdown) change.document_content = { type: 'markdown', markdown };
+  if (sectionId) change.section_id = sectionId;
+  return change;
+}
+
+// Build canvases.sections.lookup criteria from CLI options.
+export function buildSectionCriteria(options: { contains?: string; type?: 'h1' | 'h2' | 'h3' | 'any_header' }): CanvasSectionCriteria {
+  const criteria: CanvasSectionCriteria = {};
+  if (options.type) criteria.section_types = [options.type];
+  if (options.contains) criteria.contains_text = options.contains;
+  // Slack requires criteria to have at least one property. With no filters given,
+  // default to matching any header so `canvas sections <id>` lists all headers.
+  if (!criteria.section_types && !criteria.contains_text) {
+    criteria.section_types = ['any_header'];
+  }
+  return criteria;
+}
+
 export function createCanvasCommand(): Command {
   const canvas = new Command('canvas')
-    .description('List and read Slack canvas documents');
+    .description('List, read, and edit Slack canvas documents');
 
   // List canvases
   canvas
@@ -218,6 +293,109 @@ export function createCanvasCommand(): Command {
         console.log('\n' + formatCanvasContent(file, markdown));
       } catch (err: any) {
         spinner.fail('Failed to read canvas');
+        error(err.message);
+        process.exit(1);
+      }
+    });
+
+  // Edit canvas content
+  canvas
+    .command('edit')
+    .description('Edit an existing canvas')
+    .argument('<canvas-id>', 'Canvas file ID (e.g., F1234567890)')
+    .option('--operation <op>', 'Edit operation: insert_at_start, insert_at_end, insert_after, insert_before, replace, delete')
+    .option('--content <markdown>', 'Canvas content as markdown')
+    .option('--file <path>', 'Read canvas markdown from a file')
+    .option('--stdin', 'Read canvas markdown from stdin', false)
+    .option('--section <id>', 'Target section ID (from "canvas sections")')
+    .option('--workspace <id|name>', 'Workspace to use')
+    .option('--json', 'Output in JSON format', false)
+    .action(async (canvasId, options) => {
+      if (!CANVAS_ID_PATTERN.test(canvasId)) {
+        error('Invalid canvas ID', 'Canvas ID must start with F followed by alphanumeric characters (e.g., F1234567890).');
+        process.exit(1);
+      }
+
+      const operation = options.operation as CanvasEditOperation;
+      if (!operation || !VALID_EDIT_OPERATIONS.includes(operation)) {
+        error('Invalid or missing --operation', `Valid operations: ${VALID_EDIT_OPERATIONS.join(', ')}`);
+        process.exit(1);
+      }
+
+      let change: CanvasChange;
+      try {
+        const markdown = await resolveMarkdown(options);
+        change = buildEditChange(operation, markdown, options.section);
+      } catch (err: any) {
+        error(err.message);
+        process.exit(1);
+      }
+
+      const spinner = ora('Editing canvas...').start();
+
+      try {
+        const client = await getAuthenticatedClient(options.workspace);
+        await client.editCanvas(canvasId, [change]);
+        spinner.succeed(`Edited canvas ${canvasId}`);
+
+        if (options.json) {
+          console.log(JSON.stringify({ ok: true, canvas_id: canvasId, change }, null, 2));
+          return;
+        }
+
+        success(`Applied "${operation}" to canvas ${canvasId}`);
+      } catch (err: any) {
+        spinner.fail('Failed to edit canvas');
+        error(err.message);
+        process.exit(1);
+      }
+    });
+
+  // Look up section IDs for targeted edits
+  canvas
+    .command('sections')
+    .description('Look up section IDs within a canvas (for targeted edits)')
+    .argument('<canvas-id>', 'Canvas file ID (e.g., F1234567890)')
+    .option('--contains <text>', 'Only sections containing this text')
+    .option('--type <type>', 'Section type: h1, h2, h3, or any_header')
+    .option('--workspace <id|name>', 'Workspace to use')
+    .option('--json', 'Output in JSON format', false)
+    .action(async (canvasId, options) => {
+      if (!CANVAS_ID_PATTERN.test(canvasId)) {
+        error('Invalid canvas ID', 'Canvas ID must start with F followed by alphanumeric characters (e.g., F1234567890).');
+        process.exit(1);
+      }
+
+      if (options.type && !VALID_SECTION_TYPES.includes(options.type)) {
+        error('Invalid --type', `Valid types: ${VALID_SECTION_TYPES.join(', ')}`);
+        process.exit(1);
+      }
+
+      const spinner = ora('Looking up canvas sections...').start();
+
+      try {
+        const client = await getAuthenticatedClient(options.workspace);
+        const criteria = buildSectionCriteria(options);
+        const response = await client.lookupCanvasSections(canvasId, criteria);
+        const sections = response.sections || [];
+
+        if (sections.length === 0) {
+          spinner.succeed('No matching sections found');
+          return;
+        }
+
+        spinner.succeed(`Found ${sections.length} section(s)`);
+
+        if (options.json) {
+          console.log(JSON.stringify({ section_count: sections.length, sections }, null, 2));
+          return;
+        }
+
+        for (const section of sections) {
+          console.log(`  ${section.id}`);
+        }
+      } catch (err: any) {
+        spinner.fail('Failed to look up sections');
         error(err.message);
         process.exit(1);
       }

--- a/src/lib/slack-client.ts
+++ b/src/lib/slack-client.ts
@@ -1,7 +1,7 @@
 import { WebClient } from '@slack/web-api';
 import { basename } from 'node:path';
 import { readFile, stat } from 'node:fs/promises';
-import type { WorkspaceConfig, SlackAuthTestResponse } from '../types/index.ts';
+import type { WorkspaceConfig, SlackAuthTestResponse, CanvasChange, CanvasSectionCriteria } from '../types/index.ts';
 import { parseMrkdwn } from './mrkdwn.ts';
 
 interface ExternalUploadUrlResponse {
@@ -381,6 +381,22 @@ export class SlackClient {
   // Get file info (used to get canvas download URL)
   async getFileInfo(fileId: string): Promise<any> {
     return this.request('files.info', { file: fileId });
+  }
+
+  // Edit a canvas. changes[] follows Slack's canvases.edit schema.
+  async editCanvas(canvasId: string, changes: CanvasChange[]): Promise<any> {
+    return this.request('canvases.edit', {
+      canvas_id: canvasId,
+      changes: JSON.stringify(changes),
+    });
+  }
+
+  // Look up section IDs within a canvas for targeted edits.
+  async lookupCanvasSections(canvasId: string, criteria: CanvasSectionCriteria = {}): Promise<any> {
+    return this.request('canvases.sections.lookup', {
+      canvas_id: canvasId,
+      criteria: JSON.stringify(criteria),
+    });
   }
 
   // Download file content with auth, size guard, and auth page detection

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -242,3 +242,44 @@ export interface CanvasReadOptions {
   raw?: boolean;
   workspace?: string;
 }
+
+export interface CanvasDocumentContent {
+  type: 'markdown';
+  markdown: string;
+}
+
+export type CanvasEditOperation =
+  | 'insert_at_start'
+  | 'insert_at_end'
+  | 'insert_after'
+  | 'insert_before'
+  | 'replace'
+  | 'delete';
+
+export interface CanvasChange {
+  operation: CanvasEditOperation;
+  document_content?: CanvasDocumentContent;
+  section_id?: string;
+}
+
+export interface CanvasEditOptions {
+  operation?: CanvasEditOperation;
+  content?: string;
+  file?: string;
+  stdin?: boolean;
+  section?: string;
+  json?: boolean;
+  workspace?: string;
+}
+
+export interface CanvasSectionCriteria {
+  section_types?: Array<'h1' | 'h2' | 'h3' | 'any_header'>;
+  contains_text?: string;
+}
+
+export interface CanvasSectionsOptions {
+  contains?: string;
+  type?: 'h1' | 'h2' | 'h3' | 'any_header';
+  json?: boolean;
+  workspace?: string;
+}


### PR DESCRIPTION
## Summary
Adds `slackcli canvas edit` + `slackcli canvas sections` — the **U** in canvas CRUD. Second of the 3-PR series. `edit` mutates a canvas; `sections` looks up the section IDs that section-targeted edit operations need.

Closes #63

## What's added
- `canvas edit <id> --operation <op>` — 6 operations: `insert_at_start`, `insert_at_end`, `insert_after`, `insert_before`, `replace`, `delete`. One change per invocation. Operation/argument validation runs **before** any network call.
- `canvas sections <id>` — `--contains`, `--type h1|h2|h3|any_header`. Bare invocation defaults criteria to `any_header` (Slack rejects empty criteria) → lists all headers.
- `SlackClient.editCanvas()`, `SlackClient.lookupCanvasSections()`.
- Exported pure `buildEditChange()` + `buildSectionCriteria()` for unit testing.
- Types: `CanvasChange`, `CanvasEditOperation`, `CanvasEditOptions`, `CanvasSectionCriteria`.
- README: operations matrix, sections example, an ephemeral-section-ID warning (Slack regenerates `temp:` IDs after each edit — re-look-up before each section-targeted op), token-support note.
- CHANGELOG entry.

## Tests
- `canvas.test.ts` extended — one case per operation, every invalid op/arg combo, and the criteria builder (incl. empty → `any_header`).
- `bun test` → **200 pass / 0 fail**. `bun run build` → ok.
- Live-verified on a real canvas: append, replace-whole, sections lookup, replace-section, insert_after, delete-section. `insert_before` shares `insert_after`'s code path (different op string) and is unit-tested.

## Manual Tests
* Update canvas - whole-canvas ops - insert_at_end => OK!
<img width="1504" height="89" alt="image" src="https://github.com/user-attachments/assets/ecde8c24-5c38-45c5-872d-de8c780bcadd" />
<img width="406" height="406" alt="image" src="https://github.com/user-attachments/assets/7761ebc4-eab0-4ab8-9c6b-8736727138bf" />

* Update canvas - whole-canvas ops - insert_at_start => OK!
<img width="758" height="113" alt="image" src="https://github.com/user-attachments/assets/14879116-7251-4322-a50a-f02b95ae60d6" />
<img width="404" height="483" alt="image" src="https://github.com/user-attachments/assets/b78a47b6-fbe2-4628-8281-4652992c142a" />

* Update canvas - whole-canvas ops - replace => OK!
<img width="756" height="89" alt="image" src="https://github.com/user-attachments/assets/eb9aafc8-3031-4a35-8e0a-e14b77b0d60d" />
<img width="409" height="453" alt="image" src="https://github.com/user-attachments/assets/4ee597c3-3278-4014-8c0e-39979c2def23" />

* Section - List sections => OK!
<img width="755" height="250" alt="image" src="https://github.com/user-attachments/assets/795239fe-05d4-43a6-a6fe-4edf4132e8cc" />
<img width="404" height="337" alt="image" src="https://github.com/user-attachments/assets/58c50b9e-d84f-49cd-9c4c-e2bbb8380be8" />


* Update canvas - section-targeted - insert_after => OK!
<img width="756" height="226" alt="image" src="https://github.com/user-attachments/assets/451c69d4-a149-421c-95ee-7699c8c2f20e" />
<img width="400" height="399" alt="image" src="https://github.com/user-attachments/assets/57b81726-1ab8-402f-9691-5c34d22a636a" />


* Update canvas - section-targeted - replace => OK!
<img width="754" height="223" alt="image" src="https://github.com/user-attachments/assets/742bf659-4097-4685-9e42-49f51c116922" />
<img width="412" height="376" alt="image" src="https://github.com/user-attachments/assets/2e2a2525-61b8-4d68-b1d9-65ef0a63836a" />

* Update canvas - section-targeted - delete => OK!
<img width="758" height="206" alt="image" src="https://github.com/user-attachments/assets/88dc1781-fc7c-4d01-958f-bb3ad9bdb25a" />
<img width="410" height="377" alt="image" src="https://github.com/user-attachments/assets/4f28404c-a9cf-477a-89e0-ef70f962c6ca" />


* Update canvas - validation - errors BEFORE any network call
<img width="757" height="328" alt="image" src="https://github.com/user-attachments/assets/bec542d0-d495-4a08-b852-734027d921ef" />



## Notes
- Found + fixed a bug during live testing: bare `canvas sections <id>` sent empty `criteria {}` → Slack `invalid_arguments: must have minimum 1 properties`. Now defaults to `{section_types:['any_header']}`.
- Part of the 3-PR series — conceptually follows create (#62); code is independent and diffs cleanly against `main`. Rebase after #62 merges.
- Same **pre-existing** `src/lib/workspaces.ts` type-check error as #62 (Bun's `fs/promises.exists`) — untouched here, zero new type errors.
