### PR TITLE
:bug: fix: stop hardcoding stale version in local bun builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "slackcli",
-  "version": "0.2.0",
+  "version": "0.7.0",
   "description": "A fast, developer-friendly CLI tool for interacting with Slack workspaces",
   "main": "src/index.ts",
   "type": "module",
   "scripts": {
     "dev": "bun run src/index.ts",
-    "build": "bun build --compile --minify --sourcemap --define __APP_VERSION__='\"0.2.2\"' src/index.ts --outfile dist/slackcli",
+    "build": "bun run scripts/build.ts",
     "build:all": "bun run build:linux && bun run build:macos && bun run build:windows",
-    "build:linux": "bun build --compile --minify --target=bun-linux-x64 --define __APP_VERSION__='\"0.2.2\"' src/index.ts --outfile dist/slackcli-linux",
-    "build:macos": "bun build --compile --minify --target=bun-darwin-x64 --define __APP_VERSION__='\"0.2.2\"' src/index.ts --outfile dist/slackcli-macos",
-    "build:windows": "bun build --compile --minify --target=bun-windows-x64 --define __APP_VERSION__='\"0.2.2\"' src/index.ts --outfile dist/slackcli-windows.exe",
+    "build:linux": "bun run scripts/build.ts --target=bun-linux-x64 --outfile=dist/slackcli-linux",
+    "build:macos": "bun run scripts/build.ts --target=bun-darwin-x64 --outfile=dist/slackcli-macos",
+    "build:windows": "bun run scripts/build.ts --target=bun-windows-x64 --outfile=dist/slackcli-windows.exe",
     "test": "bun test",
     "type-check": "bunx tsc --noEmit"
   },

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env bun
+/**
+ * Compile slackcli, injecting package.json version as __APP_VERSION__.
+ * Usage: bun run scripts/build.ts [extra bun build args...]
+ * Example: bun run scripts/build.ts --target=bun-linux-x64 --outfile=dist/slackcli-linux
+ */
+import { join } from 'path';
+import { version } from '../package.json';
+
+const outfileArg = process.argv.find((a) => a.startsWith('--outfile='));
+const outfile = outfileArg?.slice('--outfile='.length) ?? 'dist/slackcli';
+const extraArgs = process.argv.slice(2).filter((a) => !a.startsWith('--outfile='));
+const cwd = join(import.meta.dir, '..');
+
+const result = Bun.spawnSync(
+  [
+    'bun',
+    'build',
+    '--compile',
+    '--minify',
+    '--sourcemap',
+    ...extraArgs,
+    '--define',
+    `__APP_VERSION__=${JSON.stringify(version)}`,
+    'src/index.ts',
+    `--outfile=${outfile}`,
+  ],
+  { stdout: 'inherit', stderr: 'inherit', cwd },
+);
+
+process.exit(result.exitCode ?? 1);

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -10,6 +10,7 @@ import { version } from '../package.json';
 const outfileArg = process.argv.find((a) => a.startsWith('--outfile='));
 const outfile = outfileArg?.slice('--outfile='.length) ?? 'dist/slackcli';
 const extraArgs = process.argv.slice(2).filter((a) => !a.startsWith('--outfile='));
+const hasTarget = extraArgs.some((a) => a.startsWith('--target='));
 const cwd = join(import.meta.dir, '..');
 
 const result = Bun.spawnSync(
@@ -18,7 +19,7 @@ const result = Bun.spawnSync(
     'build',
     '--compile',
     '--minify',
-    '--sourcemap',
+    ...(hasTarget ? [] : ['--sourcemap']),
     ...extraArgs,
     '--define',
     `__APP_VERSION__=${JSON.stringify(version)}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,17 +9,14 @@ import { createUpdateCommand } from './commands/update.ts';
 import { createSavedCommand } from './commands/saved.ts';
 import { createSearchCommand } from './commands/search.ts';
 import { notifyIfUpdateAvailable } from './lib/updater.ts';
-import chalk from 'chalk';
+import { getAppVersion } from './version.ts';
 
 const program = new Command();
-
-// @ts-ignore - This will be replaced at build time
-const APP_VERSION = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev';
 
 program
   .name('slackcli')
   .description('A fast, developer-friendly CLI tool for interacting with Slack workspaces')
-  .version(APP_VERSION);
+  .version(getAppVersion());
 
 // Add commands
 program.addCommand(createAuthCommand());

--- a/src/lib/updater.test.ts
+++ b/src/lib/updater.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
-import { isNewerVersion, isInstalledViaHomebrew, getUpdateCommand } from './updater.ts';
+import { isNewerVersion, isInstalledViaHomebrew, getUpdateCommand, getCurrentVersion } from './updater.ts';
+import packageJson from '../../package.json';
 
 describe('isNewerVersion', () => {
   it('returns true when latest is newer', () => {
@@ -71,5 +72,11 @@ describe('getUpdateCommand', () => {
     Object.defineProperty(process, 'execPath', { value: '/usr/local/bin/slackcli', configurable: true });
     expect(getUpdateCommand()).toBe('slackcli update');
     Object.defineProperty(process, 'execPath', { value: originalExecPath, configurable: true });
+  });
+});
+
+describe('getCurrentVersion', () => {
+  it('matches package.json when not running a baked-in binary', () => {
+    expect(getCurrentVersion()).toBe(packageJson.version);
   });
 });

--- a/src/lib/updater.test.ts
+++ b/src/lib/updater.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { isNewerVersion, isInstalledViaHomebrew, getUpdateCommand, getCurrentVersion } from './updater.ts';
+import { isNewerVersion, isInstalledViaHomebrew, getUpdateCommand, getCurrentVersion, performUpdate } from './updater.ts';
 import packageJson from '../../package.json';
 
 describe('isNewerVersion', () => {
@@ -78,5 +78,15 @@ describe('getUpdateCommand', () => {
 describe('getCurrentVersion', () => {
   it('matches package.json when not running a baked-in binary', () => {
     expect(getCurrentVersion()).toBe(packageJson.version);
+  });
+});
+
+describe('performUpdate', () => {
+  const originalExecPath = process.execPath;
+
+  it('bails early when running under bun without downloading', async () => {
+    Object.defineProperty(process, 'execPath', { value: '/Users/me/.bun/bin/bun', configurable: true });
+    await expect(performUpdate()).resolves.toBeUndefined();
+    Object.defineProperty(process, 'execPath', { value: originalExecPath, configurable: true });
   });
 });

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -4,6 +4,7 @@ import { tmpdir, homedir } from 'os';
 import { join } from 'path';
 import chalk from 'chalk';
 import { info, success, error as logError } from './formatter.ts';
+import { getAppVersion, isRunningUnderBun } from '../version.ts';
 
 const CONFIG_DIR = join(homedir(), '.config', 'slackcli');
 const UPDATE_CACHE_FILE = join(CONFIG_DIR, 'update-check.json');
@@ -15,8 +16,7 @@ interface UpdateCache {
 }
 
 const GITHUB_REPO = 'shaharia-lab/slackcli';
-// @ts-ignore - This will be replaced at build time
-const CURRENT_VERSION = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev';
+const CURRENT_VERSION = getAppVersion();
 
 interface GitHubRelease {
   tag_name: string;
@@ -212,6 +212,11 @@ export function getUpdateCommand(): string {
 // Show a one-line update notification after the command finishes (via beforeExit),
 // and refresh the cache in the background if it is stale.
 export function notifyIfUpdateAvailable(): void {
+  // Local `bun run` / source checkout — not a release binary; skip self-update nags.
+  if (isRunningUnderBun()) {
+    return;
+  }
+
   const cache = readUpdateCache();
   const now = Date.now();
 

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -113,6 +113,11 @@ export async function checkForUpdates(silent: boolean = true): Promise<{
 
 // Download and install update
 export async function performUpdate(): Promise<void> {
+  if (isRunningUnderBun()) {
+    info('Running from source (bun) — update with `git pull`, not `slackcli update`.');
+    return;
+  }
+
   info(`Checking for updates...`);
 
   const release = await fetchLatestRelease();

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test';
+import { getAppVersion, isRunningUnderBun } from './version.ts';
+import packageJson from '../package.json';
+
+describe('getAppVersion', () => {
+  it('returns package.json version when __APP_VERSION__ is not baked in', () => {
+    expect(getAppVersion()).toBe(packageJson.version);
+  });
+});
+
+describe('isRunningUnderBun', () => {
+  const originalExecPath = process.execPath;
+
+  it('returns true when execPath is the Bun interpreter', () => {
+    Object.defineProperty(process, 'execPath', { value: '/Users/me/.bun/bin/bun', configurable: true });
+    expect(isRunningUnderBun()).toBe(true);
+    Object.defineProperty(process, 'execPath', { value: originalExecPath, configurable: true });
+  });
+
+  it('returns true for bun.exe on Windows', () => {
+    Object.defineProperty(process, 'execPath', { value: 'C:\\Users\\me\\.bun\\bin\\bun.exe', configurable: true });
+    expect(isRunningUnderBun()).toBe(true);
+    Object.defineProperty(process, 'execPath', { value: originalExecPath, configurable: true });
+  });
+
+  it('returns false for a compiled slackcli binary', () => {
+    Object.defineProperty(process, 'execPath', { value: '/usr/local/bin/slackcli', configurable: true });
+    expect(isRunningUnderBun()).toBe(false);
+    Object.defineProperty(process, 'execPath', { value: originalExecPath, configurable: true });
+  });
+});

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,17 @@
+import packageJson from '../package.json';
+
+declare const __APP_VERSION__: string | undefined;
+
+/** App version: bake-time define for compiled binaries, else package.json. */
+export function getAppVersion(): string {
+  if (typeof __APP_VERSION__ !== 'undefined') {
+    return __APP_VERSION__;
+  }
+  return packageJson.version;
+}
+
+/** True when running via the Bun interpreter (source / `bun run`), not a compiled binary. */
+export function isRunningUnderBun(): boolean {
+  const base = process.execPath.split(/[/\\]/).pop() ?? '';
+  return base === 'bun' || base === 'bun.exe';
+}


### PR DESCRIPTION
Fixes #79

Local bun builds were baking in `0.2.2`, so even current source looked outdated and showed an update warning.

Now the version comes from package.json, and we skip the update nag when running under bun from source.