### PR TITLE
fix(deps): pin form-data to >=4.0.6 to address CRLF injection (GHSA-hmw2-7cc7-3qxx)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,9 @@
       },
     },
   },
+  "overrides": {
+    "form-data": "^4.0.6",
+  },
   "packages": {
     "@slack/logger": ["@slack/logger@4.0.1", "", { "dependencies": { "@types/node": ">=18" } }, "sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ=="],
 
@@ -70,7 +73,7 @@
 
     "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
 
-    "form-data": ["form-data@4.0.4", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow=="],
+    "form-data": ["form-data@4.0.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -86,7 +89,7 @@
 
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
-    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
     "is-electron": ["is-electron@2.2.2", "", {}, "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="],
 
@@ -136,7 +139,9 @@
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
-    "axios/form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+    "es-set-tostringtag/hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "get-intrinsic/hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
   },
   "engines": {
     "bun": ">=1.0.0"
+  },
+  "overrides": {
+    "form-data": "^4.0.6"
   }
 }


### PR DESCRIPTION
## Automated dependency-security fix (draft, awaiting proper triage)

Linked issue: #75

This PR is an **automated security-patch sweep**, equivalent to responding to a Dependabot alert. GitHub's Dependabot Alerts API was not reachable from the sandbox that produced this PR, so a local `bun audit` was run as a substitute.

**This is opened as a draft and is NOT requesting immediate merge.** Per this repo's `CLAUDE.md` constitution, every PR must be linked to a pre-triaged GitHub issue carrying the `ready-for-pr` label before it can be merged. Issue #75 has been opened to track this. A maintainer should triage it and apply the `ready-for-pr` label if this remediation path is acceptable, or close this PR if a different approach is preferred.

This PR does not claim to satisfy the issue-first policy on its own — it is left in draft specifically so it isn't merged before proper triage happens.

### What / Why

`bun audit` reported one **high severity** advisory:

```
form-data  >=4.0.0 <4.0.6
  @slack/web-api › form-data
  high: form-data: CRLF injection in form-data via unescaped multipart field names and filenames
  https://github.com/advisories/GHSA-hmw2-7cc7-3qxx
```

`form-data` is a transitive dependency pulled in twice — once directly by `@slack/web-api` (resolved to `4.0.4`) and once via `@slack/web-api`'s `axios` dependency (resolved to `4.0.5`). Both are within the vulnerable range `>=4.0.0 <4.0.6`.

### How

Added a `package.json` `"overrides"` entry to force `form-data` to `^4.0.6` across the whole dependency tree (a patch-level bump, no breaking changes), then regenerated `bun.lock` via `bun install`.

```json
"overrides": {
  "form-data": "^4.0.6"
}
```

### Verification

- `bun audit` — now reports **no vulnerabilities** (was 1 high)
- `bun run type-check` — passes
- `bun test` — 176 pass / 0 fail (328 expect() calls)

### Scope

No application code was touched — only `package.json` and `bun.lock`. No other actionable vulnerabilities were found in this sweep.


---
_Generated by [Claude Code](https://claude.ai/code/session_019G4oekbpTm8WFp13Tv2APM)_