### PR TITLE
feat: rich mentions, links & broadcasts for messages draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,43 @@ slackcli messages react --channel-id=C1234567890 --timestamp=1234567890.123456 -
 slackcli messages react --channel-id=C1234567890 --timestamp=1234567890.123456 --emoji=eyes
 ```
 
+#### Mentions, links & broadcasts in drafts
+
+`messages draft` understands rich mention, link, and broadcast syntax and turns it into real Slack pills — a clickable @-mention, channel link, or broadcast — instead of dead literal text. This applies to **drafts only**.
+
+**Friendly tokens** are resolved against your workspace before the draft is created:
+
+```bash
+# Mention a user by username or email
+slackcli messages draft --recipient-id=C1234567890 --message='@user:jane.doe please review'
+slackcli messages draft --recipient-id=C1234567890 --message='@user:jane@example.com please review'
+
+# A name with spaces must be quoted
+slackcli messages draft --recipient-id=C1234567890 --message='@user:"Jane Doe" please review'
+
+# Mention a usergroup by its handle or name
+slackcli messages draft --recipient-id=C1234567890 --message='@group:ror-team standup in 5'
+
+# Link a channel by name
+slackcli messages draft --recipient-id=C1234567890 --message='moved to #general'
+```
+
+Resolution uses exact-match priority (username → email → display name → real name for `@user:`; exact handle/name for `@group:` and `#channel`). If a token is ambiguous or not found, the command fails with a clear error that lists the candidates or available handles — it never silently leaves a friendly token behind as plain text.
+
+**Raw Slack escape tokens** are passed through untouched, so you can address things by ID directly:
+
+```bash
+slackcli messages draft --recipient-id=C1234567890 \
+  --message='<@U0123ABCD> see <#C0123WXYZ> and <!here> https://example.com'
+```
+
+Supported raw tokens: `<@U…>` (user), `<!subteam^S…>` (usergroup), `<#C…>` (channel), `<!here>` / `<!channel>` / `<!everyone>` (broadcasts), and `<https://…>` or `<https://…|label>` (links). Bare `https://` URLs are linkified automatically.
+
+**Scope & limitations:**
+
+- Mention resolution is wired into `messages draft` only. `messages send` posts flat text that Slack auto-links server-side; wiring it there is a planned follow-up.
+- A bold span that ends in a space (e.g. `*Tests: *`) is not valid Slack mrkdwn — keep the space outside the markers (`*Tests:* `).
+
 File uploads require Slack workspace permissions that allow file upload, such as `files:write` for standard Slack app tokens.
 
 **Common emoji names:**

--- a/src/commands/messages.test.ts
+++ b/src/commands/messages.test.ts
@@ -8,4 +8,12 @@ describe('messages command', () => {
 
     expect(send?.options.some((option) => option.long === '--file')).toBe(true);
   });
+
+  it('exposes --message and --recipient-id on messages draft', () => {
+    const messages = createMessagesCommand();
+    const draft = messages.commands.find((command) => command.name() === 'draft');
+
+    expect(draft?.options.some((option) => option.long === '--message')).toBe(true);
+    expect(draft?.options.some((option) => option.long === '--recipient-id')).toBe(true);
+  });
 });

--- a/src/commands/messages.ts
+++ b/src/commands/messages.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import ora from 'ora';
 import { getAuthenticatedClient } from '../lib/auth.ts';
 import { success, error } from '../lib/formatter.ts';
+import { resolveMentions } from '../lib/mentions.ts';
 
 export function createMessagesCommand(): Command {
   const messages = new Command('messages')
@@ -101,8 +102,11 @@ export function createMessagesCommand(): Command {
           channelId = dmResponse.channel.id;
         }
 
+        spinner.text = 'Resolving mentions...';
+        const resolvedMessage = await resolveMentions(options.message, client);
+
         spinner.text = 'Creating draft...';
-        const response = await client.createDraft(channelId, options.message, {
+        const response = await client.createDraft(channelId, resolvedMessage, {
           thread_ts: options.threadTs,
         });
 

--- a/src/lib/mentions.test.ts
+++ b/src/lib/mentions.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'bun:test';
+import { SlackClient } from './slack-client.ts';
+import { resolveMentions } from './mentions.ts';
+
+interface FakeData {
+  usergroups?: any[];
+  people?: Record<string, any[]>;
+  channels?: Record<string, any[]>;
+}
+
+// Subclass SlackClient and override request() so no network call is made.
+// search.modules / usergroups.list are routed to the canned FakeData.
+class FakeSlackClient extends SlackClient {
+  public usergroupsCalls = 0;
+
+  constructor(private readonly data: FakeData = {}) {
+    super({
+      workspace_id: 'T123',
+      workspace_name: 'Test Workspace',
+      auth_type: 'browser',
+      xoxd_token: 'xoxd-test',
+      xoxc_token: 'xoxc-test',
+      workspace_url: 'https://example.slack.com',
+    });
+  }
+
+  override async request(method: string, params: Record<string, any> = {}): Promise<any> {
+    if (method === 'usergroups.list') {
+      this.usergroupsCalls++;
+      return { ok: true, usergroups: this.data.usergroups || [] };
+    }
+
+    if (method === 'search.modules') {
+      const query = String(params.query);
+      if (params.module === 'people') {
+        return { ok: true, items: this.data.people?.[query] || [] };
+      }
+      if (params.module === 'channels') {
+        return { ok: true, items: this.data.channels?.[query] || [] };
+      }
+    }
+
+    throw new Error(`Unexpected method: ${method} ${JSON.stringify(params)}`);
+  }
+}
+
+describe('resolveMentions', () => {
+  it('passes plain text through unchanged', async () => {
+    const client = new FakeSlackClient();
+    expect(await resolveMentions('hello world', client)).toBe('hello world');
+  });
+
+  it('passes existing escape tokens through verbatim', async () => {
+    const client = new FakeSlackClient();
+    const input = '<@U1> <#C1> <!here> <https://example.com|site>';
+    expect(await resolveMentions(input, client)).toBe(input);
+  });
+
+  it('resolves @group: by handle', async () => {
+    const client = new FakeSlackClient({
+      usergroups: [{ id: 'S1', handle: 'ror_team', name: 'RoR Team' }],
+    });
+    expect(await resolveMentions('@group:ror_team', client)).toBe('<!subteam^S1>');
+  });
+
+  it('resolves @group: by name when the handle does not match', async () => {
+    const client = new FakeSlackClient({
+      usergroups: [{ id: 'S2', handle: 'devs', name: 'engineers' }],
+    });
+    expect(await resolveMentions('@group:engineers', client)).toBe('<!subteam^S2>');
+  });
+
+  it('matches @group: handles case-insensitively', async () => {
+    const client = new FakeSlackClient({
+      usergroups: [{ id: 'S1', handle: 'ror_team', name: 'RoR Team' }],
+    });
+    expect(await resolveMentions('@group:ROR_TEAM', client)).toBe('<!subteam^S1>');
+  });
+
+  it('throws and lists available handles when a group is not found', async () => {
+    const client = new FakeSlackClient({
+      usergroups: [{ id: 'S1', handle: 'ror_team' }, { id: 'S2', handle: 'devs' }],
+    });
+    await expect(resolveMentions('@group:nope', client)).rejects.toThrow(/ror_team/);
+  });
+
+  it('resolves @user: by username', async () => {
+    const client = new FakeSlackClient({
+      people: { paul: [{ id: 'U1', name: 'paul' }] },
+    });
+    expect(await resolveMentions('@user:paul', client)).toBe('<@U1>');
+  });
+
+  it('resolves @user: by email', async () => {
+    const client = new FakeSlackClient({
+      people: {
+        'paul@example.com': [{ id: 'U2', name: 'paul', profile: { email: 'paul@example.com' } }],
+      },
+    });
+    expect(await resolveMentions('@user:paul@example.com', client)).toBe('<@U2>');
+  });
+
+  it('picks the exact username over the first result when multiple match', async () => {
+    const client = new FakeSlackClient({
+      people: {
+        paul: [
+          { id: 'U9', name: 'paul.jones', real_name: 'Paul Jones' },
+          { id: 'U1', name: 'paul', real_name: 'Paul Smith' },
+        ],
+      },
+    });
+    // Naive results[0] would wrongly pick U9; exact-match priority picks U1.
+    expect(await resolveMentions('@user:paul', client)).toBe('<@U1>');
+  });
+
+  it('resolves @user: with a quoted name via real_name', async () => {
+    const client = new FakeSlackClient({
+      people: {
+        'Jane Doe': [{ id: 'U7', name: 'jane', real_name: 'Jane Doe' }],
+      },
+    });
+    expect(await resolveMentions('@user:"Jane Doe"', client)).toBe('<@U7>');
+  });
+
+  it('falls back to the sole result when there is exactly one and no exact match', async () => {
+    const client = new FakeSlackClient({
+      people: { jane: [{ id: 'U5', name: 'jane.doe', real_name: 'Jane Doe' }] },
+    });
+    expect(await resolveMentions('@user:jane', client)).toBe('<@U5>');
+  });
+
+  it('throws an ambiguity error when multiple match and none is exact', async () => {
+    const client = new FakeSlackClient({
+      people: {
+        pa: [
+          { id: 'U1', name: 'paula' },
+          { id: 'U2', name: 'pawel' },
+        ],
+      },
+    });
+    await expect(resolveMentions('@user:pa', client)).rejects.toThrow(/ambiguous/);
+  });
+
+  it('throws when no user matches', async () => {
+    const client = new FakeSlackClient({ people: { ghost: [] } });
+    await expect(resolveMentions('@user:ghost', client)).rejects.toThrow(/No user matches/);
+  });
+
+  it('resolves #channel by exact name', async () => {
+    const client = new FakeSlackClient({
+      channels: { general: [{ id: 'C1', name: 'general' }] },
+    });
+    expect(await resolveMentions('#general', client)).toBe('<#C1>');
+  });
+
+  it('prefers the exact channel name over a fuzzy match', async () => {
+    const client = new FakeSlackClient({
+      channels: {
+        general: [
+          { id: 'C9', name: 'general-chat' },
+          { id: 'C1', name: 'general' },
+        ],
+      },
+    });
+    expect(await resolveMentions('#general', client)).toBe('<#C1>');
+  });
+
+  it('throws when no channel matches', async () => {
+    const client = new FakeSlackClient({ channels: { nope: [] } });
+    await expect(resolveMentions('#nope', client)).rejects.toThrow(/No channel matches/);
+  });
+
+  it('resolves multiple tokens in one message', async () => {
+    const client = new FakeSlackClient({
+      people: { paul: [{ id: 'U1', name: 'paul' }] },
+      channels: { general: [{ id: 'C1', name: 'general' }] },
+    });
+    expect(await resolveMentions('@user:paul see #general', client)).toBe('<@U1> see <#C1>');
+  });
+
+  it('leaves a # inside a URL untouched', async () => {
+    const client = new FakeSlackClient();
+    const input = 'see https://example.com#section now';
+    expect(await resolveMentions(input, client)).toBe(input);
+  });
+
+  it('fetches usergroups only once across multiple @group tokens', async () => {
+    const client = new FakeSlackClient({
+      usergroups: [{ id: 'S1', handle: 'ror_team' }],
+    });
+    const out = await resolveMentions('@group:ror_team and @group:ror_team', client);
+    expect(out).toBe('<!subteam^S1> and <!subteam^S1>');
+    expect(client.usergroupsCalls).toBe(1);
+  });
+});

--- a/src/lib/mentions.ts
+++ b/src/lib/mentions.ts
@@ -1,0 +1,234 @@
+// Resolve friendly mention tokens into Slack escape tokens before a draft is
+// built. The mrkdwn parser (src/lib/mrkdwn.ts) turns Slack escape tokens such
+// as <@U…>, <!subteam^S…> and <#C…> into rich_text mention elements, but it
+// has no way to look names up. This module bridges that gap by translating:
+//
+//   @group:<handle>       → <!subteam^S…>   (usergroups.list)
+//   @user:<name|email>    → <@U…>           (search people, exact-match first)
+//   #<channel>            → <#C…>           (search channels, exact name)
+//
+// Existing escape tokens are passed through verbatim. Lookups that cannot be
+// resolved unambiguously throw a clear, actionable error rather than leaving a
+// friendly token behind as dead literal text.
+
+import type { SlackClient } from './slack-client.ts';
+
+interface ResolvedPerson {
+  id: string;
+  name?: string;
+  real_name?: string;
+  display_name?: string;
+  email?: string;
+}
+
+interface ResolvedChannel {
+  id: string;
+  name?: string;
+}
+
+const GROUP_PREFIX = '@group:';
+const USER_PREFIX = '@user:';
+
+// Read a token argument starting at `start`. Supports a quoted form
+// (@user:"Jane Doe") and an unquoted form that runs to the next whitespace
+// (so emails like jane@example.com are captured intact).
+function readArg(text: string, start: number): { value: string; end: number } {
+  if (text[start] === '"') {
+    const close = text.indexOf('"', start + 1);
+    if (close !== -1) {
+      return { value: text.slice(start + 1, close), end: close + 1 };
+    }
+  }
+
+  let j = start;
+  while (j < text.length && !/\s/.test(text[j])) j++;
+  return { value: text.slice(start, j), end: j };
+}
+
+// Read a channel name (letters, digits, hyphen, underscore) starting at `start`.
+function readChannelName(text: string, start: number): { value: string; end: number } {
+  let j = start;
+  while (j < text.length && /[a-z0-9_-]/i.test(text[j])) j++;
+  return { value: text.slice(start, j), end: j };
+}
+
+function normalizePeople(response: any): ResolvedPerson[] {
+  if (response.items) {
+    // search.modules (browser auth)
+    return response.items.map((p: any) => ({
+      id: p.id,
+      name: p.name,
+      real_name: p.real_name || p.profile?.real_name,
+      display_name: p.profile?.display_name,
+      email: p.profile?.email,
+    }));
+  }
+
+  // users.list fallback (standard auth)
+  return (response.members || [])
+    .filter((u: any) => !u.deleted && !u.is_bot)
+    .map((u: any) => ({
+      id: u.id,
+      name: u.name,
+      real_name: u.real_name || u.profile?.real_name,
+      display_name: u.profile?.display_name,
+      email: u.profile?.email,
+    }));
+}
+
+function normalizeChannels(response: any): ResolvedChannel[] {
+  if (response.items) {
+    // search.modules (browser auth)
+    return response.items.map((c: any) => ({ id: c.id, name: c.name }));
+  }
+
+  // conversations.list fallback (standard auth)
+  return (response.channels || []).map((c: any) => ({ id: c.id, name: c.name }));
+}
+
+function describePerson(person: ResolvedPerson): string {
+  const label = person.real_name || person.display_name || person.email;
+  const handle = person.name ? `@${person.name}` : person.id;
+  return label ? `${handle} (${label})` : handle;
+}
+
+async function resolveGroup(handle: string, getUsergroups: () => Promise<any[]>): Promise<string> {
+  const groups = await getUsergroups();
+  const target = handle.toLowerCase();
+
+  const match =
+    groups.find((g) => g.handle?.toLowerCase() === target) ||
+    groups.find((g) => g.name?.toLowerCase() === target);
+
+  if (!match) {
+    const handles = groups.map((g) => g.handle).filter(Boolean).sort();
+    const available = handles.length ? handles.join(', ') : '(none)';
+    throw new Error(
+      `No usergroup matches "@group:${handle}". Available handles: ${available}.`,
+    );
+  }
+
+  return `<!subteam^${match.id}>`;
+}
+
+async function resolveUser(query: string, client: SlackClient): Promise<string> {
+  const response = await client.searchModules(query, 'people');
+  const people = normalizePeople(response);
+  const target = query.toLowerCase();
+
+  // Exact-match priority: username → email → display name → real name.
+  const exact =
+    people.find((p) => p.name?.toLowerCase() === target) ||
+    people.find((p) => p.email?.toLowerCase() === target) ||
+    people.find((p) => p.display_name?.toLowerCase() === target) ||
+    people.find((p) => p.real_name?.toLowerCase() === target);
+
+  if (exact) return `<@${exact.id}>`;
+
+  // Fall back to the sole result only when there is exactly one.
+  if (people.length === 1) return `<@${people[0].id}>`;
+
+  if (people.length === 0) {
+    throw new Error(
+      `No user matches "@user:${query}". Try an exact username or email, e.g. @user:jane.doe or @user:jane@example.com.`,
+    );
+  }
+
+  const candidates = people.slice(0, 10).map(describePerson).join(', ');
+  throw new Error(
+    `"@user:${query}" is ambiguous — ${people.length} matches: ${candidates}. ` +
+      'Use an exact username or email to disambiguate.',
+  );
+}
+
+async function resolveChannel(name: string, client: SlackClient): Promise<string> {
+  const response = await client.searchModules(name, 'channels');
+  const channels = normalizeChannels(response);
+  const target = name.toLowerCase();
+
+  // Exact name match takes priority over any fuzzy search hit.
+  const exact = channels.find((c) => c.name?.toLowerCase() === target);
+  if (exact) return `<#${exact.id}>`;
+
+  if (channels.length === 1) return `<#${channels[0].id}>`;
+
+  if (channels.length === 0) {
+    throw new Error(`No channel matches "#${name}". Use the exact channel name.`);
+  }
+
+  const candidates = channels
+    .slice(0, 10)
+    .map((c) => (c.name ? `#${c.name}` : c.id))
+    .join(', ');
+  throw new Error(
+    `"#${name}" is ambiguous — ${channels.length} matches: ${candidates}. Use the exact channel name.`,
+  );
+}
+
+// Translate friendly mention tokens in `text` into Slack escape tokens.
+// A single left-to-right scan is used (rather than a global regex replace) so
+// that labels inside existing escape tokens, and '#' characters inside URLs,
+// are never mistaken for friendly tokens.
+export async function resolveMentions(text: string, client: SlackClient): Promise<string> {
+  let usergroups: any[] | null = null;
+  const getUsergroups = async (): Promise<any[]> => {
+    if (usergroups === null) {
+      const response = await client.listUsergroups({ include_disabled: true });
+      usergroups = response.usergroups || [];
+    }
+    return usergroups ?? [];
+  };
+
+  let result = '';
+  let i = 0;
+
+  while (i < text.length) {
+    const ch = text[i];
+
+    // Pass existing escape tokens (<@…>, <#…>, <!…>, <https://…>) through verbatim.
+    if (ch === '<') {
+      const end = text.indexOf('>', i + 1);
+      if (end !== -1) {
+        result += text.slice(i, end + 1);
+        i = end + 1;
+        continue;
+      }
+      result += ch;
+      i++;
+      continue;
+    }
+
+    if (text.startsWith(GROUP_PREFIX, i)) {
+      const { value, end } = readArg(text, i + GROUP_PREFIX.length);
+      if (value.length > 0) {
+        result += await resolveGroup(value, getUsergroups);
+        i = end;
+        continue;
+      }
+    }
+
+    if (text.startsWith(USER_PREFIX, i)) {
+      const { value, end } = readArg(text, i + USER_PREFIX.length);
+      if (value.length > 0) {
+        result += await resolveUser(value, client);
+        i = end;
+        continue;
+      }
+    }
+
+    // #channel, only at a word boundary so '#' inside a URL is left untouched.
+    if (ch === '#' && (i === 0 || /\s/.test(text[i - 1]))) {
+      const { value, end } = readChannelName(text, i + 1);
+      if (value.length > 0) {
+        result += await resolveChannel(value, client);
+        i = end;
+        continue;
+      }
+    }
+
+    result += ch;
+    i++;
+  }
+
+  return result;
+}

--- a/src/lib/mrkdwn.test.ts
+++ b/src/lib/mrkdwn.test.ts
@@ -137,3 +137,128 @@ describe('parseMrkdwn', () => {
     }]);
   });
 });
+
+describe('parseMrkdwn — mentions, links and broadcasts', () => {
+  it('parses a user mention', () => {
+    expect(elements('<@U123>')).toEqual([
+      { type: 'user', user_id: 'U123' },
+    ]);
+  });
+
+  it('parses a user mention and drops the |label', () => {
+    expect(elements('<@U123|alice>')).toEqual([
+      { type: 'user', user_id: 'U123' },
+    ]);
+  });
+
+  it('parses a usergroup mention', () => {
+    expect(elements('<!subteam^S456>')).toEqual([
+      { type: 'usergroup', usergroup_id: 'S456' },
+    ]);
+  });
+
+  it('parses a usergroup mention with a |label', () => {
+    expect(elements('<!subteam^S456|ror-team>')).toEqual([
+      { type: 'usergroup', usergroup_id: 'S456' },
+    ]);
+  });
+
+  it('parses a channel mention', () => {
+    expect(elements('<#C789>')).toEqual([
+      { type: 'channel', channel_id: 'C789' },
+    ]);
+  });
+
+  it('parses a channel mention with a |label', () => {
+    expect(elements('<#C789|general>')).toEqual([
+      { type: 'channel', channel_id: 'C789' },
+    ]);
+  });
+
+  it('parses a <!here> broadcast', () => {
+    expect(elements('<!here>')).toEqual([
+      { type: 'broadcast', range: 'here' },
+    ]);
+  });
+
+  it('parses a <!channel> broadcast', () => {
+    expect(elements('<!channel>')).toEqual([
+      { type: 'broadcast', range: 'channel' },
+    ]);
+  });
+
+  it('parses a <!everyone> broadcast', () => {
+    expect(elements('<!everyone>')).toEqual([
+      { type: 'broadcast', range: 'everyone' },
+    ]);
+  });
+
+  it('parses an explicit link without a label', () => {
+    expect(elements('<https://example.com>')).toEqual([
+      { type: 'link', url: 'https://example.com' },
+    ]);
+  });
+
+  it('parses an explicit link with a label', () => {
+    expect(elements('<https://example.com|Example>')).toEqual([
+      { type: 'link', url: 'https://example.com', text: 'Example' },
+    ]);
+  });
+
+  it('splits a bare URL out of surrounding text', () => {
+    expect(elements('see https://example.com now')).toEqual([
+      { type: 'text', text: 'see ' },
+      { type: 'link', url: 'https://example.com' },
+      { type: 'text', text: ' now' },
+    ]);
+  });
+
+  it('keeps text immediately after a link separate', () => {
+    expect(elements('<https://example.com> done')).toEqual([
+      { type: 'link', url: 'https://example.com' },
+      { type: 'text', text: ' done' },
+    ]);
+  });
+
+  it('does not append following text onto a mention element', () => {
+    // Regression guard for the line-78 fix: without the `type === 'text'`
+    // guard, the trailing "\nhi" would be concatenated onto the mention.
+    expect(elements('<@U123>\nhi')).toEqual([
+      { type: 'user', user_id: 'U123' },
+      { type: 'text', text: '\nhi' },
+    ]);
+  });
+
+  it('combines a mention with bold text', () => {
+    expect(elements('*Heads up* <@U123>')).toEqual([
+      { type: 'text', text: 'Heads up', style: { bold: true } },
+      { type: 'text', text: ' ' },
+      { type: 'user', user_id: 'U123' },
+    ]);
+  });
+
+  it('keeps a link inside *bold* unstyled (pushed unchanged)', () => {
+    expect(elements('*<https://example.com>*')).toEqual([
+      { type: 'link', url: 'https://example.com' },
+    ]);
+  });
+
+  it('leaves a stray < as plain text', () => {
+    expect(elements('a < b')).toEqual([
+      { type: 'text', text: 'a < b' },
+    ]);
+  });
+
+  it('returns a valid rich_text block for a mention', () => {
+    expect(parseMrkdwn('hi <@U123>')).toEqual([{
+      type: 'rich_text',
+      elements: [{
+        type: 'rich_text_section',
+        elements: [
+          { type: 'text', text: 'hi ' },
+          { type: 'user', user_id: 'U123' },
+        ],
+      }],
+    }]);
+  });
+});

--- a/src/lib/mrkdwn.ts
+++ b/src/lib/mrkdwn.ts
@@ -1,5 +1,7 @@
 // Parse Slack mrkdwn text into rich_text block elements.
-// Supports: *bold*, _italic_, ~strike~, `code`, and combinations.
+// Supports: *bold*, _italic_, ~strike~, `code`, mentions (<@U…>, <!subteam^S…>),
+// channels (<#C…>), broadcasts (<!here>/<!channel>/<!everyone>), and links
+// (<https://…> and bare URLs), plus combinations.
 
 interface RichTextStyle {
   bold?: boolean;
@@ -8,11 +10,45 @@ interface RichTextStyle {
   code?: boolean;
 }
 
-interface RichTextElement {
+interface RichTextText {
   type: 'text';
   text: string;
   style?: RichTextStyle;
 }
+
+interface RichTextUser {
+  type: 'user';
+  user_id: string;
+}
+
+interface RichTextUsergroup {
+  type: 'usergroup';
+  usergroup_id: string;
+}
+
+interface RichTextChannel {
+  type: 'channel';
+  channel_id: string;
+}
+
+interface RichTextBroadcast {
+  type: 'broadcast';
+  range: 'here' | 'channel' | 'everyone';
+}
+
+interface RichTextLink {
+  type: 'link';
+  url: string;
+  text?: string;
+}
+
+type RichTextElement =
+  | RichTextText
+  | RichTextUser
+  | RichTextUsergroup
+  | RichTextChannel
+  | RichTextBroadcast
+  | RichTextLink;
 
 interface RichTextSection {
   type: 'rich_text_section';
@@ -32,11 +68,85 @@ const MARKERS: [string, keyof RichTextStyle][] = [
   ['~', 'strike'],
 ];
 
+// Classify the content of a Slack escape token (the text between < and >).
+// Returns null when the content matches no known token, so the caller can
+// treat the leading '<' as a plain character.
+function parseEscapeToken(inner: string): RichTextElement | null {
+  // User mention: <@U…> or <@U…|label> (label is dropped)
+  if (inner.startsWith('@')) {
+    const id = inner.slice(1).split('|')[0];
+    if (/^[UW][A-Z0-9]+$/.test(id)) {
+      return { type: 'user', user_id: id };
+    }
+    return null;
+  }
+
+  // Usergroup mention: <!subteam^S…> or <!subteam^S…|label>
+  if (inner.startsWith('!subteam^')) {
+    const id = inner.slice('!subteam^'.length).split('|')[0];
+    if (/^S[A-Z0-9]+$/.test(id)) {
+      return { type: 'usergroup', usergroup_id: id };
+    }
+    return null;
+  }
+
+  // Broadcast: <!here>, <!channel>, <!everyone> (also <!here|label>)
+  if (inner.startsWith('!')) {
+    const range = inner.slice(1).split('|')[0];
+    if (range === 'here' || range === 'channel' || range === 'everyone') {
+      return { type: 'broadcast', range };
+    }
+    return null;
+  }
+
+  // Channel mention: <#C…> or <#C…|label>
+  if (inner.startsWith('#')) {
+    const id = inner.slice(1).split('|')[0];
+    if (/^C[A-Z0-9]+$/.test(id)) {
+      return { type: 'channel', channel_id: id };
+    }
+    return null;
+  }
+
+  // Link: <https://…>, <http://…>, or <https://…|label>
+  if (inner.startsWith('http://') || inner.startsWith('https://')) {
+    const pipeIndex = inner.indexOf('|');
+    if (pipeIndex === -1) {
+      return { type: 'link', url: inner };
+    }
+    return { type: 'link', url: inner.slice(0, pipeIndex), text: inner.slice(pipeIndex + 1) };
+  }
+
+  return null;
+}
+
 function parseInline(text: string): RichTextElement[] {
   const elements: RichTextElement[] = [];
 
   let i = 0;
   while (i < text.length) {
+    // Explicit escape tokens: <@U…>, <!subteam^S…>, <#C…>, <!here>, <https://…>
+    if (text[i] === '<') {
+      const end = text.indexOf('>', i + 1);
+      if (end !== -1) {
+        const token = parseEscapeToken(text.substring(i + 1, end));
+        if (token) {
+          elements.push(token);
+          i = end + 1;
+          continue;
+        }
+      }
+      // Unrecognized '<' falls through and is handled as a plain character.
+    }
+
+    // Bare URL (http/https) — stops at whitespace or '<'
+    const urlMatch = /^https?:\/\/[^\s<]+/.exec(text.slice(i));
+    if (urlMatch) {
+      elements.push({ type: 'link', url: urlMatch[0] });
+      i += urlMatch[0].length;
+      continue;
+    }
+
     let matched = false;
 
     for (const [marker, styleKey] of MARKERS) {
@@ -50,20 +160,22 @@ function parseInline(text: string): RichTextElement[] {
       // Don't match empty content or content that starts/ends with space
       if (inner.length === 0 || inner.startsWith(' ') || inner.endsWith(' ')) continue;
 
-      // Flush any plain text before this marker
-      // (already handled by the outer loop collecting plain chars)
-
       const style: RichTextStyle = { [styleKey]: true };
 
       if (styleKey === 'code') {
         // Code spans don't nest
         elements.push({ type: 'text', text: inner, style });
       } else {
-        // Recursively parse inner content for nested formatting
+        // Recursively parse inner content for nested formatting.
+        // Non-text children (e.g. a link inside *...*) are pushed unchanged.
         const innerElements = parseInline(inner);
         for (const el of innerElements) {
-          const mergedStyle = { ...el.style, [styleKey]: true };
-          elements.push({ type: 'text', text: el.text, style: mergedStyle });
+          if (el.type === 'text') {
+            const mergedStyle = { ...el.style, [styleKey]: true };
+            elements.push({ type: 'text', text: el.text, style: mergedStyle });
+          } else {
+            elements.push(el);
+          }
         }
       }
 
@@ -72,21 +184,23 @@ function parseInline(text: string): RichTextElement[] {
       break;
     }
 
-    if (!matched) {
-      // Plain character: append to last plain element or create new one
-      const last = elements[elements.length - 1];
-      if (last && !last.style) {
-        last.text += text[i];
-      } else {
-        elements.push({ type: 'text', text: text[i] });
-      }
-      i++;
+    if (matched) continue;
+
+    // Plain character: append to last plain text element or create a new one.
+    // The `last.type === 'text'` guard is load-bearing: non-text elements have
+    // no `style`, so without it the char would be appended onto a mention/link.
+    const last = elements[elements.length - 1];
+    if (last && last.type === 'text' && !last.style) {
+      last.text += text[i];
+    } else {
+      elements.push({ type: 'text', text: text[i] });
     }
+    i++;
   }
 
   // Clean up: remove empty style objects
   return elements.map(el => {
-    if (el.style && Object.keys(el.style).length === 0) {
+    if (el.type === 'text' && el.style && Object.keys(el.style).length === 0) {
       const { style, ...rest } = el;
       return rest as RichTextElement;
     }

--- a/src/lib/slack-client.ts
+++ b/src/lib/slack-client.ts
@@ -351,6 +351,17 @@ export class SlackClient {
     return this.request('users.list', params);
   }
 
+  // List usergroups (used to resolve @group:<handle> mentions to <!subteam^S…>)
+  async listUsergroups(options: {
+    include_disabled?: boolean;
+    include_users?: boolean;
+  } = {}): Promise<any> {
+    const params: Record<string, any> = {};
+    if (options.include_disabled !== undefined) params.include_disabled = options.include_disabled;
+    if (options.include_users !== undefined) params.include_users = options.include_users;
+    return this.request('usergroups.list', params);
+  }
+
   // Get conversation info
   async getConversationInfo(channel: string): Promise<any> {
     return this.request('conversations.info', { channel });


### PR DESCRIPTION
Closes #68

## Summary

`messages draft` could not emit Slack rich_text **mention / link / broadcast** elements, so friendly or escaped tokens were stored as dead literal text. This PR delivers two pieces:

**F1 — mrkdwn parser (`src/lib/mrkdwn.ts`, pure):** `RichTextElement` becomes a discriminated union and the parser now recognises user (`<@U…>`), usergroup (`<!subteam^S…>`), channel (`<#C…>`) and broadcast (`<!here>`/`<!channel>`/`<!everyone>`) escape tokens, explicit links (`<https://…>` / `<https://…|label>`), and bare `https://` URLs. The plain-character append is guarded with `last.type === 'text'` so a trailing newline/space can no longer corrupt a mention or link element.

**F4 — friendly-name resolution (`src/lib/mentions.ts`):** a new `resolveMentions(text, client)` runs before parsing and translates:

- `@group:<handle>` → `<!subteam^S…>` (new `listUsergroups()` on the client; cached per call)
- `@user:<name|email>` (quotes supported) → `<@U…>` with **exact-match priority** (username → email → display name → real name), so the right user is picked rather than the first search hit
- `#<channel>` → `<#C…>` by exact name

Existing escape tokens pass through verbatim, and `#` inside a URL is left alone. Ambiguous / not-found tokens raise clear, actionable errors (listing candidates or available handles) instead of leaving dead text. Resolution is wired into the `draft` action only; errors propagate to the existing spinner-fail / exit-1 handler.

## Tests

- `bun run type-check` — clean.
- `bun test` — all green (214 tests). Extends `src/lib/mrkdwn.test.ts` (mentions/links/broadcasts, bare-URL split, the line-78 regression guard, mention+bold, stray `<`) and adds `src/lib/mentions.test.ts` (fully stubbed `SlackClient`, no network — group by handle/name, case-insensitivity, the multi-result "pick the exact username" case, single-result fallback, ambiguity & not-found errors, channel exact-priority, `#`-in-URL passthrough, usergroup caching).
- `bun run build` — binary builds; `--version` and `messages draft --help` verified.

## Manual Tests

We can now send formatted draft like this:
<img width="1133" height="155" alt="image" src="https://github.com/user-attachments/assets/63175369-bfc1-4367-bd9d-1ae63e7e914f" />
<img width="1128" height="190" alt="image" src="https://github.com/user-attachments/assets/61aa2d48-2234-4456-b8c7-7851c156f423" />

## Docs

`README.md` gains a "Mentions, links & broadcasts in drafts" subsection covering the friendly syntax, raw escape-token passthrough, draft-only scope, and the bold-trailing-space limitation.

## Known limitation

A bold span ending in a space (`*Tests: *`) is not valid Slack mrkdwn and cannot round-trip byte-for-byte; the space must sit outside the markers. Validation against real composer payloads was 10/12 elements byte-identical, the exceptions being this inherent constraint.

## Out of scope

- Wiring `resolveMentions` into `messages send` (flat `chat.postMessage` text already auto-links escape tokens) — planned follow-up.
- An `unfurl` control parameter.
- A `--blocks-json` raw Block Kit passthrough.
