### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slackcli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A fast, developer-friendly CLI tool for interacting with Slack workspaces",
   "main": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
Closes #83

Bumps `package.json` to `0.7.1` for the v0.7.1 patch release. After merge, tag `v0.7.1` on main triggers the Release workflow (binaries + GitHub release + Homebrew tap).

Changes since v0.7.0:
- fix: prevent `--json` output truncation at 64 KiB pipe buffer (#76)
- fix: stop hardcoding stale version in local bun builds (#80)
- fix(deps): pin `form-data` to >=4.0.6 — GHSA-hmw2-7cc7-3qxx (#74)
- ci: fail release when tag mismatches package.json version (#82)