### PR TITLE
feat: add canvas delete command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Canvas Delete** (`canvas delete`): Permanently delete a canvas via the `canvases.delete` API
+  - Works with both standard and browser authentication
+  - Prompts for confirmation in an interactive terminal; `--yes` skips the prompt and is required when running non-interactively
+  - Supports `--json` output
+  - Adds `deleteCanvas` method to SlackClient and `confirmPrompt`/`parseConfirm` helpers
+
 ## [0.2.0] - 2026-01-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -245,7 +245,14 @@ slackcli canvas read F1234567890 --raw
 
 # Read the canvas associated with a channel
 slackcli canvas read --channel=C1234567890
+
+# Delete a canvas (permanent — prompts for confirmation unless --yes)
+slackcli canvas delete F1234567890
+slackcli canvas delete F1234567890 --yes
+slackcli canvas delete F1234567890 --yes --json
 ```
+
+> **Warning:** `canvas delete` permanently removes the canvas. Once deleted, there is no way to recover it. In an interactive terminal you'll be asked to confirm; pass `--yes` to skip the prompt (required when running non-interactively). Requires the `canvases:write` scope.
 
 ### Update Commands
 

--- a/src/commands/canvas.test.ts
+++ b/src/commands/canvas.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'bun:test';
+import { createCanvasCommand } from './canvas.ts';
+
+describe('canvas command', () => {
+  it('registers a delete subcommand', () => {
+    const canvas = createCanvasCommand();
+    const del = canvas.commands.find((command) => command.name() === 'delete');
+
+    expect(del).toBeDefined();
+  });
+
+  it('exposes a --yes flag on canvas delete', () => {
+    const canvas = createCanvasCommand();
+    const del = canvas.commands.find((command) => command.name() === 'delete');
+
+    expect(del?.options.some((option) => option.long === '--yes')).toBe(true);
+  });
+
+  it('exposes a --json flag on canvas delete', () => {
+    const canvas = createCanvasCommand();
+    const del = canvas.commands.find((command) => command.name() === 'delete');
+
+    expect(del?.options.some((option) => option.long === '--json')).toBe(true);
+  });
+});

--- a/src/commands/canvas.ts
+++ b/src/commands/canvas.ts
@@ -1,8 +1,9 @@
 import { Command } from 'commander';
 import ora from 'ora';
 import { getAuthenticatedClient } from '../lib/auth.ts';
-import { error, formatCanvasList, formatCanvasContent } from '../lib/formatter.ts';
+import { error, success, info, formatCanvasList, formatCanvasContent } from '../lib/formatter.ts';
 import { canvasHtmlToMarkdown, isAuthPage } from '../lib/canvas-parser.ts';
+import { confirmPrompt } from '../lib/interactive-input.ts';
 import type { SlackCanvas, SlackUser } from '../types/index.ts';
 
 const CANVAS_ID_PATTERN = /^F[A-Z0-9]+$/i;
@@ -10,7 +11,7 @@ const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 
 export function createCanvasCommand(): Command {
   const canvas = new Command('canvas')
-    .description('List and read Slack canvas documents');
+    .description('Manage Slack canvas documents');
 
   // List canvases
   canvas
@@ -218,6 +219,65 @@ export function createCanvasCommand(): Command {
         console.log('\n' + formatCanvasContent(file, markdown));
       } catch (err: any) {
         spinner.fail('Failed to read canvas');
+        error(err.message);
+        process.exit(1);
+      }
+    });
+
+  // Delete a canvas (permanent)
+  canvas
+    .command('delete')
+    .description('Permanently delete a canvas')
+    .argument('<canvas-id>', 'Canvas file ID (e.g., F1234567890)')
+    .option('-y, --yes', 'Skip the confirmation prompt', false)
+    .option('--workspace <id|name>', 'Workspace to use')
+    .option('--json', 'Output in JSON format', false)
+    .action(async (canvasId, options) => {
+      // Validate the canvas ID before doing anything destructive
+      if (!CANVAS_ID_PATTERN.test(canvasId)) {
+        error(
+          'Invalid canvas ID',
+          'Canvas ID must start with F followed by alphanumeric characters (e.g., F1234567890).',
+        );
+        process.exit(1);
+      }
+
+      // Confirmation guard — deletion is irreversible
+      if (!options.yes) {
+        if (!process.stdin.isTTY) {
+          error(
+            'Refusing to delete without confirmation.',
+            'Re-run with --yes to delete non-interactively.',
+          );
+          process.exit(1);
+        }
+
+        const confirmed = await confirmPrompt(
+          `Delete canvas ${canvasId}? This cannot be undone.`,
+        );
+        if (!confirmed) {
+          info('Aborted.');
+          return;
+        }
+      }
+
+      const spinner = ora('Deleting canvas...').start();
+
+      try {
+        const client = await getAuthenticatedClient(options.workspace);
+
+        await client.deleteCanvas(canvasId);
+
+        spinner.succeed(`Deleted canvas ${canvasId}`);
+
+        if (options.json) {
+          console.log(JSON.stringify({ ok: true, canvas_id: canvasId }, null, 2));
+          return;
+        }
+
+        success(`Canvas ${canvasId} has been permanently deleted.`);
+      } catch (err: any) {
+        spinner.fail('Failed to delete canvas');
         error(err.message);
         process.exit(1);
       }

--- a/src/lib/interactive-input.test.ts
+++ b/src/lib/interactive-input.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { isInteractiveTerminal, hasPipedInput } from './interactive-input';
+import { isInteractiveTerminal, hasPipedInput, parseConfirm } from './interactive-input';
 
 describe('interactive-input', () => {
   describe('isInteractiveTerminal', () => {
@@ -49,6 +49,31 @@ describe('interactive-input', () => {
     it('should be importable', async () => {
       const { readInteractiveInput } = await import('./interactive-input');
       expect(typeof readInteractiveInput).toBe('function');
+    });
+  });
+
+  describe('parseConfirm', () => {
+    it('treats y / yes (any case) as confirmation', () => {
+      expect(parseConfirm('y')).toBe(true);
+      expect(parseConfirm('Y')).toBe(true);
+      expect(parseConfirm('yes')).toBe(true);
+      expect(parseConfirm('YES')).toBe(true);
+      expect(parseConfirm('Yes')).toBe(true);
+    });
+
+    it('ignores surrounding whitespace', () => {
+      expect(parseConfirm('  y  ')).toBe(true);
+      expect(parseConfirm('\tyes\n')).toBe(true);
+    });
+
+    it('treats everything else as no (default safe)', () => {
+      expect(parseConfirm('')).toBe(false);
+      expect(parseConfirm('n')).toBe(false);
+      expect(parseConfirm('no')).toBe(false);
+      expect(parseConfirm('maybe')).toBe(false);
+      expect(parseConfirm('yep')).toBe(false);
+      expect(parseConfirm('yeah')).toBe(false);
+      expect(parseConfirm('1')).toBe(false);
     });
   });
 });

--- a/src/lib/interactive-input.ts
+++ b/src/lib/interactive-input.ts
@@ -91,6 +91,31 @@ export async function readInteractiveInput(
 }
 
 /**
+ * Parse a yes/no answer. Only "y"/"yes" (case-insensitive) count as yes;
+ * everything else (including empty) is no. Pure function for easy testing.
+ */
+export function parseConfirm(answer: string): boolean {
+  return /^y(es)?$/i.test(answer.trim());
+}
+
+/**
+ * Ask a yes/no confirmation question. Defaults to No on empty input or EOF.
+ * TTY-only — callers should guard non-TTY usage (e.g. require an explicit flag).
+ */
+export async function confirmPrompt(question: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    rl.question(`${question} [y/N] `, (answer) => {
+      rl.close();
+      resolve(parseConfirm(answer));
+    });
+  });
+}
+
+/**
  * Check if we're running in an interactive terminal
  */
 export function isInteractiveTerminal(): boolean {

--- a/src/lib/slack-client.test.ts
+++ b/src/lib/slack-client.test.ts
@@ -113,3 +113,35 @@ describe('SlackClient.uploadFileExternal', () => {
     expect(client.calls).toEqual([]);
   });
 });
+
+class CapturingSlackClient extends SlackClient {
+  public readonly calls: Array<{ method: string; params: Record<string, unknown> }> = [];
+
+  constructor() {
+    super({
+      workspace_id: 'T123',
+      workspace_name: 'Test Workspace',
+      auth_type: 'browser',
+      xoxd_token: 'xoxd-test',
+      xoxc_token: 'xoxc-test',
+      workspace_url: 'https://example.slack.com',
+    });
+  }
+
+  override async request(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+    this.calls.push({ method, params });
+    return { ok: true };
+  }
+}
+
+describe('SlackClient.deleteCanvas', () => {
+  it('calls canvases.delete with the canvas_id', async () => {
+    const client = new CapturingSlackClient();
+
+    await client.deleteCanvas('F1234567890');
+
+    expect(client.calls).toEqual([
+      { method: 'canvases.delete', params: { canvas_id: 'F1234567890' } },
+    ]);
+  });
+});

--- a/src/lib/slack-client.ts
+++ b/src/lib/slack-client.ts
@@ -457,6 +457,11 @@ export class SlackClient {
     return null;
   }
 
+  // Permanently delete a canvas. Irreversible — there is no way to recover it.
+  async deleteCanvas(canvasId: string): Promise<any> {
+    return this.request('canvases.delete', { canvas_id: canvasId });
+  }
+
   // Check auth type
   get authType(): string {
     return this.config.auth_type;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -242,3 +242,9 @@ export interface CanvasReadOptions {
   raw?: boolean;
   workspace?: string;
 }
+
+export interface CanvasDeleteOptions {
+  yes?: boolean;
+  json?: boolean;
+  workspace?: string;
+}


### PR DESCRIPTION
## Summary
Adds `slackcli canvas delete` — the **D** in canvas CRUD. Final of the 3-PR series. Delete is permanent, so it's guarded by a confirmation.

Closes #64

## What's added
- `canvas delete <id>` — `-y/--yes`, `--json`, `--workspace`.
- Guard: interactive TTY without `--yes` → `[y/N]` prompt (defaults to No); `--yes` skips it; non-TTY (piped) without `--yes` → refuses with a clear error telling the user to pass `--yes`.
- `SlackClient.deleteCanvas()` → wraps `canvases.delete`. `canvas_not_found` surfaces via the existing error path.
- `confirmPrompt()` + pure `parseConfirm()` helpers in `src/lib/interactive-input.ts`.
- Types: `CanvasDeleteOptions`. README delete example with bold irreversibility. CHANGELOG entry.

## Tests
- `parseConfirm` unit tests — `y`/`yes` (any case) → confirm; whitespace trimmed; everything else → safe No.
- `bun test` → **183 pass / 0 fail**. `bun run build` → ok.
- Live-verified: `delete --yes` removes a canvas (re-read → `canvas_not_found`); no-`--yes` in a non-TTY refuses and leaves the canvas intact; invalid id rejected before any network call.

## Manual Tests

* Remove canvas that created in https://github.com/shaharia-lab/slackcli/pull/66 => OK!
<img width="396" height="448" alt="image" src="https://github.com/user-attachments/assets/4e92387a-8e66-4c7c-9db4-0a3c136b5dc8" />
<img width="748" height="401" alt="image" src="https://github.com/user-attachments/assets/a3b6131a-5b27-4b01-a2e8-706ba524bd78" />
<img width="394" height="432" alt="image" src="https://github.com/user-attachments/assets/0332f940-8178-452d-bfd8-72a6ec40ee9f" />
<img width="755" height="460" alt="image" src="https://github.com/user-attachments/assets/d629ec61-0f80-465b-9e35-3f7addce6890" />


## Notes
- Part of the 3-PR series — suggested review/merge after create (#62) + edit (#63). Code-independent, diffs cleanly against `main`; rebase after the earlier two merge.
- Same **pre-existing** `src/lib/workspaces.ts` type-check error as #62 (Bun's `fs/promises.exists`) — untouched here, zero new type errors.
