### PR TITLE
fix: prevent --json output truncation at 64 KiB pipe buffer (#73)

### DIFF
--- a/src/commands/canvas.ts
+++ b/src/commands/canvas.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import ora from 'ora';
 import { getAuthenticatedClient } from '../lib/auth.ts';
-import { error, formatCanvasList, formatCanvasContent } from '../lib/formatter.ts';
+import { error, formatCanvasList, formatCanvasContent, writeJson } from '../lib/formatter.ts';
 import { canvasHtmlToMarkdown, isAuthPage } from '../lib/canvas-parser.ts';
 import type { SlackCanvas, SlackUser } from '../types/index.ts';
 
@@ -48,7 +48,7 @@ export function createCanvasCommand(): Command {
         spinner.succeed(`Found ${files.length} canvases`);
 
         if (options.json) {
-          console.log(JSON.stringify({
+          writeJson({
             canvas_count: files.length,
             canvases: files.map(f => ({
               id: f.id,
@@ -60,7 +60,7 @@ export function createCanvasCommand(): Command {
               size: f.size,
               permalink: f.permalink,
             })),
-          }, null, 2));
+          });
           return;
         }
 
@@ -201,7 +201,7 @@ export function createCanvasCommand(): Command {
         }
 
         if (options.json) {
-          console.log(JSON.stringify({
+          writeJson({
             id: file.id,
             title: file.title || file.name,
             created: file.created,
@@ -211,7 +211,7 @@ export function createCanvasCommand(): Command {
             size: file.size,
             permalink: file.permalink,
             markdown,
-          }, null, 2));
+          });
           return;
         }
 

--- a/src/commands/conversations.ts
+++ b/src/commands/conversations.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 import ora from 'ora';
 import { getAuthenticatedClient } from '../lib/auth.ts';
-import { error, formatChannelList, formatConversationHistory, formatUnreadChannels } from '../lib/formatter.ts';
+import { error, formatChannelList, formatConversationHistory, formatUnreadChannels, writeJson } from '../lib/formatter.ts';
 import { fetchMessage } from '../lib/message.ts';
 import { fetchUnreadChannels } from '../lib/unread.ts';
 import type { SlackChannel, SlackMessage, SlackUser } from '../types/index.ts';
@@ -141,7 +141,7 @@ export function createConversationsCommand(): Command {
 
         // Output in JSON format if requested
         if (options.json) {
-          console.log(JSON.stringify({
+          writeJson({
             channel_id: channelId,
             message_count: messages.length,
             messages: messages.map(msg => ({
@@ -173,7 +173,7 @@ export function createConversationsCommand(): Command {
               real_name: u.real_name,
               email: u.profile?.email,
             })),
-          }, null, 2));
+          });
         } else {
           console.log('\n' + formatConversationHistory(channelId, messages, users));
         }
@@ -222,7 +222,7 @@ export function createConversationsCommand(): Command {
         spinner.succeed('Message found');
 
         if (options.json) {
-          console.log(JSON.stringify({
+          writeJson({
             channel_id: channelId,
             message: {
               ts: msg.ts,
@@ -252,7 +252,7 @@ export function createConversationsCommand(): Command {
               real_name: u.real_name,
               email: u.profile?.email,
             })),
-          }, null, 2));
+          });
         } else {
           console.log('\n' + formatConversationHistory(channelId, [msg], users));
         }
@@ -299,7 +299,7 @@ export function createConversationsCommand(): Command {
         spinner.succeed(`${channels.length} conversations with unread messages`);
 
         if (options.json) {
-          console.log(JSON.stringify({ unread_channels: channels }, null, 2));
+          writeJson({ unread_channels: channels });
           return;
         }
 

--- a/src/commands/saved.ts
+++ b/src/commands/saved.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import ora from 'ora';
 import { getAuthenticatedClient } from '../lib/auth.ts';
-import { error, formatSavedItems } from '../lib/formatter.ts';
+import { error, formatSavedItems, writeJson } from '../lib/formatter.ts';
 import { enrichSavedItems } from '../lib/saved.ts';
 
 export function createSavedCommand(): Command {
@@ -39,7 +39,7 @@ export function createSavedCommand(): Command {
         spinner.succeed(`Found ${items.length} saved items`);
 
         if (options.json) {
-          console.log(JSON.stringify({ item_count: items.length, items }, null, 2));
+          writeJson({ item_count: items.length, items });
           return;
         }
 

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -7,6 +7,7 @@ import {
   formatChannelSearchResults,
   formatPeopleSearchResults,
   formatPaginationHint,
+  writeJson,
 } from '../lib/formatter.ts';
 import type { ChannelSearchResult, PeopleSearchResult } from '../types/index.ts';
 
@@ -57,13 +58,13 @@ export function createSearchCommand(): Command {
 
         if (options.json) {
           const pagination = response.messages?.pagination;
-          console.log(JSON.stringify({
+          writeJson({
             query,
             total,
             page: pagination?.page || 1,
             pages: pagination?.page_count || 1,
             matches,
-          }, null, 2));
+          });
           return;
         }
 
@@ -125,7 +126,7 @@ export function createSearchCommand(): Command {
         spinner.succeed(`Found ${total} matching channels (showing ${channels.length})`);
 
         if (options.json) {
-          console.log(JSON.stringify({ query, total, channels }, null, 2));
+          writeJson({ query, total, channels });
           return;
         }
 
@@ -186,7 +187,7 @@ export function createSearchCommand(): Command {
         spinner.succeed(`Found ${total} matching people (showing ${people.length})`);
 
         if (options.json) {
-          console.log(JSON.stringify({ query, total, people }, null, 2));
+          writeJson({ query, total, people });
           return;
         }
 

--- a/src/lib/formatter.test.ts
+++ b/src/lib/formatter.test.ts
@@ -8,6 +8,7 @@ import {
   formatPaginationHint,
   formatFileSize,
   formatMessage,
+  writeJson,
 } from './formatter.ts';
 import type {
   SavedItem,
@@ -395,4 +396,37 @@ describe('formatFileSize', () => {
   it('formats 1023 bytes (boundary before KB)', () => {
     expect(formatFileSize(1023)).toBe('1023 B');
   });
+});
+
+describe('writeJson', () => {
+  it('writes 2-space indented JSON with a trailing newline', () => {
+    const chunks: string[] = [];
+    const original = process.stdout.write;
+    process.stdout.write = ((chunk: string) => { chunks.push(chunk); return true; }) as typeof process.stdout.write;
+    try {
+      writeJson({ a: 1, b: ['x'] });
+    } finally {
+      process.stdout.write = original;
+    }
+    expect(chunks.join('')).toBe(JSON.stringify({ a: 1, b: ['x'] }, null, 2) + '\n');
+  });
+
+  // Regression for #73. The truncation only manifests when stdout is a pipe
+  // and ora has already materialised process.stdout, so this has to run in a
+  // real child process with piped stdout; an in-process stub cannot catch it.
+  it('does not truncate output larger than the 64 KiB pipe buffer', async () => {
+    const script = `
+      import ora from 'ora';
+      import { writeJson } from ${JSON.stringify(import.meta.dir + '/formatter.ts')};
+      ora('working').start().succeed('done');
+      writeJson({ items: Array.from({ length: 4000 }, (_, i) => ({ i, text: 'x'.repeat(200) })) });
+    `;
+    const proc = Bun.spawn(['bun', '-e', script], { stdout: 'pipe', stderr: 'ignore' });
+    const out = await new Response(proc.stdout).text();
+    await proc.exited;
+
+    expect(out.length).toBeGreaterThan(65536);
+    const parsed = JSON.parse(out);
+    expect(parsed.items).toHaveLength(4000);
+  }, 30000);
 });

--- a/src/lib/formatter.test.ts
+++ b/src/lib/formatter.test.ts
@@ -415,18 +415,27 @@ describe('writeJson', () => {
   // and ora has already materialised process.stdout, so this has to run in a
   // real child process with piped stdout; an in-process stub cannot catch it.
   it('does not truncate output larger than the 64 KiB pipe buffer', async () => {
+    const buildPayload = "{ items: Array.from({ length: 4000 }, (_, i) => ({ i, text: 'x'.repeat(200) })) }";
     const script = `
       import ora from 'ora';
       import { writeJson } from ${JSON.stringify(import.meta.dir + '/formatter.ts')};
       ora('working').start().succeed('done');
-      writeJson({ items: Array.from({ length: 4000 }, (_, i) => ({ i, text: 'x'.repeat(200) })) });
+      writeJson(${buildPayload});
     `;
     const proc = Bun.spawn(['bun', '-e', script], { stdout: 'pipe', stderr: 'ignore' });
     const out = await new Response(proc.stdout).text();
     await proc.exited;
 
-    expect(out.length).toBeGreaterThan(65536);
-    const parsed = JSON.parse(out);
-    expect(parsed.items).toHaveLength(4000);
+    // Compare byte-exactly against the same payload built here. A
+    // greater-than check would pass on a truncated build, since a draining
+    // reader lets a nondeterministic amount past the 64 KiB buffer.
+    const expected = JSON.stringify(
+      { items: Array.from({ length: 4000 }, (_, i) => ({ i, text: 'x'.repeat(200) })) },
+      null,
+      2,
+    ) + '\n';
+    expect(expected.length).toBeGreaterThan(65536); // guards the fixture stays big enough to regress
+    expect(out.length).toBe(expected.length);
+    expect(out).toBe(expected);
   }, 30000);
 });

--- a/src/lib/formatter.ts
+++ b/src/lib/formatter.ts
@@ -11,7 +11,13 @@ import type {
 // which materialises Bun's Node-compat WriteStream. Once that exists,
 // console.log routes through the async stream path, and output past the
 // 64 KiB pipe buffer is dropped when the process exits, silently producing
-// truncated JSON with exit code 0. process.stdout.write is unaffected.
+// truncated JSON with exit code 0 (issue #73).
+//
+// process.stdout.write shares that async pipe path; it is not synchronous.
+// It completes only because callers return and let the process exit
+// naturally, which drains pending writes. So: never call process.exit()
+// after writeJson() — doing so truncates at 64 KiB and reintroduces #73.
+// Set process.exitCode and return instead.
 export function writeJson(value: unknown): void {
   process.stdout.write(JSON.stringify(value, null, 2) + '\n');
 }

--- a/src/lib/formatter.ts
+++ b/src/lib/formatter.ts
@@ -4,6 +4,18 @@ import type {
   SavedItem, SearchMatch, ChannelSearchResult, PeopleSearchResult, UnreadChannel,
 } from '../types/index.ts';
 
+// Serialise a value as JSON and write it to stdout.
+//
+// Deliberately process.stdout.write rather than console.log: ora reads
+// process.stdout.isTTY at import time (via cli-cursor -> restore-cursor),
+// which materialises Bun's Node-compat WriteStream. Once that exists,
+// console.log routes through the async stream path, and output past the
+// 64 KiB pipe buffer is dropped when the process exits, silently producing
+// truncated JSON with exit code 0. process.stdout.write is unaffected.
+export function writeJson(value: unknown): void {
+  process.stdout.write(JSON.stringify(value, null, 2) + '\n');
+}
+
 // Format timestamp to human-readable date
 export function formatTimestamp(ts: string): string {
   const timestamp = parseFloat(ts) * 1000;


### PR DESCRIPTION
Closes #73

## WHAT

Route every `--json` code path through a new `writeJson()` helper backed by `process.stdout.write`, instead of `console.log(JSON.stringify(...))`. 9 call sites across `search.ts`, `conversations.ts`, `canvas.ts` and `saved.ts`.

## WHY

Any `--json` command whose payload exceeds 64 KiB had its stdout truncated mid-string when piped, producing unparseable JSON, and still exited 0 so callers could not detect it.

Root cause is not the single-file executable, as the report hypothesised. `ora` reads `process.stdout.isTTY` at import time (via `cli-cursor` -> `restore-cursor@5.1.0`). Touching `process.stdout` materialises Bun's Node-compat `WriteStream`, which moves `console.log` off Bun's synchronous writer onto the async stream path. When stdout is a pipe, the first 64 KiB fills the OS pipe buffer and the remainder is queued, then the process exits before it drains. Every command starts an ora spinner, so every `--json` path was affected.

Evidence, 5.36 MB payload, real pinned tree (ora 8.2.0, restore-cursor 5.1.0):

| Variant | Bytes piped |
|---|---|
| `console.log` with ora | 65536 |
| `console.log` without ora | 5364912 |
| `process.stdout.isTTY` touched before the log | 65536 |
| `process.stdout.isTTY` touched after the log | 5364912 |
| `process.stdout.write()` with ora | 5364912 |
| `console.log` with ora, redirected to a file | 5364912 |

Pipe only. Neither `process.exit` nor `bun build --compile` is involved: plain `bun run` truncates identically, and the `--json` success paths never call `process.exit`.

## HOW

- `src/lib/formatter.ts`: add `writeJson(value)`, with a comment recording why `console.log` is unsafe here so the pattern does not regress.
- Replace all 9 `console.log(JSON.stringify(...))` sites with `writeJson(...)`.
- `src/lib/formatter.test.ts`: two tests. One pins the serialisation shape. The other is the regression test: it spawns a real child process with piped stdout, loads ora, and writes a >64 KiB payload. An in-process stub cannot catch this bug because it only manifests on a real pipe.

## Verification

- Type-check clean; 178 tests pass; `pre-commit run --all-files` fully green; build 92M, under the 150MB CI cap.
- Mutation-checked: reverting `writeJson` to `console.log` fails both new tests, so they genuinely pin the defect rather than passing vacuously.

## Deferred to #77

The same root cause affects stdout paths that are not `--json`, all tracked in #77:

- `canvas read --raw` (`canvas.ts:144`) writes up to 10 MB of HTML via `console.log`. Machine-consumable, so this is the more urgent half.
- Human-readable output: `formatSearchMessages` (`search.ts:71`) and `formatConversationHistory` (`conversations.ts:178,257`) truncate identically when piped to `less`.

Kept out of this PR because #73 is specifically about `--json`, and CLAUDE.md asks changes to stay focused. #77 carries the rest with a `writeOut()` sibling helper.
