### PR TITLE
ci: fail release when tag mismatches package.json version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,29 @@ permissions:
   contents: read
 
 jobs:
+  # Fail fast if the pushed tag disagrees with package.json, so we never
+  # release binaries whose baked-in version drifts from the source tree (#81).
+  verify-version:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Verify tag matches package.json version
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          PKG_VERSION="$(jq -r .version package.json)"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag v${TAG_VERSION} does not match package.json version ${PKG_VERSION}"
+            echo "Fix: bump package.json to \"${TAG_VERSION}\" on main, then delete and re-push the tag."
+            exit 1
+          fi
+          echo "Tag v${TAG_VERSION} matches package.json version ${PKG_VERSION}"
+
   build:
+    needs: verify-version
     permissions:
       contents: read
     strategy:


### PR DESCRIPTION
Closes #81

## WHAT
Adds a `verify-version` job to `release.yml` that runs before the build matrix and fails the release if the pushed tag (minus `v`) doesn't match `package.json`'s `version`.

## WHY
`release.yml` bakes `__APP_VERSION__` from the git tag but never verifies `package.json`, so the two silently drift after each release (#79, #80). This gate catches a forgotten bump in seconds, before any binaries are built.

## HOW
- New first job `verify-version` (ubuntu-latest, `contents: read`, pinned checkout) comparing `${GITHUB_REF#refs/tags/v}` to `jq -r .version package.json`; mismatch → `::error` with both versions + fix instructions, exit 1.
- `build` now `needs: verify-version`, so the 5-leg matrix never starts on a mismatch.

## Verification
- YAML validated + pre-commit hooks pass
- Comparison logic exercised locally for both match and mismatch paths
- Full end-to-end validation happens on the next `v*.*.*` tag push