### PR TITLE
feat(messages): add edit command to update existing messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ slackcli messages send --recipient-id=C1234567890 --thread-ts=1234567890.123456 
 # Send a message with a file attachment
 slackcli messages send --recipient-id=C1234567890 --message="Here is the file" --file=./report.pdf
 
+# Edit an existing message you posted
+slackcli messages edit --channel-id=C1234567890 --timestamp=1234567890.123456 --message="Corrected message"
+
 # Create a draft message in a channel (only works with browser session tokens)
 slackcli messages draft --recipient-id=C1234567890 --message="Hello team!"
 
@@ -217,6 +220,8 @@ slackcli messages react --channel-id=C1234567890 --timestamp=1234567890.123456 -
 ```
 
 File uploads require Slack workspace permissions that allow file upload, such as `files:write` for standard Slack app tokens.
+
+Editing only works on messages posted by the authenticated user or app; ephemeral messages cannot be edited.
 
 **Common emoji names:**
 - `+1` or `thumbsup` - 👍

--- a/src/commands/messages.test.ts
+++ b/src/commands/messages.test.ts
@@ -8,4 +8,16 @@ describe('messages command', () => {
 
     expect(send?.options.some((option) => option.long === '--file')).toBe(true);
   });
+
+  it('exposes an edit subcommand requiring channel, timestamp, and message', () => {
+    const messages = createMessagesCommand();
+    const edit = messages.commands.find((command) => command.name() === 'edit');
+
+    expect(edit).toBeDefined();
+    const required = edit?.options
+      .filter((option) => option.mandatory)
+      .map((option) => option.long)
+      .sort();
+    expect(required).toEqual(['--channel-id', '--message', '--timestamp']);
+  });
 });

--- a/src/commands/messages.ts
+++ b/src/commands/messages.ts
@@ -80,6 +80,35 @@ export function createMessagesCommand(): Command {
       }
     });
 
+  // Edit an existing message
+  messages
+    .command('edit')
+    .description('Update the text of an existing message you posted')
+    .requiredOption('--channel-id <id>', 'Channel ID where the message is')
+    .requiredOption('--timestamp <ts>', 'Message timestamp')
+    .requiredOption('--message <text>', 'New message text content')
+    .option('--workspace <id|name>', 'Workspace to use')
+    .action(async (options) => {
+      const spinner = ora('Updating message...').start();
+
+      try {
+        const client = await getAuthenticatedClient(options.workspace);
+
+        const response = await client.updateMessage(
+          options.channelId,
+          options.timestamp,
+          options.message,
+        );
+
+        spinner.succeed('Message updated successfully!');
+        success(`Message timestamp: ${response.ts}`);
+      } catch (err: any) {
+        spinner.fail('Failed to update message');
+        error(err.message);
+        process.exit(1);
+      }
+    });
+
   // Create draft message
   messages
     .command('draft')

--- a/src/lib/slack-client.test.ts
+++ b/src/lib/slack-client.test.ts
@@ -36,6 +36,10 @@ class TestSlackClient extends SlackClient {
       };
     }
 
+    if (method === 'chat.update') {
+      return { ok: true, channel: params.channel, ts: params.ts, text: params.text };
+    }
+
     throw new Error(`Unexpected method: ${method}`);
   }
 }
@@ -111,5 +115,21 @@ describe('SlackClient.uploadFileExternal', () => {
     ).rejects.toThrow('File not found: /tmp/slackcli-missing-file.txt');
 
     expect(client.calls).toEqual([]);
+  });
+});
+
+describe('SlackClient.updateMessage', () => {
+  it('calls chat.update with the channel, timestamp, and new text', async () => {
+    const client = new TestSlackClient();
+
+    const response = await client.updateMessage('C123', '1234567890.123456', 'Corrected message');
+
+    expect(client.calls).toEqual([
+      {
+        method: 'chat.update',
+        params: { channel: 'C123', ts: '1234567890.123456', text: 'Corrected message' },
+      },
+    ]);
+    expect(response.ts).toBe('1234567890.123456');
   });
 });

--- a/src/lib/slack-client.ts
+++ b/src/lib/slack-client.ts
@@ -151,6 +151,10 @@ export class SlackClient {
     return this.request('chat.postMessage', params);
   }
 
+  async updateMessage(channel: string, ts: string, text: string): Promise<any> {
+    return this.request('chat.update', { channel, ts, text });
+  }
+
   async uploadFileExternal(channel: string, filePath: string, options: {
     initial_comment?: string;
     thread_ts?: string;


### PR DESCRIPTION
## Summary

Adds a `slackcli messages edit` command to correct an already-sent message, closing the gap where the CLI could `send` and `react` but not update.

```bash
slackcli messages edit \
  --channel-id=C1234567890 \
  --timestamp=1234567890.123456 \
  --message="Corrected message"
```

## Changes

- `SlackClient.updateMessage()` wrapping Slack's `chat.update` (works with both standard and browser auth).
- `messages edit` command with required `--channel-id`, `--timestamp`, `--message`, plus the standard `--workspace` selector. Message identification and output mirror `messages react`.
- Tests: client-level `chat.update` call assertion + command-shape test for the required options.
- README documented under Message Commands, with a note that only the authenticated user/app's own (non-ephemeral) messages can be edited.

## Notes

- Slack only allows updating messages posted by the authenticated user/app; ephemeral messages can't be updated with `chat.update`. Those constraints surface as normal Slack API errors.

Closes #87