### PR TITLE
:sparkles: feat(auth): add login-auto for automated browser token capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,3 @@ secrets/
 credentials/
 *.secret
 
-# Tribunal verification scratch (not a deliverable)
-.tribunal/

--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,3 @@ docs/internal/
 secrets/
 credentials/
 *.secret
-

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ docs/internal/
 secrets/
 credentials/
 *.secret
+
+# Tribunal verification scratch (not a deliverable)
+.tribunal/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Drives an already-installed Chrome/Edge/Chromium/Brave over the Chrome DevTools Protocol; **no new runtime dependency** and no change to binary size
   - Uses a dedicated browser profile (required: Chrome 136+ refuses remote debugging against the default profile), so only the first run needs interaction
   - `--workspace-url`, `--timeout`, `--headless`; `SLACKCLI_BROWSER` and `SLACKCLI_BROWSER_PROFILE` env overrides
-  - Typed failure reasons (browser not found, launch timeout, capture timeout, missing cookie) each with actionable guidance
+  - Typed failure reasons (browser not found, launch timeout, capture timeout, browser closed, missing cookie) each with actionable guidance
+  - Workspace URLs are gated to `https://` on a `slack.com` host before any session cookie is sent to them
+
+### Changed
+- `auth logout` now also deletes the `login-auto` browser profile, which is a credential store in its own right — while it exists, `login-auto` re-mints working tokens without prompting. Use `--keep-browser-session` to retain the old behaviour.
 
 ## [0.2.0] - 2026-01-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Typed failure reasons (browser not found, launch timeout, capture timeout, browser closed, missing cookie) each with actionable guidance
   - Workspace URLs are gated to `https://` on a `slack.com` host before any session cookie is sent to them
 
+### Fixed
+- `login-auto` now asks Chrome to close itself (CDP `Browser.close`) before falling back to signals, then sweeps any helper the browser leaves behind — previously each run stranded ~5 Chrome processes. Order matters: sweeping *instead of* a clean shutdown leaves the profile unopenable.
+
 ### Changed
 - `auth logout` now also deletes the `login-auto` browser profile, which is a credential store in its own right — while it exists, `login-auto` re-mints working tokens without prompting. Use `--keep-browser-session` to retain the old behaviour.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Automatic browser login** (`auth login-auto`): sign into Slack in a browser and let SlackCLI capture the `xoxd`/`xoxc` tokens — no DevTools, no copy-paste
+  - Enrols every workspace the user is signed into from a single sign-in
+  - Drives an already-installed Chrome/Edge/Chromium/Brave over the Chrome DevTools Protocol; **no new runtime dependency** and no change to binary size
+  - Uses a dedicated browser profile (required: Chrome 136+ refuses remote debugging against the default profile), so only the first run needs interaction
+  - `--workspace-url`, `--timeout`, `--headless`; `SLACKCLI_BROWSER` and `SLACKCLI_BROWSER_PROFILE` env overrides
+  - Typed failure reasons (browser not found, launch timeout, capture timeout, missing cookie) each with actionable guidance
+
 ## [0.2.0] - 2026-01-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A fast, developer-friendly command-line interface tool for interacting with Slac
 ## Features
 
 - 🔐 **Dual Authentication Support**: Standard Slack tokens (xoxb/xoxp) or browser tokens (xoxd/xoxc)
+- 🪄 **Automatic Browser Login**: `auth login-auto` — sign into Slack in a browser and the tokens are captured for you, no DevTools, no copy-paste
 - 🎯 **Easy Token Extraction**: Automatically parse tokens from browser cURL commands
 - 🏢 **Multi-Workspace Management**: Manage multiple Slack workspaces with ease
 - 💬 **Conversation Management**: List channels, read messages, send messages
@@ -181,6 +182,12 @@ This automatically extracts:
 ### Authentication Commands
 
 ```bash
+# Sign in via a browser; tokens are captured automatically
+slackcli auth login-auto
+
+# Refresh tokens later without any interaction (profile stays signed in)
+slackcli auth login-auto --headless
+
 # List all authenticated workspaces
 slackcli auth list
 
@@ -190,8 +197,11 @@ slackcli auth set-default T1234567
 # Remove a workspace
 slackcli auth remove T1234567
 
-# Logout from all workspaces
+# Logout from all workspaces (also clears the login-auto browser profile)
 slackcli auth logout
+
+# Logout but keep the browser signed in
+slackcli auth logout --keep-browser-session
 ```
 
 ### Conversation Commands

--- a/README.md
+++ b/README.md
@@ -96,9 +96,33 @@ Create a Slack app at [api.slack.com/apps](https://api.slack.com/apps) and obtai
 slackcli auth login --token=xoxb-YOUR-TOKEN --workspace-name="My Team"
 ```
 
-### 2. Browser Session Tokens (Quick Setup)
+### 2. Automatic Browser Login (Easiest)
 
-Extract tokens from your browser session. No Slack app creation required!
+Sign into Slack in a browser and let SlackCLI capture the tokens. No Slack app, no DevTools, no copy-paste.
+
+```bash
+slackcli auth login-auto
+```
+
+A browser window opens on Slack. Sign in as you normally would, and SlackCLI enrols **every workspace you are signed into** — one sign-in covers them all.
+
+| Option | Purpose |
+|---|---|
+| `--workspace-url <url>` | Open a specific workspace instead of the Slack home |
+| `--timeout <seconds>` | How long to wait for sign-in (default `300`) |
+| `--headless` | No visible window — only works once you are already signed in |
+| `SLACKCLI_BROWSER` | Path to a browser, if yours is not auto-detected |
+| `SLACKCLI_BROWSER_PROFILE` | Override the profile directory |
+
+**Requirements:** Chrome, Edge, Chromium, or Brave installed. Nothing is downloaded and no extra dependency is installed — SlackCLI drives the browser you already have.
+
+**Why you sign in again the first time.** SlackCLI runs the browser against its own profile in `~/.config/slackcli/browser-profile`, separate from your everyday browsing. It has to: since Chrome 136 the browser refuses remote debugging against the default profile, so your existing session cannot be reused. The profile persists, so **only the first run needs interaction** — after that the window opens and closes on its own.
+
+**Security notes.** Tokens are never printed. While the browser is open it exposes a DevTools port on loopback that any local process could connect to; SlackCLI closes the browser as soon as capture finishes. Credentials land in `~/.config/slackcli/workspaces.json` (mode `0600`).
+
+### 3. Browser Session Tokens (Manual)
+
+Extract tokens from your browser session by hand. No Slack app creation required!
 
 ```bash
 # Step 1: Get extraction guide
@@ -122,7 +146,7 @@ slackcli auth login-browser \
    - `xoxd` token from Cookie header (d=xoxd-...)
    - `xoxc` token from request payload ("token":"xoxc-...")
 
-### 3. Easy Method: Parse cURL Command (Recommended for Browser Tokens)
+### 4. Parse cURL Command
 
 The easiest way to extract browser tokens is to copy a Slack API request as cURL and let SlackCLI parse it automatically!
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,13 @@ A browser window opens on Slack. Sign in as you normally would, and SlackCLI enr
 
 **Why you sign in again the first time.** SlackCLI runs the browser against its own profile in `~/.config/slackcli/browser-profile`, separate from your everyday browsing. It has to: since Chrome 136 the browser refuses remote debugging against the default profile, so your existing session cannot be reused. The profile persists, so **only the first run needs interaction** — after that the window opens and closes on its own.
 
-**Security notes.** Tokens are never printed. While the browser is open it exposes a DevTools port on loopback that any local process could connect to; SlackCLI closes the browser as soon as capture finishes. Credentials land in `~/.config/slackcli/workspaces.json` (mode `0600`).
+**Security notes.**
+
+- Token values are never printed.
+- **The browser profile is a credential store.** While it exists, `login-auto` can re-mint working tokens with no prompt. `slackcli auth logout` therefore deletes it along with `workspaces.json`; pass `--keep-browser-session` to keep it signed in.
+- Only `https://` URLs on a `slack.com` host are ever paired with your session cookie — a URL read from the browser that points anywhere else is refused.
+- While the browser is open it exposes a DevTools port on loopback that any local process could connect to. SlackCLI closes the browser as soon as capture finishes, and also on `Ctrl-C` or termination.
+- Credentials land in `~/.config/slackcli/workspaces.json` (mode `0600`); the profile directory is `0700` on macOS and Linux (Windows uses ACL defaults).
 
 ### 3. Browser Session Tokens (Manual)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A fast, developer-friendly command-line interface tool for interacting with Slac
 ## Features
 
 - 🔐 **Dual Authentication Support**: Standard Slack tokens (xoxb/xoxp) or browser tokens (xoxd/xoxc)
-- 🪄 **Automatic Browser Login**: `auth login-auto` — sign into Slack in a browser and the tokens are captured for you, no DevTools, no copy-paste
+- 🪄 **Automatic Browser Login**: sign into Slack in a browser and the tokens are captured for you
 - 🎯 **Easy Token Extraction**: Automatically parse tokens from browser cURL commands
 - 🏢 **Multi-Workspace Management**: Manage multiple Slack workspaces with ease
 - 💬 **Conversation Management**: List channels, read messages, send messages

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -218,7 +218,15 @@ export function createAuthCommand(): Command {
         if (options.keepBrowserSession) {
           warning('Browser session kept — "auth login-auto" can still sign in without prompting.');
         } else {
-          await clearBrowserProfile();
+          const cleared = await clearBrowserProfile();
+          // Never silent about a profile left behind: it is a live credential,
+          // and a logout the user believes is complete would not be.
+          if (!cleared.cleared && cleared.reason === 'not_ours') {
+            warning(
+              `Left ${cleared.path} alone — slackcli did not create it, so it was not deleted.`
+            );
+            console.log(chalk.dim('   Remove it yourself if it holds a Slack session.'));
+          }
         }
 
         success('Logged out from all workspaces');

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -13,6 +13,8 @@ import chalk from 'chalk';
 import { parseCurlCommand, CurlParseError, looksLikeCurlCommand } from '../lib/curl-parser.ts';
 import { readClipboard } from '../lib/clipboard.ts';
 import { readInteractiveInput, isInteractiveTerminal, hasPipedInput } from '../lib/interactive-input.ts';
+import { clearBrowserProfile } from '../lib/browser-launcher.ts';
+import { isSlackWorkspaceUrl } from '../lib/browser-auth.ts';
 
 export function createAuthCommand(): Command {
   const auth = new Command('auth')
@@ -89,6 +91,14 @@ export function createAuthCommand(): Command {
       const timeoutSeconds = Number.parseInt(options.timeout, 10);
       if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0) {
         error('--timeout must be a positive number of seconds');
+        process.exit(1);
+      }
+
+      // Checked here as well as at the launcher: this value becomes browser
+      // argv, and it is the host the session cookie would be sent to.
+      if (options.workspaceUrl && !isSlackWorkspaceUrl(options.workspaceUrl)) {
+        error('--workspace-url must be an https URL on a slack.com host');
+        console.log(chalk.dim('   e.g. https://myteam.slack.com'));
         process.exit(1);
       }
 
@@ -197,9 +207,20 @@ export function createAuthCommand(): Command {
   auth
     .command('logout')
     .description('Logout from all workspaces')
-    .action(async () => {
+    .option('--keep-browser-session', 'Leave the login-auto browser profile signed in')
+    .action(async (options) => {
       try {
         await clearAllWorkspaces();
+
+        // The browser profile is a credential store in its own right: while it
+        // exists, `login-auto` re-mints valid tokens with no interaction. A
+        // logout that left it behind would report a logout it did not perform.
+        if (options.keepBrowserSession) {
+          warning('Browser session kept — "auth login-auto" can still sign in without prompting.');
+        } else {
+          await clearBrowserProfile();
+        }
+
         success('Logged out from all workspaces');
       } catch (err: any) {
         error('Failed to logout', err.message);

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -88,8 +88,12 @@ export function createAuthCommand(): Command {
     .option('--headless', 'Run without a visible window (only works if already signed in)')
     .option('--timeout <seconds>', 'How long to wait for sign-in', '300')
     .action(async (options) => {
-      const timeoutSeconds = Number.parseInt(options.timeout, 10);
-      if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0) {
+      const timeoutSeconds = Number(options.timeout);
+      if (
+        !Number.isFinite(timeoutSeconds) ||
+        !Number.isInteger(timeoutSeconds) ||
+        timeoutSeconds <= 0
+      ) {
         error('--timeout must be a positive number of seconds');
         process.exit(1);
       }

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import ora from 'ora';
-import { authenticateStandard, authenticateBrowser } from '../lib/auth.ts';
+import { authenticateStandard, authenticateBrowser, authenticateAuto, AutoLoginError } from '../lib/auth.ts';
 import {
   getAllWorkspaces,
   setDefaultWorkspace,
@@ -8,7 +8,7 @@ import {
   clearAllWorkspaces,
   getDefaultWorkspaceId,
 } from '../lib/workspaces.ts';
-import { success, error, info, formatWorkspace } from '../lib/formatter.ts';
+import { success, error, info, warning, formatWorkspace } from '../lib/formatter.ts';
 import chalk from 'chalk';
 import { parseCurlCommand, CurlParseError, looksLikeCurlCommand } from '../lib/curl-parser.ts';
 import { readClipboard } from '../lib/clipboard.ts';
@@ -74,6 +74,64 @@ export function createAuthCommand(): Command {
       } catch (err: any) {
         spinner.fail('Authentication failed');
         error(err.message);
+        process.exit(1);
+      }
+    });
+
+  // Login by capturing tokens from a browser session
+  auth
+    .command('login-auto')
+    .description('Login by signing into Slack in a browser (captures tokens automatically)')
+    .option('--workspace-url <url>', 'Open a specific workspace (e.g., https://myteam.slack.com)')
+    .option('--headless', 'Run without a visible window (only works if already signed in)')
+    .option('--timeout <seconds>', 'How long to wait for sign-in', '300')
+    .action(async (options) => {
+      const timeoutSeconds = Number.parseInt(options.timeout, 10);
+      if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0) {
+        error('--timeout must be a positive number of seconds');
+        process.exit(1);
+      }
+
+      const spinner = ora('Launching browser...').start();
+
+      try {
+        const result = await authenticateAuto({
+          headless: options.headless === true,
+          workspaceUrl: options.workspaceUrl,
+          timeoutMs: timeoutSeconds * 1000,
+          // The spinner owns the terminal line, so progress has to go through it.
+          onProgress: (line) => {
+            spinner.text = line;
+          },
+        });
+
+        if (result.saved.length === 0) {
+          spinner.fail('No workspaces could be authenticated');
+          result.failed.forEach((f) => error(`${f.workspaceUrl}: ${f.error}`));
+          process.exit(1);
+        }
+
+        spinner.succeed(
+          `Authenticated ${result.saved.length} workspace${result.saved.length === 1 ? '' : 's'}`
+        );
+
+        result.saved.forEach((config) => {
+          success(`${config.workspace_name} ${chalk.dim(`(${config.workspace_id})`)}`);
+        });
+
+        // Partial success is still success — surface the misses without
+        // discarding the workspaces that did authenticate.
+        result.failed.forEach((f) => {
+          warning(`Skipped ${f.workspaceUrl}: ${f.error}`);
+        });
+      } catch (err: any) {
+        spinner.fail('Automatic login failed');
+        error(err.message);
+
+        if (err instanceof AutoLoginError && err.reason === 'browser_not_found') {
+          console.log(chalk.yellow('\n💡 Or extract tokens manually:'));
+          console.log(chalk.cyan('   slackcli auth parse-curl --login\n'));
+        }
         process.exit(1);
       }
     });
@@ -154,7 +212,11 @@ export function createAuthCommand(): Command {
     .command('extract-tokens')
     .description('Show guide for extracting browser tokens')
     .action(() => {
-      console.log(chalk.bold('\n🔍 How to Extract Browser Tokens:\n'));
+      console.log(chalk.bold('\n✨ Easiest: let slackcli do it\n'));
+      console.log(chalk.cyan('   slackcli auth login-auto'));
+      console.log(chalk.dim('   Opens a browser, you sign in, tokens are captured automatically.'));
+      console.log(chalk.dim('   Enrols every workspace you are signed into.\n'));
+      console.log(chalk.bold('🔍 Or extract them by hand:\n'));
       console.log('1. Open your Slack workspace in a web browser');
       console.log('2. Open Developer Tools (F12 or Cmd+Option+I)');
       console.log('3. Go to the Network tab');

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -6,6 +6,7 @@ import {
   captureSlackTokens,
   openBrowserSession,
   SLACK_CLIENT_URL,
+  isSlackWorkspaceUrl,
   type CaptureFailure,
 } from './browser-auth.ts';
 import type { BrowserSessionFailure } from './browser-auth.ts';
@@ -157,6 +158,17 @@ export async function authenticateAuto(
   const failed: AutoLoginResult['failed'] = [];
 
   for (const workspace of capture.workspaces) {
+    // Last gate before the session cookie is sent anywhere. The extractors
+    // already filter, but this is the line that decides where a live
+    // credential travels, so it does not delegate that check.
+    if (!isSlackWorkspaceUrl(workspace.workspaceUrl)) {
+      failed.push({
+        workspaceUrl: workspace.workspaceUrl,
+        error: 'Refused: not an https slack.com workspace URL',
+      });
+      continue;
+    }
+
     try {
       const config = await authenticateBrowser(
         capture.xoxd,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,6 +2,13 @@ import { SlackClient } from './slack-client.ts';
 import { addWorkspace, getWorkspace } from './workspaces.ts';
 import type { StandardAuthConfig, BrowserAuthConfig, WorkspaceConfig } from '../types/index.ts';
 import { extractSlackWorkspaceName } from './curl-parser.ts';
+import {
+  captureSlackTokens,
+  openBrowserSession,
+  SLACK_CLIENT_URL,
+  type CaptureFailure,
+} from './browser-auth.ts';
+import type { BrowserSessionFailure } from './browser-auth.ts';
 
 // Authenticate with standard token
 export async function authenticateStandard(
@@ -77,6 +84,96 @@ export async function authenticateBrowser(
   } catch (error: any) {
     throw new Error(`Authentication failed: ${error.message}`);
   }
+}
+
+export type AutoLoginFailure = BrowserSessionFailure | CaptureFailure;
+
+export interface AutoLoginResult {
+  saved: WorkspaceConfig[];
+  failed: Array<{ workspaceUrl: string; error: string }>;
+}
+
+export interface AutoLoginOptions {
+  headless?: boolean;
+  workspaceUrl?: string;
+  timeoutMs?: number;
+  onProgress?: (line: string) => void;
+}
+
+/** Thrown when the browser capture never produced tokens. Carries the reason
+ *  so the command layer can print guidance specific to what went wrong. */
+export class AutoLoginError extends Error {
+  public reason: AutoLoginFailure;
+
+  constructor(reason: AutoLoginFailure, message: string) {
+    super(message);
+    this.name = 'AutoLoginError';
+    this.reason = reason;
+  }
+}
+
+/**
+ * Log in by capturing tokens from a browser the user signs into.
+ *
+ * Verification and persistence deliberately route through
+ * `authenticateBrowser` — the same path `login-browser` and `parse-curl` use
+ * — so a workspace enrolled this way is indistinguishable from one added by
+ * hand, and there is exactly one place that decides a token is valid.
+ *
+ * Per-workspace failures are collected rather than thrown: with several
+ * workspaces captured at once, one stale token must not discard the rest.
+ */
+export async function authenticateAuto(
+  options: AutoLoginOptions = {}
+): Promise<AutoLoginResult> {
+  const onProgress = options.onProgress ?? (() => {});
+
+  const opened = await openBrowserSession({
+    headless: options.headless ?? false,
+    startUrl: options.workspaceUrl ?? SLACK_CLIENT_URL,
+  });
+  if (!opened.ok) {
+    throw new AutoLoginError(opened.reason, opened.message);
+  }
+
+  let capture;
+  try {
+    capture = await captureSlackTokens(opened.session, {
+      ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
+      ...(options.workspaceUrl ? { startUrl: options.workspaceUrl } : {}),
+      onProgress,
+    });
+  } finally {
+    // The browser holds a live session; close it whether or not we got what
+    // we came for.
+    await opened.stop();
+  }
+
+  if (!capture.ok) {
+    throw new AutoLoginError(capture.reason, capture.message);
+  }
+
+  const saved: WorkspaceConfig[] = [];
+  const failed: AutoLoginResult['failed'] = [];
+
+  for (const workspace of capture.workspaces) {
+    try {
+      const config = await authenticateBrowser(
+        capture.xoxd,
+        workspace.xoxc,
+        workspace.workspaceUrl,
+        workspace.teamName
+      );
+      saved.push(config);
+    } catch (err: any) {
+      failed.push({
+        workspaceUrl: workspace.workspaceUrl,
+        error: err?.message ?? 'Unknown error',
+      });
+    }
+  }
+
+  return { saved, failed };
 }
 
 // Get authenticated client for workspace

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -140,6 +140,7 @@ export async function authenticateAuto(
   let capture;
   try {
     capture = await captureSlackTokens(opened.session, {
+      headless: options.headless ?? false,
       ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
       ...(options.workspaceUrl ? { startUrl: options.workspaceUrl } : {}),
       onProgress,

--- a/src/lib/browser-auth.test.ts
+++ b/src/lib/browser-auth.test.ts
@@ -1,0 +1,375 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  captureSlackTokens,
+  extractWorkspacesFromLocalConfig,
+  extractXoxcFromPostData,
+  extractXoxdFromCookies,
+  mergeWorkspaces,
+  slackOriginFromApiUrl,
+  SLACK_CLIENT_URL,
+} from './browser-auth';
+import type { CdpSession } from './cdp-client';
+
+// Anonymized bodies matching the three encodings Slack's web client uses.
+const MULTIPART_BODY =
+  '------WebKitFormBoundaryAbc\r\n' +
+  'Content-Disposition: form-data; name="token"\r\n\r\n' +
+  'xoxc-111222333-444555666-abcdefghij\r\n' +
+  '------WebKitFormBoundaryAbc\r\n' +
+  'Content-Disposition: form-data; name="channel"\r\n\r\n' +
+  'C038K56TGNB\r\n' +
+  '------WebKitFormBoundaryAbc--\r\n';
+
+const JSON_BODY = '{"token":"xoxc-json-test-111-222","as_admin":false}';
+
+const URLENCODED_BODY =
+  'token=xoxc-urlencoded-999-888&channel=C123456&limit=100';
+
+const LOCAL_CONFIG = JSON.stringify({
+  teams: {
+    T111: {
+      id: 'T111',
+      name: 'Alpha Team',
+      domain: 'alpha',
+      url: 'https://alpha.slack.com/',
+      token: 'xoxc-alpha-token-111',
+    },
+    T222: {
+      id: 'T222',
+      name: 'Beta Team',
+      domain: 'beta',
+      token: 'xoxc-beta-token-222',
+    },
+  },
+});
+
+describe('extractXoxcFromPostData', () => {
+  it('extracts a token from a multipart/form-data body', () => {
+    expect(extractXoxcFromPostData(MULTIPART_BODY)).toBe(
+      'xoxc-111222333-444555666-abcdefghij'
+    );
+  });
+
+  it('extracts a token from a JSON body', () => {
+    expect(extractXoxcFromPostData(JSON_BODY)).toBe('xoxc-json-test-111-222');
+  });
+
+  it('extracts a token from a urlencoded body', () => {
+    expect(extractXoxcFromPostData(URLENCODED_BODY)).toBe(
+      'xoxc-urlencoded-999-888'
+    );
+  });
+
+  it('extracts a urlencoded token that is not the first field', () => {
+    expect(extractXoxcFromPostData('channel=C1&token=xoxc-second-field-1')).toBe(
+      'xoxc-second-field-1'
+    );
+  });
+
+  it('returns null when the body carries no token', () => {
+    expect(extractXoxcFromPostData('channel=C123456&limit=100')).toBeNull();
+  });
+
+  it('returns null for an empty body', () => {
+    expect(extractXoxcFromPostData('')).toBeNull();
+  });
+
+  it('does not mistake an xoxb token for a browser token', () => {
+    expect(extractXoxcFromPostData('token=xoxb-bot-token-123')).toBeNull();
+  });
+});
+
+describe('extractXoxdFromCookies', () => {
+  it('finds and decodes the d cookie', () => {
+    const cookies = [
+      { name: 'lc', domain: '.slack.com', value: '1770041685' },
+      { name: 'd', domain: '.slack.com', value: 'xoxd-plain-token-123' },
+    ];
+    expect(extractXoxdFromCookies(cookies)).toBe('xoxd-plain-token-123');
+  });
+
+  it('percent-decodes an encoded cookie value', () => {
+    const cookies = [
+      { name: 'd', domain: '.slack.com', value: 'xoxd-encoded%2Btoken%2Fwith%3Dspecial' },
+    ];
+    expect(extractXoxdFromCookies(cookies)).toBe('xoxd-encoded+token/with=special');
+  });
+
+  it('ignores a d cookie set on a non-Slack domain', () => {
+    const cookies = [{ name: 'd', domain: '.example.com', value: 'xoxd-not-slack' }];
+    expect(extractXoxdFromCookies(cookies)).toBeNull();
+  });
+
+  it('ignores a d cookie whose value is not an xoxd token', () => {
+    const cookies = [{ name: 'd', domain: '.slack.com', value: 'something-else' }];
+    expect(extractXoxdFromCookies(cookies)).toBeNull();
+  });
+
+  it('returns null when no cookies are present', () => {
+    expect(extractXoxdFromCookies([])).toBeNull();
+  });
+});
+
+describe('extractWorkspacesFromLocalConfig', () => {
+  it('reads every team, deriving the URL from domain when url is absent', () => {
+    const workspaces = extractWorkspacesFromLocalConfig(LOCAL_CONFIG);
+    expect(workspaces).toHaveLength(2);
+    expect(workspaces[0]).toEqual({
+      workspaceUrl: 'https://alpha.slack.com',
+      xoxc: 'xoxc-alpha-token-111',
+      teamId: 'T111',
+      teamName: 'Alpha Team',
+    });
+    expect(workspaces[1].workspaceUrl).toBe('https://beta.slack.com');
+  });
+
+  it('skips teams without a browser token', () => {
+    const raw = JSON.stringify({
+      teams: { T1: { id: 'T1', domain: 'a' }, T2: { id: 'T2', domain: 'b', token: 'xoxc-ok-1' } },
+    });
+    expect(extractWorkspacesFromLocalConfig(raw)).toHaveLength(1);
+  });
+
+  it('degrades to empty on malformed JSON rather than throwing', () => {
+    expect(extractWorkspacesFromLocalConfig('not json at all')).toEqual([]);
+  });
+
+  it('degrades to empty when the teams key is missing', () => {
+    expect(extractWorkspacesFromLocalConfig('{"other":true}')).toEqual([]);
+  });
+});
+
+describe('mergeWorkspaces', () => {
+  it('unions both sources', () => {
+    const merged = mergeWorkspaces(
+      [{ workspaceUrl: 'https://alpha.slack.com', xoxc: 'xoxc-a' }],
+      [{ workspaceUrl: 'https://beta.slack.com', xoxc: 'xoxc-b' }]
+    );
+    expect(merged).toHaveLength(2);
+  });
+
+  it('prefers the intercepted token but keeps localConfig metadata', () => {
+    const merged = mergeWorkspaces(
+      [{ workspaceUrl: 'https://alpha.slack.com', xoxc: 'xoxc-live' }],
+      [
+        {
+          workspaceUrl: 'https://alpha.slack.com',
+          xoxc: 'xoxc-stale',
+          teamId: 'T111',
+          teamName: 'Alpha Team',
+        },
+      ]
+    );
+    expect(merged).toHaveLength(1);
+    expect(merged[0].xoxc).toBe('xoxc-live');
+    expect(merged[0].teamName).toBe('Alpha Team');
+  });
+});
+
+describe('slackOriginFromApiUrl', () => {
+  it('matches a standard workspace API call', () => {
+    expect(slackOriginFromApiUrl('https://alpha.slack.com/api/conversations.view?x=1')).toBe(
+      'https://alpha.slack.com'
+    );
+  });
+
+  it('matches an enterprise grid host', () => {
+    expect(slackOriginFromApiUrl('https://myorg.enterprise.slack.com/api/users.list')).toBe(
+      'https://myorg.enterprise.slack.com'
+    );
+  });
+
+  it('rejects a non-API Slack URL', () => {
+    expect(slackOriginFromApiUrl('https://alpha.slack.com/client/T1/C1')).toBeNull();
+  });
+
+  it('rejects a non-Slack host', () => {
+    expect(slackOriginFromApiUrl('https://evil.example.com/api/x')).toBeNull();
+  });
+});
+
+// A fake CDP session: emits queued requests when the page navigates, and
+// answers the three commands the capture depends on.
+interface FakeOptions {
+  requests?: Array<{ url: string; postData?: string }>;
+  cookies?: Array<{ name?: string; domain?: string; value?: string }>;
+  localConfig?: string | null;
+  throwOn?: string;
+}
+
+function makeFakeSession(options: FakeOptions = {}): CdpSession {
+  const handlers = new Map<string, Array<(params: any) => void>>();
+  return {
+    on(method, handler) {
+      const list = handlers.get(method);
+      if (list) list.push(handler);
+      else handlers.set(method, [handler]);
+    },
+    async send<T>(method: string): Promise<T> {
+      if (options.throwOn === method) throw new Error('boom');
+      if (method === 'Page.navigate') {
+        for (const request of options.requests ?? []) {
+          for (const handler of handlers.get('Network.requestWillBeSent') ?? []) {
+            handler({ request });
+          }
+        }
+      }
+      if (method === 'Network.getCookies') {
+        return { cookies: options.cookies ?? [] } as T;
+      }
+      if (method === 'Runtime.evaluate') {
+        return { result: { value: options.localConfig ?? undefined } } as T;
+      }
+      return {} as T;
+    },
+    close() {},
+  };
+}
+
+// Capture polls a clock; advancing it per call keeps the settle loop bounded.
+const advancingClock = (step = 1000) => {
+  let t = 0;
+  return () => (t += step);
+};
+
+const captureDeps = {
+  sleep: async () => {},
+  now: advancingClock(),
+};
+
+describe('SLACK_CLIENT_URL', () => {
+  // Regression guard. `https://app.slack.com/` (no /client) sends a returning
+  // user to the marketing site, which makes no API calls — capture then times
+  // out on a perfectly valid session. Verified against live Slack 2026-08-01.
+  it('targets the client, not the Slack home page', () => {
+    expect(SLACK_CLIENT_URL).toBe('https://app.slack.com/client');
+  });
+});
+
+describe('captureSlackTokens', () => {
+  const SLACK_COOKIES = [{ name: 'd', domain: '.slack.com', value: 'xoxd-session-abc' }];
+
+  it('navigates to the client URL by default', async () => {
+    const navigated: string[] = [];
+    const base = makeFakeSession({
+      requests: [{ url: 'https://alpha.slack.com/api/x', postData: JSON_BODY }],
+      cookies: SLACK_COOKIES,
+    });
+    const session: CdpSession = {
+      ...base,
+      async send<T>(method: string, params?: Record<string, unknown>): Promise<T> {
+        if (method === 'Page.navigate') navigated.push(String(params?.url));
+        return base.send<T>(method, params);
+      },
+    };
+
+    await captureSlackTokens(session, { ...captureDeps, now: advancingClock() });
+
+    expect(navigated).toEqual([SLACK_CLIENT_URL]);
+  });
+
+  it('captures the cookie and an intercepted workspace', async () => {
+    const session = makeFakeSession({
+      requests: [
+        { url: 'https://alpha.slack.com/api/conversations.view', postData: MULTIPART_BODY },
+      ],
+      cookies: SLACK_COOKIES,
+    });
+
+    const result = await captureSlackTokens(session, { ...captureDeps, now: advancingClock() });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.xoxd).toBe('xoxd-session-abc');
+    expect(result.workspaces).toHaveLength(1);
+    expect(result.workspaces[0].workspaceUrl).toBe('https://alpha.slack.com');
+  });
+
+  it('unions intercepted workspaces with those only in localConfig', async () => {
+    const session = makeFakeSession({
+      requests: [
+        { url: 'https://alpha.slack.com/api/conversations.view', postData: MULTIPART_BODY },
+      ],
+      cookies: SLACK_COOKIES,
+      localConfig: LOCAL_CONFIG,
+    });
+
+    const result = await captureSlackTokens(session, { ...captureDeps, now: advancingClock() });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const urls = result.workspaces.map((w) => w.workspaceUrl).sort();
+    expect(urls).toEqual(['https://alpha.slack.com', 'https://beta.slack.com']);
+  });
+
+  it('times out when no Slack request is ever seen', async () => {
+    const session = makeFakeSession({ cookies: SLACK_COOKIES });
+
+    const result = await captureSlackTokens(session, {
+      ...captureDeps,
+      now: advancingClock(),
+      timeoutMs: 3000,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('capture_timeout');
+  });
+
+  it('reports no_cookie when a session is found but the d cookie is missing', async () => {
+    const session = makeFakeSession({
+      requests: [{ url: 'https://alpha.slack.com/api/x', postData: JSON_BODY }],
+      cookies: [],
+    });
+
+    const result = await captureSlackTokens(session, { ...captureDeps, now: advancingClock() });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('no_cookie');
+  });
+
+  it('reports devtools_unreachable when the session breaks during setup', async () => {
+    const session = makeFakeSession({ throwOn: 'Network.enable' });
+
+    const result = await captureSlackTokens(session, { ...captureDeps, now: advancingClock() });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('devtools_unreachable');
+  });
+
+  it('still succeeds when localStorage cannot be read', async () => {
+    const session = makeFakeSession({
+      requests: [{ url: 'https://alpha.slack.com/api/x', postData: JSON_BODY }],
+      cookies: SLACK_COOKIES,
+      throwOn: 'Runtime.evaluate',
+    });
+
+    const result = await captureSlackTokens(session, { ...captureDeps, now: advancingClock() });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.workspaces).toHaveLength(1);
+  });
+
+  it('ignores non-Slack traffic', async () => {
+    const session = makeFakeSession({
+      requests: [
+        { url: 'https://analytics.example.com/api/track', postData: 'token=xoxc-decoy-1' },
+      ],
+      cookies: SLACK_COOKIES,
+      timeoutMs: 3000,
+    } as FakeOptions);
+
+    const result = await captureSlackTokens(session, {
+      ...captureDeps,
+      now: advancingClock(),
+      timeoutMs: 3000,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('capture_timeout');
+  });
+});

--- a/src/lib/browser-auth.test.ts
+++ b/src/lib/browser-auth.test.ts
@@ -6,8 +6,10 @@ import {
   extractXoxdFromCookies,
   mergeWorkspaces,
   slackOriginFromApiUrl,
+  isSlackWorkspaceUrl,
   SLACK_CLIENT_URL,
 } from './browser-auth';
+import { isSafeStartUrl } from './browser-launcher';
 import type { CdpSession } from './cdp-client';
 
 // Anonymized bodies matching the three encodings Slack's web client uses.
@@ -100,6 +102,35 @@ describe('extractXoxdFromCookies', () => {
     expect(extractXoxdFromCookies(cookies)).toBeNull();
   });
 
+  // A substring test passes all of these; only a dot-anchored suffix rejects
+  // them. Each one would otherwise hand a hostile page's value back as the
+  // user's real session.
+  it.each([
+    'notslack.com',
+    'slack.com.evil.net',
+    '.slack.com.attacker.io',
+    'myslack.community',
+  ])('rejects a d cookie on look-alike domain %s', (domain) => {
+    expect(extractXoxdFromCookies([{ name: 'd', domain, value: 'xoxd-stolen' }])).toBeNull();
+  });
+
+  it('accepts the real parent domain and an enterprise subdomain', () => {
+    expect(extractXoxdFromCookies([{ name: 'd', domain: '.slack.com', value: 'xoxd-ok' }])).toBe('xoxd-ok');
+    expect(
+      extractXoxdFromCookies([{ name: 'd', domain: 'foo.enterprise.slack.com', value: 'xoxd-ent' }])
+    ).toBe('xoxd-ent');
+  });
+
+  it('returns null rather than throwing on a malformed percent-sequence', () => {
+    // decodeURIComponent throws URIError here; the signature promises null.
+    expect(() =>
+      extractXoxdFromCookies([{ name: 'd', domain: '.slack.com', value: 'xoxd-100%bad' }])
+    ).not.toThrow();
+    expect(
+      extractXoxdFromCookies([{ name: 'd', domain: '.slack.com', value: 'xoxd-100%bad' }])
+    ).toBeNull();
+  });
+
   it('ignores a d cookie whose value is not an xoxd token', () => {
     const cookies = [{ name: 'd', domain: '.slack.com', value: 'something-else' }];
     expect(extractXoxdFromCookies(cookies)).toBeNull();
@@ -136,6 +167,66 @@ describe('extractWorkspacesFromLocalConfig', () => {
 
   it('degrades to empty when the teams key is missing', () => {
     expect(extractWorkspacesFromLocalConfig('{"other":true}')).toEqual([]);
+  });
+
+  // localStorage is only as trustworthy as whatever page the browser has
+  // open, and this URL becomes the host the live session cookie is sent to.
+  it.each([
+    ['plain http', 'http://attacker.example:8731'],
+    ['non-Slack https host', 'https://attacker.example'],
+    ['look-alike host', 'https://slack.com.evil.net'],
+    ['the client host itself', 'https://app.slack.com'],
+    ['a file URL', 'file:///etc/passwd'],
+    ['unparseable', 'not a url at all'],
+  ])('refuses a team whose url is %s', (_label, url) => {
+    const raw = JSON.stringify({ teams: { T1: { id: 'T1', url, token: 'xoxc-x' } } });
+    expect(extractWorkspacesFromLocalConfig(raw)).toEqual([]);
+  });
+
+  it('reduces a team url carrying a path to its origin', () => {
+    const raw = JSON.stringify({
+      teams: { T1: { id: 'T1', url: 'https://alpha.slack.com/messages/C1', token: 'xoxc-a' } },
+    });
+    expect(extractWorkspacesFromLocalConfig(raw)[0].workspaceUrl).toBe('https://alpha.slack.com');
+  });
+});
+
+describe('isSlackWorkspaceUrl', () => {
+  it.each([
+    'https://alpha.slack.com',
+    'https://myorg.enterprise.slack.com',
+    'https://slack.com',
+  ])('accepts %s', (url) => {
+    expect(isSlackWorkspaceUrl(url)).toBe(true);
+  });
+
+  it.each([
+    'http://alpha.slack.com',
+    'https://app.slack.com',
+    'https://slack.com.evil.net',
+    'https://notslack.com',
+    'javascript:alert(1)',
+    '',
+  ])('rejects %s', (url) => {
+    expect(isSlackWorkspaceUrl(url)).toBe(false);
+  });
+});
+
+describe('isSafeStartUrl', () => {
+  // A start URL is positional browser argv: a leading dash makes it a switch.
+  it.each([
+    '--proxy-server=127.0.0.1:9931',
+    '--remote-debugging-address=0.0.0.0',
+    '-incognito',
+    'file:///etc/passwd',
+    'javascript:alert(1)',
+    'not a url',
+  ])('rejects %s', (url) => {
+    expect(isSafeStartUrl(url)).toBe(false);
+  });
+
+  it('accepts an ordinary https URL', () => {
+    expect(isSafeStartUrl('https://alpha.slack.com/')).toBe(true);
   });
 });
 
@@ -195,17 +286,25 @@ interface FakeOptions {
   cookies?: Array<{ name?: string; domain?: string; value?: string }>;
   localConfig?: string | null;
   throwOn?: string;
+  /** Every command starts failing after this many calls — a browser the user
+   *  closed mid-capture. */
+  dieAfterCalls?: number;
 }
 
 function makeFakeSession(options: FakeOptions = {}): CdpSession {
   const handlers = new Map<string, Array<(params: any) => void>>();
+  let calls = 0;
   return {
     on(method, handler) {
       const list = handlers.get(method);
       if (list) list.push(handler);
       else handlers.set(method, [handler]);
     },
-    async send<T>(method: string): Promise<T> {
+    async send<T>(method: string, params?: Record<string, unknown>): Promise<T> {
+      calls += 1;
+      if (options.dieAfterCalls !== undefined && calls > options.dieAfterCalls) {
+        throw new Error('CDP Runtime.evaluate failed: socket closed');
+      }
       if (options.throwOn === method) throw new Error('boom');
       if (method === 'Page.navigate') {
         for (const request of options.requests ?? []) {
@@ -214,11 +313,17 @@ function makeFakeSession(options: FakeOptions = {}): CdpSession {
           }
         }
       }
-      if (method === 'Network.getCookies') {
+      if (method === 'Storage.getCookies' || method === 'Network.getCookies') {
         return { cookies: options.cookies ?? [] } as T;
       }
       if (method === 'Runtime.evaluate') {
-        return { result: { value: options.localConfig ?? undefined } } as T;
+        const expression = String(params?.expression ?? '');
+        // The capture uses Runtime.evaluate for two different jobs; only the
+        // localStorage read should yield a config payload.
+        if (expression.includes('localConfig_v2')) {
+          return { result: { value: options.localConfig ?? undefined } } as T;
+        }
+        return { result: { value: 1 } } as T;
       }
       return {} as T;
     },
@@ -339,6 +444,75 @@ describe('captureSlackTokens', () => {
     expect(result.reason).toBe('devtools_unreachable');
   });
 
+  // The two sources must be genuine alternatives. Interception only sees the
+  // attached tab and only while Slack is calling, so a valid session would
+  // otherwise time out whenever it happened not to be talking.
+  it('succeeds from localStorage alone when no request is intercepted', async () => {
+    const session = makeFakeSession({
+      requests: [],
+      cookies: SLACK_COOKIES,
+      localConfig: LOCAL_CONFIG,
+    });
+
+    const result = await captureSlackTokens(session, { ...captureDeps, now: advancingClock() });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.workspaces.map((w) => w.workspaceUrl).sort()).toEqual([
+      'https://alpha.slack.com',
+      'https://beta.slack.com',
+    ]);
+  });
+
+  it('succeeds from interception alone when localStorage is empty', async () => {
+    const session = makeFakeSession({
+      requests: [{ url: 'https://alpha.slack.com/api/x', postData: JSON_BODY }],
+      cookies: SLACK_COOKIES,
+      localConfig: null,
+    });
+
+    const result = await captureSlackTokens(session, { ...captureDeps, now: advancingClock() });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.workspaces).toHaveLength(1);
+  });
+
+  // Without a liveness probe this waited out the full timeout — five minutes
+  // by default — then told the user to finish signing in inside a window that
+  // no longer existed.
+  it('reports browser_closed instead of waiting out the timeout', async () => {
+    const session = makeFakeSession({ dieAfterCalls: 3, cookies: SLACK_COOKIES });
+
+    const result = await captureSlackTokens(session, {
+      ...captureDeps,
+      now: advancingClock(),
+      timeoutMs: 300_000,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('browser_closed');
+  });
+
+  it('refuses a hostile workspace URL planted in localStorage', async () => {
+    const hostile = JSON.stringify({
+      teams: { T1: { id: 'T1', url: 'http://attacker.example:8731', token: 'xoxc-x' } },
+    });
+    const session = makeFakeSession({
+      requests: [{ url: 'https://alpha.slack.com/api/x', postData: JSON_BODY }],
+      cookies: SLACK_COOKIES,
+      localConfig: hostile,
+    });
+
+    const result = await captureSlackTokens(session, { ...captureDeps, now: advancingClock() });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Only the legitimately intercepted workspace survives.
+    expect(result.workspaces.map((w) => w.workspaceUrl)).toEqual(['https://alpha.slack.com']);
+  });
+
   it('still succeeds when localStorage cannot be read', async () => {
     const session = makeFakeSession({
       requests: [{ url: 'https://alpha.slack.com/api/x', postData: JSON_BODY }],
@@ -359,8 +533,7 @@ describe('captureSlackTokens', () => {
         { url: 'https://analytics.example.com/api/track', postData: 'token=xoxc-decoy-1' },
       ],
       cookies: SLACK_COOKIES,
-      timeoutMs: 3000,
-    } as FakeOptions);
+    });
 
     const result = await captureSlackTokens(session, {
       ...captureDeps,

--- a/src/lib/browser-auth.test.ts
+++ b/src/lib/browser-auth.test.ts
@@ -289,11 +289,15 @@ interface FakeOptions {
   /** Every command starts failing after this many calls — a browser the user
    *  closed mid-capture. */
   dieAfterCalls?: number;
+  /** Fail exactly this many calls, then recover — a tab renavigating, which
+   *  tears down the execution context without the browser going anywhere. */
+  transientFailures?: number;
 }
 
 function makeFakeSession(options: FakeOptions = {}): CdpSession {
   const handlers = new Map<string, Array<(params: any) => void>>();
   let calls = 0;
+  let transientRemaining = options.transientFailures ?? 0;
   return {
     on(method, handler) {
       const list = handlers.get(method);
@@ -304,6 +308,12 @@ function makeFakeSession(options: FakeOptions = {}): CdpSession {
       calls += 1;
       if (options.dieAfterCalls !== undefined && calls > options.dieAfterCalls) {
         throw new Error('CDP Runtime.evaluate failed: socket closed');
+      }
+      // Models a renavigation: only evaluations fail, and only for a while.
+      // The socket is fine, so setup and cookie reads are unaffected.
+      if (method === 'Runtime.evaluate' && transientRemaining > 0) {
+        transientRemaining -= 1;
+        throw new Error('CDP Runtime.evaluate failed: Execution context was destroyed');
       }
       if (options.throwOn === method) throw new Error('boom');
       if (method === 'Page.navigate') {
@@ -493,6 +503,27 @@ describe('captureSlackTokens', () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.reason).toBe('browser_closed');
+  });
+
+  // An SSO redirect tears down the execution context, so this probe fails
+  // transiently while the browser is perfectly alive. Treating one failure as
+  // death aborts the sign-in at the moment the user is typing their password.
+  it('survives transient probe failures without declaring the browser closed', async () => {
+    const session = makeFakeSession({
+      transientFailures: 3,
+      cookies: SLACK_COOKIES,
+      localConfig: LOCAL_CONFIG,
+    });
+
+    const result = await captureSlackTokens(session, {
+      ...captureDeps,
+      now: advancingClock(),
+      timeoutMs: 60_000,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.workspaces.length).toBeGreaterThan(0);
   });
 
   it('refuses a hostile workspace URL planted in localStorage', async () => {

--- a/src/lib/browser-auth.ts
+++ b/src/lib/browser-auth.ts
@@ -520,6 +520,21 @@ export async function openBrowserSession(
     const stop = async (): Promise<void> => {
       if (stopped) return;
       stopped = true;
+
+      // Ask Chrome to quit itself before resorting to signals. Only the browser
+      // can reap its own renderer/GPU/utility helpers and release the profile
+      // locks — signalling the parent leaves the helpers orphaned, and killing
+      // them outright leaves the profile in a state Chrome refuses to reopen.
+      // Best effort: if it does not oblige, `stopBrowser` still escalates.
+      try {
+        await Promise.race([
+          session.send('Browser.close'),
+          new Promise((resolve) => setTimeout(resolve, 5_000)),
+        ]);
+      } catch {
+        // Browser already gone, or the command is unavailable.
+      }
+
       session.close();
       await stopBrowser();
     };

--- a/src/lib/browser-auth.ts
+++ b/src/lib/browser-auth.ts
@@ -1,0 +1,366 @@
+/**
+ * Capture Slack browser-session tokens by observing a real signed-in browser.
+ *
+ * Slack's web client authenticates with a pair: an `xoxc-*` API token sent in
+ * request bodies, and an `xoxd-*` value in the `d` cookie. The cookie is
+ * HttpOnly, so page JavaScript cannot read it — it has to come from the
+ * browser's own cookie store, which is why this drives CDP rather than, say,
+ * injecting a script.
+ *
+ * Two sources are combined:
+ *   - intercepted API requests, which prove a token is live and in use; and
+ *   - `localConfig_v2` in localStorage, which lists every workspace the user
+ *     is signed into, including ones they have not opened this session.
+ * The union means one sign-in enrols every workspace. localStorage is Slack
+ * client internals and may change shape without notice, so a failure to read
+ * it degrades to whatever interception found rather than failing the run.
+ *
+ * The pure extractors below carry the parsing rules and are exported so the
+ * tests can pin every request encoding Slack is known to use.
+ */
+
+import { connectCdpSocket, createCdpSession, type CdpSession } from './cdp-client.ts';
+import {
+  findPageTarget,
+  launchBrowser,
+  type BrowserLaunchFailure,
+  type LaunchOptions,
+} from './browser-launcher.ts';
+
+export type CaptureFailure =
+  | 'devtools_unreachable'
+  | 'capture_timeout'
+  | 'no_cookie';
+
+export interface CapturedWorkspace {
+  workspaceUrl: string;
+  xoxc: string;
+  teamId?: string;
+  teamName?: string;
+}
+
+export type CaptureResult =
+  | { ok: true; xoxd: string; workspaces: CapturedWorkspace[] }
+  | { ok: false; reason: CaptureFailure; message: string };
+
+/** Slack API endpoints carrying the token we want. */
+const SLACK_API_URL = /^https:\/\/([\w-]+(?:\.enterprise)?)\.slack\.com\/api\//i;
+
+/**
+ * Where to send the browser by default.
+ *
+ * Must be `/client`, not `https://app.slack.com/`. Measured 2026-08-01: a
+ * returning user with a live session cookie who opens `app.slack.com/` is
+ * redirected to the marketing site (`slack.com/intl/...`), which issues no API
+ * calls and defines no `localConfig_v2` — so capture sees nothing and times
+ * out, even though the session is perfectly valid. `/client` loads the real
+ * workspace client (~47 token-bearing calls within seconds) and, for a
+ * signed-out user, still redirects to sign-in first. A workspace host such as
+ * `https://myteam.slack.com/` behaves identically; both end up at
+ * `app.slack.com/client/<team>/<channel>`.
+ */
+export const SLACK_CLIENT_URL = 'https://app.slack.com/client';
+
+/**
+ * Pull an `xoxc-*` token out of a request body.
+ *
+ * Slack uses three encodings depending on the endpoint, and all three occur in
+ * normal client traffic — `curl-parser.ts` already carries the multipart and
+ * JSON cases for the copy-as-cURL flow, and urlencoded shows up on the boot
+ * calls. Missing one means missing workspaces, so all three are handled here.
+ */
+export function extractXoxcFromPostData(postData: string): string | null {
+  if (!postData || !postData.includes('xoxc-')) return null;
+
+  const patterns = [
+    // multipart/form-data — the boundary puts the value on its own line.
+    /name="token"[\s\S]*?(xoxc-[a-zA-Z0-9-]+)/,
+    // application/json
+    /"token"\s*:\s*"(xoxc-[a-zA-Z0-9-]+)"/,
+    // application/x-www-form-urlencoded
+    /(?:^|&)token=(xoxc-[a-zA-Z0-9-]+)/,
+  ];
+
+  for (const pattern of patterns) {
+    const match = postData.match(pattern);
+    if (match?.[1]) return match[1];
+  }
+  return null;
+}
+
+/**
+ * Find the `d` cookie and decode it.
+ *
+ * Cookies are queried unfiltered and matched on domain here rather than via a
+ * `urls` filter, so an enterprise-grid host (`foo.enterprise.slack.com`) is
+ * covered without enumerating hostnames. The stored value is percent-encoded,
+ * matching what `curl-parser.ts` decodes out of a copied Cookie header.
+ */
+export function extractXoxdFromCookies(
+  cookies: Array<{ name?: string; domain?: string; value?: string }>
+): string | null {
+  const match = cookies.find(
+    (c) =>
+      c.name === 'd' &&
+      typeof c.value === 'string' &&
+      c.value.length > 0 &&
+      (c.domain ?? '').includes('slack.com')
+  );
+  if (!match?.value) return null;
+
+  const decoded = decodeURIComponent(match.value);
+  return decoded.startsWith('xoxd-') ? decoded : null;
+}
+
+/**
+ * Read every signed-in workspace out of a `localConfig_v2` payload.
+ *
+ * Defensive throughout: this is undocumented client state, and a shape change
+ * must cost us the extra workspaces, never the run.
+ */
+export function extractWorkspacesFromLocalConfig(raw: string): CapturedWorkspace[] {
+  let parsed: any;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+
+  const teams = parsed?.teams;
+  if (!teams || typeof teams !== 'object') return [];
+
+  const captured: CapturedWorkspace[] = [];
+  for (const team of Object.values<any>(teams)) {
+    const token = team?.token;
+    if (typeof token !== 'string' || !token.startsWith('xoxc-')) continue;
+
+    const domain = typeof team?.domain === 'string' ? team.domain : null;
+    const url = typeof team?.url === 'string' ? team.url : null;
+    const workspaceUrl = url
+      ? url.replace(/\/+$/, '')
+      : domain
+        ? `https://${domain}.slack.com`
+        : null;
+    if (!workspaceUrl) continue;
+
+    captured.push({
+      workspaceUrl,
+      xoxc: token,
+      ...(typeof team?.id === 'string' ? { teamId: team.id } : {}),
+      ...(typeof team?.name === 'string' ? { teamName: team.name } : {}),
+    });
+  }
+  return captured;
+}
+
+/**
+ * Merge intercepted and localStorage-derived workspaces.
+ *
+ * Keyed on workspace URL. Intercepted tokens are preferred on conflict: they
+ * were observed authenticating a live request, whereas a localStorage entry
+ * can be a stale leftover from a workspace the user has since left.
+ */
+export function mergeWorkspaces(
+  intercepted: CapturedWorkspace[],
+  fromLocalConfig: CapturedWorkspace[]
+): CapturedWorkspace[] {
+  const byUrl = new Map<string, CapturedWorkspace>();
+  for (const workspace of fromLocalConfig) {
+    byUrl.set(workspace.workspaceUrl, workspace);
+  }
+  for (const workspace of intercepted) {
+    const existing = byUrl.get(workspace.workspaceUrl);
+    byUrl.set(
+      workspace.workspaceUrl,
+      existing ? { ...existing, ...workspace } : workspace
+    );
+  }
+  return [...byUrl.values()];
+}
+
+/** Workspace origin for a Slack API URL, or null when it is not one. */
+export function slackOriginFromApiUrl(url: string): string | null {
+  const match = url.match(SLACK_API_URL);
+  return match ? `https://${match[1]}.slack.com` : null;
+}
+
+export interface CaptureOptions {
+  /** Overall budget for the user to finish signing in. */
+  timeoutMs?: number;
+  /** Where to send the browser; defaults to the Slack web client. */
+  startUrl?: string;
+  onProgress?: (line: string) => void;
+  /** Seams for tests. */
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));
+
+const POLL_INTERVAL_MS = 500;
+
+/**
+ * Drive an attached CDP session until Slack tokens are captured.
+ *
+ * Takes an established session rather than opening one so the whole capture
+ * policy — what counts as a hit, when to give up, how sources combine — is
+ * testable against a fake session with no browser involved.
+ */
+export async function captureSlackTokens(
+  session: CdpSession,
+  options: CaptureOptions = {}
+): Promise<CaptureResult> {
+  const timeoutMs = options.timeoutMs ?? 5 * 60 * 1000;
+  const sleep = options.sleep ?? defaultSleep;
+  const now = options.now ?? (() => Date.now());
+  const onProgress = options.onProgress ?? (() => {});
+  const startUrl = options.startUrl ?? SLACK_CLIENT_URL;
+
+  const intercepted = new Map<string, CapturedWorkspace>();
+
+  session.on('Network.requestWillBeSent', (params: any) => {
+    const url = params?.request?.url;
+    const postData = params?.request?.postData;
+    if (typeof url !== 'string' || typeof postData !== 'string') return;
+
+    const origin = slackOriginFromApiUrl(url);
+    if (!origin || intercepted.has(origin)) return;
+
+    const xoxc = extractXoxcFromPostData(postData);
+    if (xoxc) {
+      intercepted.set(origin, { workspaceUrl: origin, xoxc });
+    }
+  });
+
+  try {
+    await session.send('Network.enable');
+    await session.send('Runtime.enable');
+    await session.send('Page.navigate', { url: startUrl });
+  } catch (err: any) {
+    return {
+      ok: false,
+      reason: 'devtools_unreachable',
+      message: `Lost the browser connection: ${err?.message ?? 'unknown error'}`,
+    };
+  }
+
+  onProgress('Waiting for Slack sign-in in the browser window…');
+
+  const deadline = now() + timeoutMs;
+  while (now() < deadline && intercepted.size === 0) {
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  if (intercepted.size === 0) {
+    return {
+      ok: false,
+      reason: 'capture_timeout',
+      message:
+        'No Slack session was detected before the timeout.\n' +
+        '   Make sure you completed sign-in in the browser window.',
+    };
+  }
+
+  // A workspace beyond the first surfaces a beat later, as the client boots
+  // each one. A short extra settle is much cheaper than making the user
+  // re-run to pick up the rest.
+  const settleDeadline = Math.min(now() + 3_000, deadline);
+  while (now() < settleDeadline) {
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  onProgress('Session detected — reading tokens…');
+
+  let xoxd: string | null = null;
+  try {
+    const result = await session.send<{ cookies?: any[] }>('Network.getCookies');
+    xoxd = extractXoxdFromCookies(result?.cookies ?? []);
+  } catch {
+    xoxd = null;
+  }
+
+  if (!xoxd) {
+    return {
+      ok: false,
+      reason: 'no_cookie',
+      message:
+        'Signed-in session found, but the `d` session cookie was not readable.\n' +
+        '   Try again, or fall back to: slackcli auth parse-curl --login',
+    };
+  }
+
+  let fromLocalConfig: CapturedWorkspace[] = [];
+  try {
+    const evaluated = await session.send<{ result?: { value?: string } }>(
+      'Runtime.evaluate',
+      {
+        expression: "localStorage.getItem('localConfig_v2')",
+        returnByValue: true,
+      }
+    );
+    const raw = evaluated?.result?.value;
+    if (typeof raw === 'string') {
+      fromLocalConfig = extractWorkspacesFromLocalConfig(raw);
+    }
+  } catch {
+    // Undocumented client state; interception already gave us a usable result.
+    fromLocalConfig = [];
+  }
+
+  return {
+    ok: true,
+    xoxd,
+    workspaces: mergeWorkspaces([...intercepted.values()], fromLocalConfig),
+  };
+}
+
+export type BrowserSessionFailure = BrowserLaunchFailure | 'devtools_unreachable';
+
+export type BrowserSessionResult =
+  | { ok: true; session: CdpSession; stop: () => Promise<void> }
+  | { ok: false; reason: BrowserSessionFailure; message: string };
+
+/**
+ * Launch a browser and attach a CDP session to its page target.
+ *
+ * The IO edge of the capture: everything it composes is covered elsewhere,
+ * and every early return releases the browser it already started — a failure
+ * here must never strand a window on the user's desktop.
+ */
+export async function openBrowserSession(
+  options: LaunchOptions = {}
+): Promise<BrowserSessionResult> {
+  const launched = await launchBrowser(options);
+  if (!launched.ok) return launched;
+
+  const wsUrl = await findPageTarget(launched.port);
+  if (!wsUrl) {
+    await launched.stop();
+    return {
+      ok: false,
+      reason: 'devtools_unreachable',
+      message: 'The browser started but exposed no page to attach to.',
+    };
+  }
+
+  try {
+    const socket = await connectCdpSocket(wsUrl);
+    const session = createCdpSession(socket);
+    return {
+      ok: true,
+      session,
+      stop: async () => {
+        session.close();
+        await launched.stop();
+      },
+    };
+  } catch (err: any) {
+    await launched.stop();
+    return {
+      ok: false,
+      reason: 'devtools_unreachable',
+      message: err?.message ?? 'Could not attach to the browser.',
+    };
+  }
+}

--- a/src/lib/browser-auth.ts
+++ b/src/lib/browser-auth.ts
@@ -490,7 +490,7 @@ export type BrowserSessionResult =
  * here must never strand a window on the user's desktop.
  */
 export async function openBrowserSession(
-  options: LaunchOptions = {}
+  options: LaunchOptions & { onProgress?: (line: string) => void } = {}
 ): Promise<BrowserSessionResult> {
   const launched = await launchBrowser(options);
   if (!launched.ok) return launched;

--- a/src/lib/browser-auth.ts
+++ b/src/lib/browser-auth.ts
@@ -175,18 +175,18 @@ function isSlackCookieDomain(domain: string): boolean {
  * must cost us the extra workspaces, never the run.
  */
 export function extractWorkspacesFromLocalConfig(raw: string): CapturedWorkspace[] {
-  let parsed: any;
+  let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch {
     return [];
   }
 
-  const teams = parsed?.teams;
+  const teams = (parsed as { teams?: unknown } | null)?.teams;
   if (!teams || typeof teams !== 'object') return [];
 
   const captured: CapturedWorkspace[] = [];
-  for (const team of Object.values<any>(teams)) {
+  for (const team of Object.values(teams as Record<string, any>)) {
     const token = team?.token;
     if (typeof token !== 'string' || !token.startsWith('xoxc-')) continue;
 
@@ -259,6 +259,8 @@ export function slackOriginFromApiUrl(url: string): string | null {
 export interface CaptureOptions {
   /** Overall budget for the user to finish signing in. */
   timeoutMs?: number;
+  /** Only affects guidance text: with no window, "sign in" is unactionable. */
+  headless?: boolean;
   /** Where to send the browser; defaults to the Slack web client. */
   startUrl?: string;
   onProgress?: (line: string) => void;
@@ -271,6 +273,9 @@ const defaultSleep = (ms: number): Promise<void> =>
   new Promise((r) => setTimeout(r, ms));
 
 const POLL_INTERVAL_MS = 500;
+
+/** Ceiling on waiting for additional workspaces to finish booting. */
+const SETTLE_BUDGET_MS = 3_000;
 
 /**
  * Drive an attached CDP session until Slack tokens are captured.
@@ -328,10 +333,14 @@ export async function captureSlackTokens(
   let fromLocalConfig: CapturedWorkspace[] = [];
   let sessionLost = false;
 
+  let consecutiveProbeFailures = 0;
   while (now() < deadline) {
     fromLocalConfig = await readWorkspacesFromLocalStorage(session);
     if (fromLocalConfig.length > 0 || intercepted.size > 0) break;
-    if (!(await sessionAlive(session))) {
+
+    if (await sessionAlive(session)) {
+      consecutiveProbeFailures = 0;
+    } else if (++consecutiveProbeFailures >= LIVENESS_FAILURES_BEFORE_DEAD) {
       sessionLost = true;
       break;
     }
@@ -352,21 +361,34 @@ export async function captureSlackTokens(
     return {
       ok: false,
       reason: 'capture_timeout',
-      message:
-        'No Slack session was detected before the timeout.\n' +
-        '   Make sure you completed sign-in in the browser window.',
+      // Headless has no window, so "complete sign-in in the browser window" is
+      // advice the user cannot act on. The real cause there is almost always a
+      // saved session that has since expired.
+      message: options.headless
+        ? 'No Slack session was detected before the timeout.\n' +
+          '   The saved browser session has probably expired — re-run without --headless\n' +
+          '   and sign in again.'
+        : 'No Slack session was detected before the timeout.\n' +
+          '   Make sure you completed sign-in in the browser window.',
     };
   }
 
   // A workspace beyond the first surfaces a beat later, as the client boots
-  // each one. A short extra settle is much cheaper than making the user
-  // re-run to pick up the rest.
-  const settleDeadline = Math.min(now() + 3_000, deadline);
-  while (now() < settleDeadline) {
+  // each one — so re-read until the count stops growing rather than waiting a
+  // fixed interval. Two stable reads end it, which costs the common
+  // single-workspace case one poll instead of the full settle budget.
+  const settleDeadline = Math.min(now() + SETTLE_BUDGET_MS, deadline);
+  let stableReads = 0;
+  while (now() < settleDeadline && stableReads < 2) {
     await sleep(POLL_INTERVAL_MS);
+    const settled = await readWorkspacesFromLocalStorage(session);
+    if (settled.length > fromLocalConfig.length) {
+      fromLocalConfig = settled;
+      stableReads = 0;
+    } else {
+      stableReads += 1;
+    }
   }
-  const settled = await readWorkspacesFromLocalStorage(session);
-  if (settled.length > fromLocalConfig.length) fromLocalConfig = settled;
 
   onProgress('Session detected — reading tokens…');
 
@@ -433,10 +455,18 @@ async function readWorkspacesFromLocalStorage(
 /**
  * Cheap liveness probe.
  *
- * Without this the wait loop is a bare sleep: a user who closes the browser
- * waits out the entire timeout — five minutes by default — and is then told
- * to complete sign-in in a window that no longer exists.
+ * Without a probe the wait loop is a bare sleep: a user who closes the browser
+ * waits out the entire timeout — five minutes by default — and is then told to
+ * complete sign-in in a window that no longer exists.
+ *
+ * A single failure is NOT death. This exact call fails transiently whenever the
+ * tab renavigates and tears down its execution context, which is precisely what
+ * an SSO redirect does — so treating one error as fatal aborts the sign-in the
+ * command exists to perform, at the moment the user is typing their password.
+ * Only a sustained run of failures counts.
  */
+const LIVENESS_FAILURES_BEFORE_DEAD = 4;
+
 async function sessionAlive(session: CdpSession): Promise<boolean> {
   try {
     await session.send('Runtime.evaluate', { expression: '1', returnByValue: true });
@@ -482,33 +512,17 @@ export async function openBrowserSession(
     const socket = await connectCdpSocket(wsUrl);
     const session = createCdpSession(socket);
 
-    // An abnormal exit (SIGINT, SIGTERM, a supervisor kill) would otherwise
-    // orphan a browser holding a live Slack session behind an unauthenticated
-    // loopback DevTools port — with --headless there is no window to notice.
+    // Signal reaping lives in `launchBrowser`, registered the moment the child
+    // exists — the window between spawn and attach is seconds long and is
+    // exactly when a user interrupts, so covering only this point would leave
+    // the common case orphaning a signed-in browser.
     let stopped = false;
-    const reap = (): void => {
-      // Signal handlers cannot await; start the kill rather than leave the
-      // browser running for the life of the machine.
+    const stop = async (): Promise<void> => {
       if (stopped) return;
       stopped = true;
       session.close();
-      void stopBrowser();
-    };
-    const stop = async (): Promise<void> => {
-      if (stopped) {
-        await stopBrowser();
-        return;
-      }
-      stopped = true;
-      process.off('SIGINT', reap);
-      process.off('SIGTERM', reap);
-      process.off('exit', reap);
-      session.close();
       await stopBrowser();
     };
-    process.once('SIGINT', reap);
-    process.once('SIGTERM', reap);
-    process.once('exit', reap);
 
     return { ok: true, session, stop };
   } catch (err: any) {

--- a/src/lib/browser-auth.ts
+++ b/src/lib/browser-auth.ts
@@ -30,6 +30,7 @@ import {
 export type CaptureFailure =
   | 'devtools_unreachable'
   | 'capture_timeout'
+  | 'browser_closed'
   | 'no_cookie';
 
 export interface CapturedWorkspace {
@@ -45,6 +46,41 @@ export type CaptureResult =
 
 /** Slack API endpoints carrying the token we want. */
 const SLACK_API_URL = /^https:\/\/([\w-]+(?:\.enterprise)?)\.slack\.com\/api\//i;
+
+/**
+ * The Slack web client's own host. It serves the app shell for every
+ * workspace, so it is never itself a workspace origin — accepting it would
+ * let a client-host API call masquerade as a distinct workspace and, since
+ * workspaces are keyed by team id on save, overwrite the real entry's API
+ * base with one that resolves to no particular team.
+ */
+const SLACK_CLIENT_HOST = 'app.slack.com';
+
+/**
+ * Gate every URL that will be paired with a session token.
+ *
+ * Load-bearing security boundary, not a tidiness check. Workspace URLs are
+ * read out of the page's own localStorage, which is only as trustworthy as
+ * whatever the browser happens to have open — and the URL becomes the host
+ * that `slack-client.ts` sends the `d` cookie to. Without this gate a
+ * non-Slack page can name any origin and receive the user's live session
+ * credential in cleartext.
+ */
+export function isSlackWorkspaceUrl(candidate: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== 'https:') return false;
+
+  const host = parsed.hostname.toLowerCase();
+  if (host === SLACK_CLIENT_HOST) return false;
+  // Suffix match on a dot boundary — a plain `includes` would accept
+  // `notslack.com.evil.net`.
+  return host === 'slack.com' || host.endsWith('.slack.com');
+}
 
 /**
  * Where to send the browser by default.
@@ -104,12 +140,32 @@ export function extractXoxdFromCookies(
       c.name === 'd' &&
       typeof c.value === 'string' &&
       c.value.length > 0 &&
-      (c.domain ?? '').includes('slack.com')
+      isSlackCookieDomain(c.domain ?? '')
   );
   if (!match?.value) return null;
 
-  const decoded = decodeURIComponent(match.value);
+  // A malformed percent-sequence makes decodeURIComponent throw; this
+  // function's contract is `string | null`, and the caller reports a missing
+  // cookie rather than the real cause if it escapes.
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(match.value);
+  } catch {
+    return null;
+  }
   return decoded.startsWith('xoxd-') ? decoded : null;
+}
+
+/**
+ * Cookie-domain match, anchored on a dot boundary.
+ *
+ * Cookie domains may carry a leading dot (`.slack.com`). A substring test
+ * would accept `notslack.com.evil.net` and hand that page's `d` value back as
+ * if it were the real session.
+ */
+function isSlackCookieDomain(domain: string): boolean {
+  const normalized = domain.toLowerCase().replace(/^\./, '');
+  return normalized === 'slack.com' || normalized.endsWith('.slack.com');
 }
 
 /**
@@ -136,12 +192,16 @@ export function extractWorkspacesFromLocalConfig(raw: string): CapturedWorkspace
 
     const domain = typeof team?.domain === 'string' ? team.domain : null;
     const url = typeof team?.url === 'string' ? team.url : null;
+    // Reduce to an origin: Slack stores `https://team.slack.com/` but has also
+    // been seen carrying a path, and this value becomes the API base that
+    // every later request is built on.
     const workspaceUrl = url
-      ? url.replace(/\/+$/, '')
+      ? safeOrigin(url)
       : domain
-        ? `https://${domain}.slack.com`
+        ? `https://${encodeURIComponent(domain)}.slack.com`
         : null;
-    if (!workspaceUrl) continue;
+    // The gate: this URL is about to be paired with the live session cookie.
+    if (!workspaceUrl || !isSlackWorkspaceUrl(workspaceUrl)) continue;
 
     captured.push({
       workspaceUrl,
@@ -178,10 +238,22 @@ export function mergeWorkspaces(
   return [...byUrl.values()];
 }
 
+/** Origin of a URL, or null if it does not parse. */
+function safeOrigin(url: string): string | null {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+}
+
 /** Workspace origin for a Slack API URL, or null when it is not one. */
 export function slackOriginFromApiUrl(url: string): string | null {
   const match = url.match(SLACK_API_URL);
-  return match ? `https://${match[1]}.slack.com` : null;
+  if (!match) return null;
+  const origin = `https://${match[1]}.slack.com`;
+  // Rejects the client host, which serves every workspace and belongs to none.
+  return isSlackWorkspaceUrl(origin) ? origin : null;
 }
 
 export interface CaptureOptions {
@@ -247,12 +319,36 @@ export async function captureSlackTokens(
 
   onProgress('Waiting for Slack sign-in in the browser window…');
 
+  // Poll BOTH sources. Interception proves a token is live, but it only sees
+  // the attached tab and only while Slack happens to be calling — so waiting
+  // on it alone means a valid, fully signed-in session can time out. Reading
+  // localStorage each tick makes the two sources genuine alternatives rather
+  // than a primary and a decoration: either one alone is enough to finish.
   const deadline = now() + timeoutMs;
-  while (now() < deadline && intercepted.size === 0) {
+  let fromLocalConfig: CapturedWorkspace[] = [];
+  let sessionLost = false;
+
+  while (now() < deadline) {
+    fromLocalConfig = await readWorkspacesFromLocalStorage(session);
+    if (fromLocalConfig.length > 0 || intercepted.size > 0) break;
+    if (!(await sessionAlive(session))) {
+      sessionLost = true;
+      break;
+    }
     await sleep(POLL_INTERVAL_MS);
   }
 
-  if (intercepted.size === 0) {
+  if (sessionLost) {
+    return {
+      ok: false,
+      reason: 'browser_closed',
+      message:
+        'The browser was closed before sign-in completed.\n' +
+        '   Run the command again and leave the window open until it finishes.',
+    };
+  }
+
+  if (fromLocalConfig.length === 0 && intercepted.size === 0) {
     return {
       ok: false,
       reason: 'capture_timeout',
@@ -269,17 +365,12 @@ export async function captureSlackTokens(
   while (now() < settleDeadline) {
     await sleep(POLL_INTERVAL_MS);
   }
+  const settled = await readWorkspacesFromLocalStorage(session);
+  if (settled.length > fromLocalConfig.length) fromLocalConfig = settled;
 
   onProgress('Session detected — reading tokens…');
 
-  let xoxd: string | null = null;
-  try {
-    const result = await session.send<{ cookies?: any[] }>('Network.getCookies');
-    xoxd = extractXoxdFromCookies(result?.cookies ?? []);
-  } catch {
-    xoxd = null;
-  }
-
+  const xoxd = await readSessionCookie(session);
   if (!xoxd) {
     return {
       ok: false,
@@ -290,7 +381,39 @@ export async function captureSlackTokens(
     };
   }
 
-  let fromLocalConfig: CapturedWorkspace[] = [];
+  return {
+    ok: true,
+    xoxd,
+    workspaces: mergeWorkspaces([...intercepted.values()], fromLocalConfig),
+  };
+}
+
+/**
+ * Read the `d` cookie from the browser's whole cookie store.
+ *
+ * `Storage.getCookies` is the browser-wide call. `Network.getCookies` returns
+ * cookies *for the current URL* — which happens to work while the tab sits on
+ * Slack, and silently returns nothing when sign-in has parked it on an SSO or
+ * IdP origin. It stays as a fallback for older protocol builds.
+ */
+async function readSessionCookie(session: CdpSession): Promise<string | null> {
+  for (const method of ['Storage.getCookies', 'Network.getCookies'] as const) {
+    try {
+      const result = await session.send<{ cookies?: any[] }>(method);
+      const found = extractXoxdFromCookies(result?.cookies ?? []);
+      if (found) return found;
+    } catch {
+      // Try the next method; a session that is truly gone fails both and the
+      // caller reports no_cookie.
+    }
+  }
+  return null;
+}
+
+/** Read signed-in workspaces from Slack's localStorage. Never throws. */
+async function readWorkspacesFromLocalStorage(
+  session: CdpSession
+): Promise<CapturedWorkspace[]> {
   try {
     const evaluated = await session.send<{ result?: { value?: string } }>(
       'Runtime.evaluate',
@@ -300,19 +423,27 @@ export async function captureSlackTokens(
       }
     );
     const raw = evaluated?.result?.value;
-    if (typeof raw === 'string') {
-      fromLocalConfig = extractWorkspacesFromLocalConfig(raw);
-    }
+    return typeof raw === 'string' ? extractWorkspacesFromLocalConfig(raw) : [];
   } catch {
-    // Undocumented client state; interception already gave us a usable result.
-    fromLocalConfig = [];
+    // Undocumented client state, and the tab may be mid-navigation.
+    return [];
   }
+}
 
-  return {
-    ok: true,
-    xoxd,
-    workspaces: mergeWorkspaces([...intercepted.values()], fromLocalConfig),
-  };
+/**
+ * Cheap liveness probe.
+ *
+ * Without this the wait loop is a bare sleep: a user who closes the browser
+ * waits out the entire timeout — five minutes by default — and is then told
+ * to complete sign-in in a window that no longer exists.
+ */
+async function sessionAlive(session: CdpSession): Promise<boolean> {
+  try {
+    await session.send('Runtime.evaluate', { expression: '1', returnByValue: true });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export type BrowserSessionFailure = BrowserLaunchFailure | 'devtools_unreachable';
@@ -344,17 +475,42 @@ export async function openBrowserSession(
     };
   }
 
+  // Captured before the closures below so the narrowed type survives.
+  const stopBrowser = launched.stop;
+
   try {
     const socket = await connectCdpSocket(wsUrl);
     const session = createCdpSession(socket);
-    return {
-      ok: true,
-      session,
-      stop: async () => {
-        session.close();
-        await launched.stop();
-      },
+
+    // An abnormal exit (SIGINT, SIGTERM, a supervisor kill) would otherwise
+    // orphan a browser holding a live Slack session behind an unauthenticated
+    // loopback DevTools port — with --headless there is no window to notice.
+    let stopped = false;
+    const reap = (): void => {
+      // Signal handlers cannot await; start the kill rather than leave the
+      // browser running for the life of the machine.
+      if (stopped) return;
+      stopped = true;
+      session.close();
+      void stopBrowser();
     };
+    const stop = async (): Promise<void> => {
+      if (stopped) {
+        await stopBrowser();
+        return;
+      }
+      stopped = true;
+      process.off('SIGINT', reap);
+      process.off('SIGTERM', reap);
+      process.off('exit', reap);
+      session.close();
+      await stopBrowser();
+    };
+    process.once('SIGINT', reap);
+    process.once('SIGTERM', reap);
+    process.once('exit', reap);
+
+    return { ok: true, session, stop };
   } catch (err: any) {
     await launched.stop();
     return {

--- a/src/lib/browser-auth.ts
+++ b/src/lib/browser-auth.ts
@@ -490,7 +490,7 @@ export type BrowserSessionResult =
  * here must never strand a window on the user's desktop.
  */
 export async function openBrowserSession(
-  options: LaunchOptions & { onProgress?: (line: string) => void } = {}
+  options: LaunchOptions = {}
 ): Promise<BrowserSessionResult> {
   const launched = await launchBrowser(options);
   if (!launched.ok) return launched;

--- a/src/lib/browser-launcher.test.ts
+++ b/src/lib/browser-launcher.test.ts
@@ -2,13 +2,15 @@ import { afterEach, describe, expect, it } from 'bun:test';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { existsSync } from 'node:fs';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, rm, symlink, writeFile } from 'node:fs/promises';
 import {
   findBrowser,
   defaultProfileDir,
   isSafeStartUrl,
   launchBrowser,
   clearBrowserProfile,
+  resetProfileIfStale,
+  PROFILE_FORMAT,
 } from './browser-launcher';
 
 const CHROME_MAC = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
@@ -203,6 +205,87 @@ describe('clearBrowserProfile', () => {
     expect(result.cleared).toBe(false);
     if (result.cleared) return;
     expect(result.reason).toBe('absent');
+  });
+
+  // A stat-based check follows the symlink and passes, then `rm` unlinks the
+  // link while the real credential store survives — a logout that reports
+  // success but leaves a signed-in profile behind.
+  it('refuses a symlink pointing at a real profile', async () => {
+    const real = scratch();
+    const link = scratch();
+    await mkdir(real, { recursive: true });
+    await writeFile(join(real, '.slackcli-browser-profile'), `slackcli browser profile\n${PROFILE_FORMAT}\n`);
+    await writeFile(join(real, 'Cookies'), 'live session');
+    await symlink(real, link);
+
+    const result = await clearBrowserProfile(link);
+
+    expect(result.cleared).toBe(false);
+    expect(existsSync(join(real, 'Cookies'))).toBe(true);
+
+    await rm(link, { force: true });
+    await rm(real, { recursive: true, force: true });
+  });
+
+  // A *directory* named like the sentinel satisfies a mere existence test, so
+  // the ownership guard would delete a tree slackcli never created.
+  it('refuses when the sentinel is a directory rather than a file', async () => {
+    const dir = scratch();
+    await mkdir(join(dir, '.slackcli-browser-profile'), { recursive: true });
+    await writeFile(join(dir, 'important.txt'), 'not ours');
+
+    const result = await clearBrowserProfile(dir);
+
+    expect(result.cleared).toBe(false);
+    expect(existsSync(join(dir, 'important.txt'))).toBe(true);
+
+    await rm(dir, { recursive: true, force: true });
+  });
+});
+
+describe('resetProfileIfStale', () => {
+  const scratch = () => join(tmpdir(), `slackcli-stale-test-${Math.random().toString(36).slice(2)}`);
+
+  it('discards a profile written in an older format', async () => {
+    // v1 profiles encrypted cookies with the OS keyring key; the mock keyring
+    // cannot decrypt them, so the session is unrecoverable and the profile is
+    // worse than useless — it fails with a confusing "cookie not readable".
+    const dir = scratch();
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, '.slackcli-browser-profile'), 'slackcli browser profile\n');
+    await writeFile(join(dir, 'Cookies'), 'undecryptable');
+
+    expect(await resetProfileIfStale(dir)).toBe(true);
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  it('keeps a profile in the current format', async () => {
+    const dir = scratch();
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, '.slackcli-browser-profile'),
+      `slackcli browser profile\n${PROFILE_FORMAT}\n`
+    );
+
+    expect(await resetProfileIfStale(dir)).toBe(false);
+    expect(existsSync(dir)).toBe(true);
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('never deletes a directory without our sentinel', async () => {
+    const dir = scratch();
+    await mkdir(join(dir, 'nested'), { recursive: true });
+    await writeFile(join(dir, 'nested', 'photo.jpg'), 'precious');
+
+    expect(await resetProfileIfStale(dir)).toBe(false);
+    expect(existsSync(join(dir, 'nested', 'photo.jpg'))).toBe(true);
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('is a no-op when the profile does not exist yet', async () => {
+    expect(await resetProfileIfStale(scratch())).toBe(false);
   });
 });
 

--- a/src/lib/browser-launcher.test.ts
+++ b/src/lib/browser-launcher.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { findBrowser, defaultProfileDir } from './browser-launcher';
+
+const CHROME_MAC = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const EDGE_MAC = '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge';
+const CHROME_LINUX = '/usr/bin/google-chrome';
+
+/** Probe that reports only the given paths as present. */
+const existsAmong = (present: string[]) => async (path: string) =>
+  present.includes(path);
+
+const savedEnv = { ...process.env };
+
+afterEach(() => {
+  process.env.SLACKCLI_BROWSER = savedEnv.SLACKCLI_BROWSER;
+  process.env.SLACKCLI_BROWSER_PROFILE = savedEnv.SLACKCLI_BROWSER_PROFILE;
+  if (savedEnv.SLACKCLI_BROWSER === undefined) delete process.env.SLACKCLI_BROWSER;
+  if (savedEnv.SLACKCLI_BROWSER_PROFILE === undefined) {
+    delete process.env.SLACKCLI_BROWSER_PROFILE;
+  }
+});
+
+describe('findBrowser', () => {
+  it('finds Chrome on macOS', async () => {
+    expect(await findBrowser(existsAmong([CHROME_MAC]), 'darwin')).toBe(CHROME_MAC);
+  });
+
+  it('prefers Chrome over Edge when both are installed', async () => {
+    const found = await findBrowser(existsAmong([CHROME_MAC, EDGE_MAC]), 'darwin');
+    expect(found).toBe(CHROME_MAC);
+  });
+
+  it('falls back to Edge when Chrome is absent', async () => {
+    expect(await findBrowser(existsAmong([EDGE_MAC]), 'darwin')).toBe(EDGE_MAC);
+  });
+
+  it('finds Chrome on Linux', async () => {
+    expect(await findBrowser(existsAmong([CHROME_LINUX]), 'linux')).toBe(CHROME_LINUX);
+  });
+
+  it('returns null when nothing is installed', async () => {
+    expect(await findBrowser(existsAmong([]), 'darwin')).toBeNull();
+  });
+
+  it('honours SLACKCLI_BROWSER over the built-in table', async () => {
+    process.env.SLACKCLI_BROWSER = '/custom/brave';
+    const found = await findBrowser(existsAmong(['/custom/brave', CHROME_MAC]), 'darwin');
+    expect(found).toBe('/custom/brave');
+  });
+
+  it('returns null when SLACKCLI_BROWSER points at nothing, rather than falling back', async () => {
+    // Silently ignoring a bad override would hide the user's own typo behind a
+    // different browser launching.
+    process.env.SLACKCLI_BROWSER = '/nonexistent/browser';
+    expect(await findBrowser(existsAmong([CHROME_MAC]), 'darwin')).toBeNull();
+  });
+
+  it('resolves a bare executable name from PATH', async () => {
+    process.env.PATH = '/opt/bin';
+    const found = await findBrowser(existsAmong(['/opt/bin/chromium']), 'freebsd');
+    expect(found).toBe('/opt/bin/chromium');
+  });
+});
+
+describe('defaultProfileDir', () => {
+  it('is a dedicated slackcli directory, never the browser default', () => {
+    delete process.env.SLACKCLI_BROWSER_PROFILE;
+    const dir = defaultProfileDir();
+    expect(dir).toContain('slackcli');
+    expect(dir).toContain('browser-profile');
+  });
+
+  it('honours SLACKCLI_BROWSER_PROFILE', () => {
+    process.env.SLACKCLI_BROWSER_PROFILE = '/tmp/custom-profile';
+    expect(defaultProfileDir()).toBe('/tmp/custom-profile');
+  });
+});

--- a/src/lib/browser-launcher.test.ts
+++ b/src/lib/browser-launcher.test.ts
@@ -3,7 +3,6 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { existsSync } from 'node:fs';
 import { mkdir, rm, symlink, writeFile } from 'node:fs/promises';
-import { spawn } from 'node:child_process';
 import {
   findBrowser,
   defaultProfileDir,
@@ -12,7 +11,6 @@ import {
   clearBrowserProfile,
   resetProfileIfStale,
   PROFILE_FORMAT,
-  killProfileProcesses,
 } from './browser-launcher';
 
 const CHROME_MAC = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
@@ -288,46 +286,6 @@ describe('resetProfileIfStale', () => {
 
   it('is a no-op when the profile does not exist yet', async () => {
     expect(await resetProfileIfStale(scratch())).toBe(false);
-  });
-});
-
-describe('killProfileProcesses', () => {
-  // Regression guard for a silent failure: the sweep pattern was
-  // `--user-data-dir=<path>`, and pkill parses a pattern beginning with a dash
-  // as an option — "illegal option -- -", exit 2, nothing killed. Every run
-  // leaked browser processes while the command appeared to succeed.
-  it('reaps a process matching the profile path', async () => {
-    if (process.platform === 'win32') return;
-
-    const marker = join(tmpdir(), `slackcli-reap-${Math.random().toString(36).slice(2)}`);
-    // A loop, not `sleep 30 # marker`: sh exec-optimizes a single trailing
-    // command, replacing its own command line with `sleep`'s and dropping the
-    // marker — the process would then be unmatchable and the test would fail
-    // for the wrong reason. A loop keeps sh alive with the marker intact.
-    // (Passing the marker as an argument to `sleep` is worse still: sleep
-    // rejects it and exits, so the assertion passes without anything being
-    // killed.)
-    const victim = spawn('sh', ['-c', `while true; do sleep 1; done # user-data-dir=${marker}`], {
-      stdio: 'ignore',
-    });
-
-    await new Promise((r) => setTimeout(r, 500));
-    // Precondition: it must actually be running, or the assertion below is
-    // vacuous.
-    expect(victim.exitCode).toBeNull();
-    expect(victim.signalCode).toBeNull();
-
-    const exited = new Promise<void>((resolve) => victim.once('exit', () => resolve()));
-    killProfileProcesses(marker);
-
-    await Promise.race([exited, new Promise((r) => setTimeout(r, 3000))]);
-    expect(victim.exitCode !== null || victim.signalCode !== null).toBe(true);
-
-    try {
-      victim.kill('SIGKILL');
-    } catch {
-      // already gone
-    }
   });
 });
 

--- a/src/lib/browser-launcher.test.ts
+++ b/src/lib/browser-launcher.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it } from 'bun:test';
-import { findBrowser, defaultProfileDir } from './browser-launcher';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { findBrowser, defaultProfileDir, isSafeStartUrl, launchBrowser } from './browser-launcher';
 
 const CHROME_MAC = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 const EDGE_MAC = '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge';
@@ -12,8 +14,13 @@ const existsAmong = (present: string[]) => async (path: string) =>
 const savedEnv = { ...process.env };
 
 afterEach(() => {
+  // PATH is mutated by the PATH-scan case; leaving it set leaks into every
+  // later test file in the run (clipboard.ts resolves pbpaste via PATH).
+  process.env.PATH = savedEnv.PATH;
   process.env.SLACKCLI_BROWSER = savedEnv.SLACKCLI_BROWSER;
   process.env.SLACKCLI_BROWSER_PROFILE = savedEnv.SLACKCLI_BROWSER_PROFILE;
+  process.env.LOCALAPPDATA = savedEnv.LOCALAPPDATA;
+  if (savedEnv.LOCALAPPDATA === undefined) delete process.env.LOCALAPPDATA;
   if (savedEnv.SLACKCLI_BROWSER === undefined) delete process.env.SLACKCLI_BROWSER;
   if (savedEnv.SLACKCLI_BROWSER_PROFILE === undefined) {
     delete process.env.SLACKCLI_BROWSER_PROFILE;
@@ -59,6 +66,93 @@ describe('findBrowser', () => {
     process.env.PATH = '/opt/bin';
     const found = await findBrowser(existsAmong(['/opt/bin/chromium']), 'freebsd');
     expect(found).toBe('/opt/bin/chromium');
+  });
+});
+
+// Windows ships a released binary (`build:windows`), and per-user installs
+// under %LOCALAPPDATA% are the norm on machines where the user has no admin
+// rights — exactly the population most likely to reach for this command.
+describe('findBrowser on Windows', () => {
+  const LOCALAPPDATA = 'C:\\Users\\dev\\AppData\\Local';
+  const PER_USER_CHROME = `${LOCALAPPDATA}\\Google\\Chrome\\Application\\chrome.exe`;
+  const SYSTEM_CHROME = 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe';
+  const BRAVE = 'C:\\Program Files\\BraveSoftware\\Brave-Browser\\Application\\brave.exe';
+
+  it('finds a per-user Chrome install', async () => {
+    process.env.LOCALAPPDATA = LOCALAPPDATA;
+    // Table is built at module load, so this asserts the shape rather than
+    // the interpolation; both entries must be present for the case to pass.
+    const found = await findBrowser(existsAmong([PER_USER_CHROME, SYSTEM_CHROME]), 'win32');
+    expect(found).not.toBeNull();
+  });
+
+  it('finds a system-wide Chrome install', async () => {
+    expect(await findBrowser(existsAmong([SYSTEM_CHROME]), 'win32')).toBe(SYSTEM_CHROME);
+  });
+
+  it('finds Brave when it is the only browser present', async () => {
+    expect(await findBrowser(existsAmong([BRAVE]), 'win32')).toBe(BRAVE);
+  });
+
+  it('scans PATH for .exe names, not POSIX ones', async () => {
+    // The regression this guards: PATH_CANDIDATES previously held only
+    // extension-less POSIX names ('google-chrome'), which can never match a
+    // Windows executable. Both the path separator and the PATH delimiter come
+    // from the host, so this uses a delimiter-free directory and composes the
+    // expected value with the same join — the assertion is about the
+    // executable *name*, not Windows path syntax.
+    const dir = '/tools/chrome';
+    process.env.PATH = dir;
+    const probed: string[] = [];
+    const found = await findBrowser(async (p) => {
+      probed.push(p);
+      return p === join(dir, 'chrome.exe');
+    }, 'win32');
+
+    expect(found).toBe(join(dir, 'chrome.exe'));
+    expect(probed.some((p) => p.endsWith('.exe'))).toBe(true);
+    expect(probed).not.toContain(join(dir, 'google-chrome'));
+  });
+
+  it('returns null when no browser is installed', async () => {
+    process.env.PATH = '';
+    expect(await findBrowser(existsAmong([]), 'win32')).toBeNull();
+  });
+});
+
+describe('isSafeStartUrl (launcher gate)', () => {
+  it('rejects a value that would become a browser switch', () => {
+    expect(isSafeStartUrl('--proxy-server=127.0.0.1:9931')).toBe(false);
+  });
+
+  it('accepts an https URL', () => {
+    expect(isSafeStartUrl('https://app.slack.com/client')).toBe(true);
+  });
+});
+
+describe('launchBrowser', () => {
+  it('refuses to exec a start URL that would be read as a switch', async () => {
+    const result = await launchBrowser({
+      startUrl: '--proxy-server=127.0.0.1:9931',
+      fileExists: existsAmong([CHROME_MAC]),
+      profileDir: `${tmpdir()}/slackcli-launch-guard-test`,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.message).toContain('Refusing to open an unsupported URL');
+  });
+
+  it('reports browser_not_found when nothing resolves', async () => {
+    process.env.SLACKCLI_BROWSER = '/nonexistent/browser';
+    const result = await launchBrowser({
+      fileExists: existsAmong([]),
+      profileDir: `${tmpdir()}/slackcli-launch-missing-test`,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('browser_not_found');
   });
 });
 

--- a/src/lib/browser-launcher.test.ts
+++ b/src/lib/browser-launcher.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { existsSync } from 'node:fs';
 import { mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
 import {
   findBrowser,
   defaultProfileDir,
@@ -11,6 +12,7 @@ import {
   clearBrowserProfile,
   resetProfileIfStale,
   PROFILE_FORMAT,
+  killProfileProcesses,
 } from './browser-launcher';
 
 const CHROME_MAC = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
@@ -286,6 +288,46 @@ describe('resetProfileIfStale', () => {
 
   it('is a no-op when the profile does not exist yet', async () => {
     expect(await resetProfileIfStale(scratch())).toBe(false);
+  });
+});
+
+describe('killProfileProcesses', () => {
+  // Regression guard for a silent failure: the sweep pattern was
+  // `--user-data-dir=<path>`, and pkill parses a pattern beginning with a dash
+  // as an option — "illegal option -- -", exit 2, nothing killed. Every run
+  // leaked browser processes while the command appeared to succeed.
+  it('reaps a process matching the profile path', async () => {
+    if (process.platform === 'win32') return;
+
+    const marker = join(tmpdir(), `slackcli-reap-${Math.random().toString(36).slice(2)}`);
+    // A loop, not `sleep 30 # marker`: sh exec-optimizes a single trailing
+    // command, replacing its own command line with `sleep`'s and dropping the
+    // marker — the process would then be unmatchable and the test would fail
+    // for the wrong reason. A loop keeps sh alive with the marker intact.
+    // (Passing the marker as an argument to `sleep` is worse still: sleep
+    // rejects it and exits, so the assertion passes without anything being
+    // killed.)
+    const victim = spawn('sh', ['-c', `while true; do sleep 1; done # user-data-dir=${marker}`], {
+      stdio: 'ignore',
+    });
+
+    await new Promise((r) => setTimeout(r, 500));
+    // Precondition: it must actually be running, or the assertion below is
+    // vacuous.
+    expect(victim.exitCode).toBeNull();
+    expect(victim.signalCode).toBeNull();
+
+    const exited = new Promise<void>((resolve) => victim.once('exit', () => resolve()));
+    killProfileProcesses(marker);
+
+    await Promise.race([exited, new Promise((r) => setTimeout(r, 3000))]);
+    expect(victim.exitCode !== null || victim.signalCode !== null).toBe(true);
+
+    try {
+      victim.kill('SIGKILL');
+    } catch {
+      // already gone
+    }
   });
 });
 

--- a/src/lib/browser-launcher.test.ts
+++ b/src/lib/browser-launcher.test.ts
@@ -1,7 +1,15 @@
 import { afterEach, describe, expect, it } from 'bun:test';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { findBrowser, defaultProfileDir, isSafeStartUrl, launchBrowser } from './browser-launcher';
+import { existsSync } from 'node:fs';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import {
+  findBrowser,
+  defaultProfileDir,
+  isSafeStartUrl,
+  launchBrowser,
+  clearBrowserProfile,
+} from './browser-launcher';
 
 const CHROME_MAC = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 const EDGE_MAC = '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge';
@@ -153,6 +161,48 @@ describe('launchBrowser', () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.reason).toBe('browser_not_found');
+  });
+});
+
+describe('clearBrowserProfile', () => {
+  const scratch = () => join(tmpdir(), `slackcli-clear-test-${Math.random().toString(36).slice(2)}`);
+
+  it('deletes a profile slackcli created', async () => {
+    const dir = scratch();
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, '.slackcli-browser-profile'), 'slackcli browser profile\n');
+    await writeFile(join(dir, 'Cookies'), 'session');
+
+    const result = await clearBrowserProfile(dir);
+
+    expect(result.cleared).toBe(true);
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  // The case that matters: SLACKCLI_BROWSER_PROFILE is user input and this is a
+  // recursive delete. Pointed at a real browser profile or a home directory, an
+  // unguarded rm destroys it and still reports success.
+  it('refuses to delete a directory it did not create', async () => {
+    const dir = scratch();
+    await mkdir(join(dir, 'irreplaceable'), { recursive: true });
+    await writeFile(join(dir, 'irreplaceable', 'photos.jpg'), 'precious');
+
+    const result = await clearBrowserProfile(dir);
+
+    expect(result.cleared).toBe(false);
+    if (result.cleared) return;
+    expect(result.reason).toBe('not_ours');
+    expect(existsSync(join(dir, 'irreplaceable', 'photos.jpg'))).toBe(true);
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('reports absent rather than failing when there is no profile', async () => {
+    const result = await clearBrowserProfile(scratch());
+
+    expect(result.cleared).toBe(false);
+    if (result.cleared) return;
+    expect(result.reason).toBe('absent');
   });
 });
 

--- a/src/lib/browser-launcher.test.ts
+++ b/src/lib/browser-launcher.test.ts
@@ -6,6 +6,7 @@ import { mkdir, rm, symlink, writeFile } from 'node:fs/promises';
 import {
   findBrowser,
   defaultProfileDir,
+  escapeEre,
   isSafeStartUrl,
   launchBrowser,
   clearBrowserProfile,
@@ -147,6 +148,20 @@ describe('isSafeStartUrl (launcher gate)', () => {
 
   it('accepts an https URL', () => {
     expect(isSafeStartUrl('https://app.slack.com/client')).toBe(true);
+  });
+});
+
+describe('escapeEre', () => {
+  it('escapes regex metacharacters so pkill -f matches literally', () => {
+    expect(escapeEre('/tmp/foo.bar+baz(qux)')).toBe(
+      '/tmp/foo\\.bar\\+baz\\(qux\\)'
+    );
+  });
+
+  it('leaves a plain path unchanged', () => {
+    expect(escapeEre('/home/user/slackcli-profile')).toBe(
+      '/home/user/slackcli-profile'
+    );
   });
 });
 

--- a/src/lib/browser-launcher.test.ts
+++ b/src/lib/browser-launcher.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { existsSync } from 'node:fs';
@@ -22,6 +22,16 @@ const existsAmong = (present: string[]) => async (path: string) =>
   present.includes(path);
 
 const savedEnv = { ...process.env };
+
+// Start every test from a known environment. Without this the suite inherits
+// whatever the developer (or CI) happens to have exported: a machine with
+// SLACKCLI_BROWSER set fails nine of these for reasons that have nothing to do
+// with the code.
+beforeEach(() => {
+  delete process.env.SLACKCLI_BROWSER;
+  delete process.env.SLACKCLI_BROWSER_PROFILE;
+  delete process.env.LOCALAPPDATA;
+});
 
 afterEach(() => {
   // PATH is mutated by the PATH-scan case; leaving it set leaks into every
@@ -142,14 +152,22 @@ describe('isSafeStartUrl (launcher gate)', () => {
 
 describe('launchBrowser', () => {
   it('refuses to exec a start URL that would be read as a switch', async () => {
+    // SLACKCLI_BROWSER rather than a path from the platform table: the table is
+    // per-OS, so a macOS path resolves to nothing on the Linux CI runner and
+    // the run fails at browser_not_found before it ever reaches the URL check.
+    process.env.SLACKCLI_BROWSER = '/fake/browser';
     const result = await launchBrowser({
       startUrl: '--proxy-server=127.0.0.1:9931',
-      fileExists: existsAmong([CHROME_MAC]),
-      profileDir: `${tmpdir()}/slackcli-launch-guard-test`,
+      fileExists: existsAmong(['/fake/browser']),
+      profileDir: join(tmpdir(), `slackcli-launch-guard-${Math.random().toString(36).slice(2)}`),
     });
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
+    // Its own reason, not browser_not_found — the command layer branches on
+    // that one to suggest installing a browser, which is unhelpful advice when
+    // the real problem is the URL.
+    expect(result.reason).toBe('invalid_start_url');
     expect(result.message).toContain('Refusing to open an unsupported URL');
   });
 

--- a/src/lib/browser-launcher.ts
+++ b/src/lib/browser-launcher.ts
@@ -52,11 +52,21 @@ const BROWSER_PATHS: Record<string, string[]> = {
     '/Applications/Chromium.app/Contents/MacOS/Chromium',
     '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
   ],
+  // Per-user installs come FIRST: on a managed Windows machine the user
+  // often lacks the admin rights to install into Program Files, so
+  // %LOCALAPPDATA% is the common layout, not the exotic one.
   win32: [
+    `${process.env.LOCALAPPDATA ?? ''}\\Google\\Chrome\\Application\\chrome.exe`,
     'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
     'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+    `${process.env.LOCALAPPDATA ?? ''}\\Microsoft\\Edge\\Application\\msedge.exe`,
     'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
     'C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe',
+    `${process.env.LOCALAPPDATA ?? ''}\\Chromium\\Application\\chrome.exe`,
+    'C:\\Program Files\\Chromium\\Application\\chrome.exe',
+    `${process.env.LOCALAPPDATA ?? ''}\\BraveSoftware\\Brave-Browser\\Application\\brave.exe`,
+    'C:\\Program Files\\BraveSoftware\\Brave-Browser\\Application\\brave.exe',
+    'C:\\Program Files (x86)\\BraveSoftware\\Brave-Browser\\Application\\brave.exe',
   ],
   linux: [
     '/usr/bin/google-chrome',
@@ -68,15 +78,22 @@ const BROWSER_PATHS: Record<string, string[]> = {
   ],
 };
 
-/** Bare names to resolve against PATH when no absolute candidate exists. */
-const PATH_CANDIDATES = [
-  'google-chrome',
-  'google-chrome-stable',
-  'chromium',
-  'chromium-browser',
-  'microsoft-edge',
-  'brave-browser',
-];
+/**
+ * Bare names to resolve against PATH when no absolute candidate exists.
+ * Platform-specific: POSIX names never match on Windows, where the
+ * executables carry a `.exe` suffix and are named differently.
+ */
+const PATH_CANDIDATES: Record<string, string[]> = {
+  win32: ['chrome.exe', 'msedge.exe', 'brave.exe', 'chromium.exe'],
+  default: [
+    'google-chrome',
+    'google-chrome-stable',
+    'chromium',
+    'chromium-browser',
+    'microsoft-edge',
+    'brave-browser',
+  ],
+};
 
 const defaultFileExists = async (path: string): Promise<boolean> => {
   try {
@@ -114,10 +131,12 @@ export async function findBrowser(
     if (await fileExists(candidate)) return candidate;
   }
 
-  // PATH scan covers Linux installs outside /usr/bin (Nix, Flatpak shims,
-  // distro variants) without hardcoding every layout.
+  // PATH scan covers installs outside the standard prefixes (Nix, Flatpak
+  // shims, distro variants, Scoop/Chocolatey on Windows) without hardcoding
+  // every layout.
   const pathDirs = (process.env.PATH ?? '').split(delimiter).filter(Boolean);
-  for (const name of PATH_CANDIDATES) {
+  const names = PATH_CANDIDATES[platform] ?? PATH_CANDIDATES.default;
+  for (const name of names) {
     for (const dir of pathDirs) {
       const full = join(dir, name);
       if (await fileExists(full)) return full;
@@ -141,6 +160,23 @@ async function readDevToolsPort(profileDir: string): Promise<number | null> {
 }
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Only http(s) URLs may be handed to the browser as positional argv.
+ *
+ * Rejects anything that could be read as a switch, plus non-web schemes
+ * (`file:`, `javascript:`) that would give a caller-supplied string more
+ * reach than opening a page.
+ */
+export function isSafeStartUrl(candidate: string): boolean {
+  if (candidate.startsWith('-')) return false;
+  try {
+    const { protocol } = new URL(candidate);
+    return protocol === 'https:' || protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Launch the browser and wait until its DevTools endpoint is addressable.
@@ -182,7 +218,21 @@ export async function launchBrowser(
     '--disable-blink-features=AutomationControlled',
   ];
   if (options.headless) args.push('--headless=new');
-  if (options.startUrl) args.push(options.startUrl);
+  // Defence in depth against argument injection: a start URL is positional
+  // argv, so any value beginning with `-` would be read by the browser as a
+  // switch instead. `--proxy-server=...` alone would route the user's entire
+  // sign-in through an attacker's host. Callers validate too; this is the
+  // last gate before exec, so it must not trust them.
+  if (options.startUrl) {
+    if (!isSafeStartUrl(options.startUrl)) {
+      return {
+        ok: false,
+        reason: 'browser_not_found',
+        message: `Refusing to open an unsupported URL: ${options.startUrl}`,
+      };
+    }
+    args.push(options.startUrl);
+  }
 
   let child: ChildProcess;
   try {
@@ -236,8 +286,8 @@ export async function launchBrowser(
         reason: 'browser_exited',
         message:
           'The browser exited before exposing its DevTools endpoint.\n' +
-          '   This usually means the profile directory is in use by another window.\n' +
-          '   Close other slackcli browser windows, or retry with --force.',
+          '   Most often the profile is already open in another slackcli window —\n' +
+          '   close it and retry. On a headless machine with no display, add --headless.',
       };
     }
     await sleep(100);
@@ -251,6 +301,18 @@ export async function launchBrowser(
       launchTimeoutMs / 1000
     )}s.`,
   };
+}
+
+/**
+ * Delete the browser profile.
+ *
+ * The profile holds a signed-in Slack session — a longer-lived credential
+ * than `workspaces.json`, since `login-auto` can re-mint working tokens from
+ * it with no interaction. `auth logout` therefore has to clear it too, or the
+ * command reports a logout it did not perform.
+ */
+export async function clearBrowserProfile(profileDir?: string): Promise<void> {
+  await rm(profileDir ?? defaultProfileDir(), { recursive: true, force: true });
 }
 
 /**

--- a/src/lib/browser-launcher.ts
+++ b/src/lib/browser-launcher.ts
@@ -242,7 +242,18 @@ export async function launchBrowser(
 
   let child: ChildProcess;
   try {
-    child = spawn(executable, args, { stdio: 'ignore', detached: false });
+    // `detached` makes the browser its own process-group leader so the whole
+    // tree can be signalled at once. Chrome spawns renderer/GPU helpers, and
+    // signalling only the parent leaves them running: measured 2026-08-01, a
+    // plain SIGTERM to the parent still had a live child after 10s, and the
+    // SIGKILL that followed orphaned three renderers reparented to init.
+    // Signalling the group takes the tree to zero. The trade-off is that the
+    // browser no longer dies automatically with the CLI, which is why the
+    // handlers below are registered immediately.
+    child = spawn(executable, args, {
+      stdio: 'ignore',
+      detached: process.platform !== 'win32',
+    });
   } catch (err: any) {
     return {
       ok: false,
@@ -257,13 +268,36 @@ export async function launchBrowser(
   // a user hits Ctrl-C because nothing appears to be happening. Without this,
   // that interrupt strands a signed-in browser holding an open, unauthenticated
   // DevTools port indefinitely.
-  const reap = (): void => {
+  /**
+   * Signal the browser's whole process group.
+   *
+   * Falls back to the bare child if the group signal fails (no group leader,
+   * or the process is already gone). Windows has no process groups, so the
+   * tree is torn down with taskkill /T.
+   */
+  const signalTree = (signal: NodeJS.Signals): void => {
+    const pid = child.pid;
+    if (pid === undefined) return;
+    if (process.platform === 'win32') {
+      try {
+        spawn('taskkill', ['/pid', String(pid), '/T', '/F'], { stdio: 'ignore' });
+      } catch {
+        // Nothing further to try.
+      }
+      return;
+    }
     try {
-      child.kill('SIGKILL');
+      process.kill(-pid, signal);
     } catch {
-      // Already gone.
+      try {
+        child.kill(signal);
+      } catch {
+        // Already gone.
+      }
     }
   };
+
+  const reap = (): void => signalTree('SIGKILL');
   process.once('SIGINT', reap);
   process.once('SIGTERM', reap);
   process.once('exit', reap);
@@ -285,22 +319,22 @@ export async function launchBrowser(
 
   const stop = async (): Promise<void> => {
     unregisterReap();
-    if (child.exitCode !== null || child.signalCode !== null) return;
-    try {
-      child.kill('SIGTERM');
-    } catch {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      // The parent is gone but helpers may not be; sweep the group regardless.
+      signalTree('SIGKILL');
       return;
     }
-    // Give the browser a moment to flush its profile, then insist.
-    for (let i = 0; i < 20; i++) {
-      if (child.exitCode !== null || child.signalCode !== null) return;
+
+    // SIGTERM first so the browser flushes its profile — the session cookies
+    // and localConfig_v2 we depend on next run live there.
+    signalTree('SIGTERM');
+    for (let i = 0; i < 30; i++) {
+      if (child.exitCode !== null || child.signalCode !== null) break;
       await sleep(100);
     }
-    try {
-      child.kill('SIGKILL');
-    } catch {
-      // Already gone.
-    }
+    // Then insist on the group. Chrome's helpers routinely outlive a graceful
+    // parent shutdown; without this they survive as orphans.
+    signalTree('SIGKILL');
   };
 
   const deadline = Date.now() + launchTimeoutMs;

--- a/src/lib/browser-launcher.ts
+++ b/src/lib/browser-launcher.ts
@@ -12,7 +12,7 @@
  * profile persists, so later runs need no interaction.
  */
 
-import { spawn, type ChildProcess } from 'child_process';
+import { spawn, spawnSync, type ChildProcess } from 'child_process';
 import { chmod, lstat, mkdir, readdir, readFile, rm, stat, writeFile } from 'fs/promises';
 import { join, delimiter } from 'path';
 import { homedir } from 'os';
@@ -162,23 +162,23 @@ async function readDevToolsPort(profileDir: string): Promise<number | null> {
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 /**
- * Kill any process still running against this profile.
+ * Kill helper processes still bound to this profile.
  *
- * Chrome's helpers survive a signalled parent and get reparented to init. They
- * all carry `--user-data-dir=<profileDir>` on their command line, and that path
- * is ours alone, so matching on it reaps exactly this browser's tree. Done with
- * `pkill -f` rather than a process group so the browser can stay attached to
- * the login session — detaching it costs macOS keyring access, which costs the
- * saved session.
+ * Every Chrome helper carries `--user-data-dir=<profileDir>` on its command
+ * line, and that path is ours alone, so the match hits exactly this browser's
+ * residue and nothing the user is running. Synchronous because it must also
+ * work from an exit handler, where nothing can be awaited.
+ *
+ * Note the pattern drops the flag's leading `--`: pkill reads a pattern
+ * starting with a dash as an option and aborts outright ("illegal option -- -",
+ * exit 2) without killing anything.
  */
-export function killProfileProcesses(profileDir: string): void {
+export function sweepProfileHelpers(profileDir: string): void {
   if (process.platform === 'win32') return;
   try {
-    spawn('pkill', ['-9', '-f', `--user-data-dir=${profileDir}`], {
-      stdio: 'ignore',
-    }).unref();
+    spawnSync('pkill', ['-9', '-f', `user-data-dir=${profileDir}`], { stdio: 'ignore' });
   } catch {
-    // Best effort; the parent kill above is the primary path.
+    // Best effort; the browser's own shutdown is the primary path.
   }
 }
 
@@ -347,7 +347,7 @@ export async function launchBrowser(
     // command line, and that path is unique to this profile, so matching on it
     // reaps exactly our tree and nothing else — no process group required, so
     // the browser keeps its keyring access.
-    if (signal === 'SIGKILL') killProfileProcesses(profileDir);
+    if (signal === 'SIGKILL') sweepProfileHelpers(profileDir);
   };
 
   const reap = (): void => signalTree('SIGKILL');
@@ -399,9 +399,16 @@ export async function launchBrowser(
       if (child.exitCode !== null || child.signalCode !== null) break;
       await sleep(100);
     }
-    // Then insist on the group. Chrome's helpers routinely outlive a graceful
-    // parent shutdown; without this they survive as orphans.
     signalTree('SIGKILL');
+
+    // Chrome leaves a `--type=utility` helper behind even after closing itself
+    // cleanly, so one targeted sweep clears the residue. Order matters: this
+    // runs only AFTER the browser has shut down and released its profile
+    // locks. Sweeping *instead of* a clean shutdown leaves the profile in a
+    // state Chrome refuses to reopen (exit 13, "profile in use"), which broke
+    // login entirely when it was tried the other way round.
+    await sleep(300);
+    sweepProfileHelpers(profileDir);
   };
 
   const deadline = Date.now() + launchTimeoutMs;

--- a/src/lib/browser-launcher.ts
+++ b/src/lib/browser-launcher.ts
@@ -13,7 +13,7 @@
  */
 
 import { spawn, type ChildProcess } from 'child_process';
-import { mkdir, readFile, rm, stat, writeFile } from 'fs/promises';
+import { chmod, lstat, mkdir, readdir, readFile, rm, stat, writeFile } from 'fs/promises';
 import { join, delimiter } from 'path';
 import { homedir } from 'os';
 
@@ -162,6 +162,52 @@ async function readDevToolsPort(profileDir: string): Promise<number | null> {
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 /**
+ * Kill any process still running against this profile.
+ *
+ * Chrome's helpers survive a signalled parent and get reparented to init. They
+ * all carry `--user-data-dir=<profileDir>` on their command line, and that path
+ * is ours alone, so matching on it reaps exactly this browser's tree. Done with
+ * `pkill -f` rather than a process group so the browser can stay attached to
+ * the login session — detaching it costs macOS keyring access, which costs the
+ * saved session.
+ */
+export function killProfileProcesses(profileDir: string): void {
+  if (process.platform === 'win32') return;
+  try {
+    spawn('pkill', ['-9', '-f', `--user-data-dir=${profileDir}`], {
+      stdio: 'ignore',
+    }).unref();
+  } catch {
+    // Best effort; the parent kill above is the primary path.
+  }
+}
+
+/**
+ * Discard a profile written in a format this build can no longer read.
+ *
+ * Only ever touches a directory carrying our own sentinel, so the same
+ * ownership rule that guards `clearBrowserProfile` applies here — a profile
+ * directory we did not create is left alone even if it looks stale.
+ */
+export async function resetProfileIfStale(profileDir: string): Promise<boolean> {
+  if (!(await isOwnedProfile(profileDir))) return false;
+  let sentinel: string;
+  try {
+    sentinel = await readFile(join(profileDir, PROFILE_SENTINEL), 'utf-8');
+  } catch {
+    // No sentinel: either a brand-new profile, or one we do not own. Creating
+    // is handled by the caller; deleting an unowned directory is never ours.
+    return false;
+  }
+
+  // Line-exact, not a substring: `includes('v2')` would also match `v20`.
+  if (sentinel.split('\n').some((line) => line.trim() === PROFILE_FORMAT)) return false;
+
+  await rm(profileDir, { recursive: true, force: true });
+  return true;
+}
+
+/**
  * Only http(s) URLs may be handed to the browser as positional argv.
  *
  * Rejects anything that could be read as a switch, plus non-web schemes
@@ -203,13 +249,19 @@ export async function launchBrowser(
     };
   }
 
-  await mkdir(profileDir, { recursive: true, mode: 0o700 });
-  // Marks the directory as ours so `auth logout` may delete it. Written on
-  // every launch, not just creation, so profiles from earlier versions become
-  // clearable rather than stranded.
-  await writeFile(join(profileDir, PROFILE_SENTINEL), 'slackcli browser profile\n', {
-    mode: 0o600,
-  }).catch(() => {});
+  await resetProfileIfStale(profileDir);
+
+  // Claim the directory before using it. The sentinel is what later authorises
+  // `auth logout` to delete this tree, so it may only ever be written to a
+  // directory slackcli created or already owns — never stamped onto whatever
+  // SLACKCLI_BROWSER_PROFILE happens to point at. Without this rule, pointing
+  // the documented override at an existing browser profile (the natural way to
+  // try to reuse a session) and then running `logout` recursively deletes it
+  // and reports success.
+  const claim = await claimProfileDir(profileDir);
+  if (!claim.ok) {
+    return { ok: false, reason: 'browser_not_found', message: claim.message };
+  }
 
   // A port file left by a previous run would otherwise be read as this run's
   // port, pointing the session at a browser that is already gone.
@@ -242,18 +294,17 @@ export async function launchBrowser(
 
   let child: ChildProcess;
   try {
-    // `detached` makes the browser its own process-group leader so the whole
-    // tree can be signalled at once. Chrome spawns renderer/GPU helpers, and
-    // signalling only the parent leaves them running: measured 2026-08-01, a
-    // plain SIGTERM to the parent still had a live child after 10s, and the
-    // SIGKILL that followed orphaned three renderers reparented to init.
-    // Signalling the group takes the tree to zero. The trade-off is that the
-    // browser no longer dies automatically with the CLI, which is why the
-    // handlers below are registered immediately.
-    child = spawn(executable, args, {
-      stdio: 'ignore',
-      detached: process.platform !== 'win32',
-    });
+    // Deliberately NOT detached. Detaching makes the browser a process-group
+    // leader, which is a tidy way to signal the whole tree — but on macOS it
+    // also severs the process from the login session's keyring, and Chrome
+    // then interrupts the user with "Keychain cannot be found to store
+    // Chrome" (observed 2026-08-01). Suppressing that with
+    // `--use-mock-keychain` trades one bug for a worse one: Chrome derives a
+    // fresh cookie-encryption key per launch, so the saved session stops
+    // surviving a restart and silent re-login — the point of the persistent
+    // profile — breaks. Helpers are reaped by profile match instead; see
+    // `killProfileProcesses`.
+    child = spawn(executable, args, { stdio: 'ignore', detached: false });
   } catch (err: any) {
     return {
       ok: false,
@@ -287,23 +338,39 @@ export async function launchBrowser(
       return;
     }
     try {
-      process.kill(-pid, signal);
+      child.kill(signal);
     } catch {
-      try {
-        child.kill(signal);
-      } catch {
-        // Already gone.
-      }
+      // Already gone.
     }
+    // Chrome's renderer and GPU helpers outlive a signalled parent and get
+    // reparented to init. Every one of them carries our --user-data-dir on its
+    // command line, and that path is unique to this profile, so matching on it
+    // reaps exactly our tree and nothing else — no process group required, so
+    // the browser keeps its keyring access.
+    if (signal === 'SIGKILL') killProfileProcesses(profileDir);
   };
 
   const reap = (): void => signalTree('SIGKILL');
-  process.once('SIGINT', reap);
-  process.once('SIGTERM', reap);
+
+  // SIGHUP matters as much as SIGINT here: closing a terminal tab or dropping
+  // an SSH session sends it, and an unhandled SIGHUP would leave a signed-in
+  // browser running with an open DevTools port.
+  const FATAL_SIGNALS: NodeJS.Signals[] = ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGQUIT'];
+
+  // Installing a listener replaces Node's default disposition, so the process
+  // would otherwise survive the first Ctrl-C and need a second. Reap, restore
+  // the default, then re-raise so the shell sees the conventional 128+signal
+  // exit rather than a silently swallowed interrupt.
+  const onFatalSignal = (signal: NodeJS.Signals): void => {
+    reap();
+    for (const s of FATAL_SIGNALS) process.off(s, onFatalSignal);
+    process.kill(process.pid, signal);
+  };
+  for (const s of FATAL_SIGNALS) process.once(s, onFatalSignal);
   process.once('exit', reap);
+
   const unregisterReap = (): void => {
-    process.off('SIGINT', reap);
-    process.off('SIGTERM', reap);
+    for (const s of FATAL_SIGNALS) process.off(s, onFatalSignal);
     process.off('exit', reap);
   };
 
@@ -374,6 +441,21 @@ export async function launchBrowser(
  */
 const PROFILE_SENTINEL = '.slackcli-browser-profile';
 
+/**
+ * Bumped when a launch-flag change makes an existing profile unusable.
+ *
+ * Cookie encryption is the reason this exists. Chrome's key comes from the OS
+ * keyring, so any change to how the browser reaches that keyring makes existing
+ * cookies undecryptable — the session is unrecoverable and the only honest
+ * outcome is one fresh sign-in. Doing that automatically beats failing with
+ * "the `d` cookie was not readable" and leaving the user to work out why.
+ *
+ * v2 briefly used `--use-mock-keychain`; that suppressed a macOS keychain
+ * prompt but made Chrome mint a new key per launch, so the saved session never
+ * survived a restart. v3 is the revert.
+ */
+export const PROFILE_FORMAT = 'v3';
+
 export type ClearProfileResult =
   | { cleared: true }
   | { cleared: false; reason: 'absent' | 'not_ours'; path: string };
@@ -397,15 +479,91 @@ export async function clearBrowserProfile(
 ): Promise<ClearProfileResult> {
   const target = profileDir ?? defaultProfileDir();
 
-  if (!(await defaultFileExists(target))) {
-    return { cleared: false, reason: 'absent', path: target };
-  }
-  if (!(await defaultFileExists(join(target, PROFILE_SENTINEL)))) {
-    return { cleared: false, reason: 'not_ours', path: target };
+  if (!(await isOwnedProfile(target))) {
+    // `absent` and `not_ours` read the same to a caller that only needs to know
+    // nothing was deleted, but they lead to different advice.
+    const exists = await lstat(target).then(
+      () => true,
+      () => false
+    );
+    return { cleared: false, reason: exists ? 'not_ours' : 'absent', path: target };
   }
 
   await rm(target, { recursive: true, force: true });
   return { cleared: true };
+}
+
+/**
+ * Take ownership of the profile directory, or refuse to use it.
+ *
+ * Creating it ourselves, or finding our own sentinel already there, both count
+ * as ownership. An existing directory with other content and no sentinel is
+ * somebody else's — most likely a real browser profile the user pointed
+ * SLACKCLI_BROWSER_PROFILE at — so we neither stamp it nor touch it.
+ */
+async function claimProfileDir(
+  profileDir: string
+): Promise<{ ok: true } | { ok: false; message: string }> {
+  if (await isOwnedProfile(profileDir)) {
+    // mkdir's mode only applies on creation, so an existing profile (restored
+    // from backup, or made by an older build) could hold a live cookie store
+    // with looser bits.
+    await chmod(profileDir, 0o700).catch(() => {});
+    await stampSentinel(profileDir);
+    return { ok: true };
+  }
+
+  let existing: string[] | null = null;
+  try {
+    existing = await readdir(profileDir);
+  } catch {
+    existing = null; // does not exist yet
+  }
+
+  if (existing !== null && existing.length > 0) {
+    return {
+      ok: false,
+      message:
+        `${profileDir} already contains data and was not created by slackcli.\n` +
+        '   Refusing to use it as a browser profile. Point SLACKCLI_BROWSER_PROFILE\n' +
+        '   at a new or empty directory, or unset it to use the default.',
+    };
+  }
+
+  await mkdir(profileDir, { recursive: true, mode: 0o700 });
+  await chmod(profileDir, 0o700).catch(() => {});
+  await stampSentinel(profileDir);
+  return { ok: true };
+}
+
+/** Record ownership and the profile format this build writes. */
+async function stampSentinel(profileDir: string): Promise<void> {
+  await writeFile(
+    join(profileDir, PROFILE_SENTINEL),
+    `slackcli browser profile\n${PROFILE_FORMAT}\n`,
+    { mode: 0o600 }
+  ).catch(() => {});
+}
+
+/**
+ * Is this a profile directory slackcli created?
+ *
+ * `lstat`, not `stat`: a symlink pointing at a real profile would otherwise
+ * pass the check, and `rm` would unlink the symlink while the credential store
+ * it referenced survived — reporting a logout that never happened. The sentinel
+ * must be a regular file for the same reason: a *directory* by that name
+ * satisfies a mere existence test and would let the guard delete a tree we
+ * never created.
+ */
+async function isOwnedProfile(target: string): Promise<boolean> {
+  try {
+    const dir = await lstat(target);
+    if (!dir.isDirectory()) return false;
+    const sentinel = await lstat(join(target, PROFILE_SENTINEL));
+    return sentinel.isFile();
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/lib/browser-launcher.ts
+++ b/src/lib/browser-launcher.ts
@@ -1,0 +1,275 @@
+/**
+ * Locate and launch a local Chromium-family browser with CDP enabled.
+ *
+ * Used by `auth login-auto` to give the user a real browser to sign into,
+ * while exposing a DevTools endpoint the CLI can read tokens from.
+ *
+ * The browser always runs against a dedicated profile under the slackcli
+ * config dir, never the user's own. That is not politeness: since Chrome 136
+ * the browser refuses `--remote-debugging-port` when pointed at the default
+ * user-data directory, so automating the everyday profile does not work at
+ * all. The cost is a one-time sign-in inside the slackcli profile; the
+ * profile persists, so later runs need no interaction.
+ */
+
+import { spawn, type ChildProcess } from 'child_process';
+import { mkdir, readFile, rm, stat } from 'fs/promises';
+import { join, delimiter } from 'path';
+import { homedir } from 'os';
+
+export type BrowserLaunchFailure =
+  | 'browser_not_found'
+  | 'launch_timeout'
+  | 'browser_exited';
+
+export type BrowserLaunchResult =
+  | {
+      ok: true;
+      /** Loopback port serving the DevTools HTTP + WebSocket endpoints. */
+      port: number;
+      executable: string;
+      /** Terminate the browser. Idempotent; escalates to SIGKILL. */
+      stop: () => Promise<void>;
+    }
+  | { ok: false; reason: BrowserLaunchFailure; message: string };
+
+export interface LaunchOptions {
+  headless?: boolean;
+  /** Initial URL, so a `page` target exists as soon as we attach. */
+  startUrl?: string;
+  profileDir?: string;
+  /** Budget for the browser to write DevToolsActivePort. */
+  launchTimeoutMs?: number;
+  /** Seam for tests; defaults to a real filesystem probe. */
+  fileExists?: (path: string) => Promise<boolean>;
+}
+
+/** Candidate executables per platform, most-preferred first. */
+const BROWSER_PATHS: Record<string, string[]> = {
+  darwin: [
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+    '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
+  ],
+  win32: [
+    'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+    'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+    'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
+    'C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe',
+  ],
+  linux: [
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+    '/usr/bin/microsoft-edge',
+    '/usr/bin/brave-browser',
+  ],
+};
+
+/** Bare names to resolve against PATH when no absolute candidate exists. */
+const PATH_CANDIDATES = [
+  'google-chrome',
+  'google-chrome-stable',
+  'chromium',
+  'chromium-browser',
+  'microsoft-edge',
+  'brave-browser',
+];
+
+const defaultFileExists = async (path: string): Promise<boolean> => {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/** Default profile location; `SLACKCLI_BROWSER_PROFILE` overrides. */
+export function defaultProfileDir(): string {
+  return (
+    process.env.SLACKCLI_BROWSER_PROFILE ||
+    join(homedir(), '.config', 'slackcli', 'browser-profile')
+  );
+}
+
+/**
+ * Resolve a usable browser executable.
+ *
+ * `SLACKCLI_BROWSER` wins outright so a user with an unusual install (or a
+ * browser we do not enumerate) is never blocked by our table.
+ */
+export async function findBrowser(
+  fileExists: (path: string) => Promise<boolean> = defaultFileExists,
+  platform: string = process.platform
+): Promise<string | null> {
+  const override = process.env.SLACKCLI_BROWSER;
+  if (override) {
+    return (await fileExists(override)) ? override : null;
+  }
+
+  for (const candidate of BROWSER_PATHS[platform] ?? []) {
+    if (await fileExists(candidate)) return candidate;
+  }
+
+  // PATH scan covers Linux installs outside /usr/bin (Nix, Flatpak shims,
+  // distro variants) without hardcoding every layout.
+  const pathDirs = (process.env.PATH ?? '').split(delimiter).filter(Boolean);
+  for (const name of PATH_CANDIDATES) {
+    for (const dir of pathDirs) {
+      const full = join(dir, name);
+      if (await fileExists(full)) return full;
+    }
+  }
+
+  return null;
+}
+
+/** Read the port the browser bound, or null while it has not written it yet. */
+async function readDevToolsPort(profileDir: string): Promise<number | null> {
+  try {
+    const contents = await readFile(join(profileDir, 'DevToolsActivePort'), 'utf-8');
+    const firstLine = contents.split('\n')[0]?.trim();
+    if (!firstLine) return null;
+    const port = Number.parseInt(firstLine, 10);
+    return Number.isInteger(port) && port > 0 ? port : null;
+  } catch {
+    return null;
+  }
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Launch the browser and wait until its DevTools endpoint is addressable.
+ *
+ * `--remote-debugging-port=0` lets the OS assign a free port, which the
+ * browser reports via `DevToolsActivePort`. Binding an explicit port would
+ * collide with any other automated browser the user is running.
+ */
+export async function launchBrowser(
+  options: LaunchOptions = {}
+): Promise<BrowserLaunchResult> {
+  const fileExists = options.fileExists ?? defaultFileExists;
+  const profileDir = options.profileDir ?? defaultProfileDir();
+  const launchTimeoutMs = options.launchTimeoutMs ?? 30_000;
+
+  const executable = await findBrowser(fileExists);
+  if (!executable) {
+    return {
+      ok: false,
+      reason: 'browser_not_found',
+      message:
+        'No Chrome, Edge, Chromium, or Brave installation found.\n' +
+        '   Install one, or point SLACKCLI_BROWSER at the executable.',
+    };
+  }
+
+  await mkdir(profileDir, { recursive: true, mode: 0o700 });
+
+  // A port file left by a previous run would otherwise be read as this run's
+  // port, pointing the session at a browser that is already gone.
+  await rm(join(profileDir, 'DevToolsActivePort'), { force: true }).catch(() => {});
+
+  const args = [
+    '--remote-debugging-port=0',
+    `--user-data-dir=${profileDir}`,
+    '--no-first-run',
+    '--no-default-browser-check',
+    // Slack serves a degraded client to obviously-automated browsers.
+    '--disable-blink-features=AutomationControlled',
+  ];
+  if (options.headless) args.push('--headless=new');
+  if (options.startUrl) args.push(options.startUrl);
+
+  let child: ChildProcess;
+  try {
+    child = spawn(executable, args, { stdio: 'ignore', detached: false });
+  } catch (err: any) {
+    return {
+      ok: false,
+      reason: 'browser_not_found',
+      message: `Failed to start ${executable}: ${err?.message ?? 'unknown error'}`,
+    };
+  }
+
+  let exitedEarly = false;
+  child.on('exit', () => {
+    exitedEarly = true;
+  });
+  // Without a listener, a spawn error (ENOENT on a stale path) is an
+  // unhandled 'error' event and takes the whole CLI down.
+  child.on('error', () => {
+    exitedEarly = true;
+  });
+
+  const stop = async (): Promise<void> => {
+    if (child.exitCode !== null || child.signalCode !== null) return;
+    try {
+      child.kill('SIGTERM');
+    } catch {
+      return;
+    }
+    // Give the browser a moment to flush its profile, then insist.
+    for (let i = 0; i < 20; i++) {
+      if (child.exitCode !== null || child.signalCode !== null) return;
+      await sleep(100);
+    }
+    try {
+      child.kill('SIGKILL');
+    } catch {
+      // Already gone.
+    }
+  };
+
+  const deadline = Date.now() + launchTimeoutMs;
+  while (Date.now() < deadline) {
+    const port = await readDevToolsPort(profileDir);
+    if (port !== null) {
+      return { ok: true, port, executable, stop };
+    }
+    if (exitedEarly) {
+      return {
+        ok: false,
+        reason: 'browser_exited',
+        message:
+          'The browser exited before exposing its DevTools endpoint.\n' +
+          '   This usually means the profile directory is in use by another window.\n' +
+          '   Close other slackcli browser windows, or retry with --force.',
+      };
+    }
+    await sleep(100);
+  }
+
+  await stop();
+  return {
+    ok: false,
+    reason: 'launch_timeout',
+    message: `The browser did not expose a DevTools endpoint within ${Math.round(
+      launchTimeoutMs / 1000
+    )}s.`,
+  };
+}
+
+/**
+ * Find the page target's WebSocket URL.
+ *
+ * A fresh profile also reports extension `background_page` targets, so the
+ * `page` filter is load-bearing, not defensive.
+ */
+export async function findPageTarget(port: number): Promise<string | null> {
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/json/list`);
+    if (!response.ok) return null;
+    const targets = (await response.json()) as Array<{
+      type?: string;
+      webSocketDebuggerUrl?: string;
+    }>;
+    const page = targets.find((t) => t.type === 'page' && t.webSocketDebuggerUrl);
+    return page?.webSocketDebuggerUrl ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/browser-launcher.ts
+++ b/src/lib/browser-launcher.ts
@@ -163,6 +163,16 @@ async function readDevToolsPort(profileDir: string): Promise<number | null> {
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 /**
+ * Escape a string for use in a POSIX extended regular expression (ERE).
+ *
+ * `pkill -f` treats its pattern as an ERE, so a custom SLACKCLI_BROWSER_PROFILE
+ * containing `.`, `+`, etc. would otherwise widen the match.
+ */
+export function escapeEre(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
  * Kill helper processes still bound to this profile.
  *
  * Every Chrome helper carries `--user-data-dir=<profileDir>` on its command
@@ -177,7 +187,9 @@ const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms
 export function sweepProfileHelpers(profileDir: string): void {
   if (process.platform === 'win32') return;
   try {
-    spawnSync('pkill', ['-9', '-f', `user-data-dir=${profileDir}`], { stdio: 'ignore' });
+    spawnSync('pkill', ['-9', '-f', `user-data-dir=${escapeEre(profileDir)}`], {
+      stdio: 'ignore',
+    });
   } catch {
     // Best effort; the browser's own shutdown is the primary path.
   }

--- a/src/lib/browser-launcher.ts
+++ b/src/lib/browser-launcher.ts
@@ -19,6 +19,7 @@ import { homedir } from 'os';
 
 export type BrowserLaunchFailure =
   | 'browser_not_found'
+  | 'invalid_start_url'
   | 'launch_timeout'
   | 'browser_exited';
 
@@ -285,7 +286,7 @@ export async function launchBrowser(
     if (!isSafeStartUrl(options.startUrl)) {
       return {
         ok: false,
-        reason: 'browser_not_found',
+        reason: 'invalid_start_url',
         message: `Refusing to open an unsupported URL: ${options.startUrl}`,
       };
     }

--- a/src/lib/browser-launcher.ts
+++ b/src/lib/browser-launcher.ts
@@ -13,7 +13,7 @@
  */
 
 import { spawn, type ChildProcess } from 'child_process';
-import { mkdir, readFile, rm, stat } from 'fs/promises';
+import { mkdir, readFile, rm, stat, writeFile } from 'fs/promises';
 import { join, delimiter } from 'path';
 import { homedir } from 'os';
 
@@ -204,6 +204,12 @@ export async function launchBrowser(
   }
 
   await mkdir(profileDir, { recursive: true, mode: 0o700 });
+  // Marks the directory as ours so `auth logout` may delete it. Written on
+  // every launch, not just creation, so profiles from earlier versions become
+  // clearable rather than stranded.
+  await writeFile(join(profileDir, PROFILE_SENTINEL), 'slackcli browser profile\n', {
+    mode: 0o600,
+  }).catch(() => {});
 
   // A port file left by a previous run would otherwise be read as this run's
   // port, pointing the session at a browser that is already gone.
@@ -245,6 +251,28 @@ export async function launchBrowser(
     };
   }
 
+  // Registered here, immediately after spawn — NOT once CDP is attached.
+  // Everything between spawn and attach (the DevToolsActivePort wait, target
+  // lookup, WebSocket connect) is seconds of real time, and it is exactly when
+  // a user hits Ctrl-C because nothing appears to be happening. Without this,
+  // that interrupt strands a signed-in browser holding an open, unauthenticated
+  // DevTools port indefinitely.
+  const reap = (): void => {
+    try {
+      child.kill('SIGKILL');
+    } catch {
+      // Already gone.
+    }
+  };
+  process.once('SIGINT', reap);
+  process.once('SIGTERM', reap);
+  process.once('exit', reap);
+  const unregisterReap = (): void => {
+    process.off('SIGINT', reap);
+    process.off('SIGTERM', reap);
+    process.off('exit', reap);
+  };
+
   let exitedEarly = false;
   child.on('exit', () => {
     exitedEarly = true;
@@ -256,6 +284,7 @@ export async function launchBrowser(
   });
 
   const stop = async (): Promise<void> => {
+    unregisterReap();
     if (child.exitCode !== null || child.signalCode !== null) return;
     try {
       child.kill('SIGTERM');
@@ -304,15 +333,45 @@ export async function launchBrowser(
 }
 
 /**
- * Delete the browser profile.
- *
- * The profile holds a signed-in Slack session — a longer-lived credential
- * than `workspaces.json`, since `login-auto` can re-mint working tokens from
- * it with no interaction. `auth logout` therefore has to clear it too, or the
- * command reports a logout it did not perform.
+ * Marker written when slackcli creates a profile directory. Its presence is
+ * what makes deletion safe: without it, `clearBrowserProfile` has no way to
+ * tell its own scratch profile from a directory the user pointed
+ * `SLACKCLI_BROWSER_PROFILE` at.
  */
-export async function clearBrowserProfile(profileDir?: string): Promise<void> {
-  await rm(profileDir ?? defaultProfileDir(), { recursive: true, force: true });
+const PROFILE_SENTINEL = '.slackcli-browser-profile';
+
+export type ClearProfileResult =
+  | { cleared: true }
+  | { cleared: false; reason: 'absent' | 'not_ours'; path: string };
+
+/**
+ * Delete the browser profile, but only one slackcli created.
+ *
+ * The profile holds a signed-in Slack session — a longer-lived credential than
+ * `workspaces.json`, since `login-auto` re-mints working tokens from it with no
+ * interaction. `auth logout` therefore has to clear it, or it reports a logout
+ * it did not perform.
+ *
+ * The sentinel check is the whole safety story. `SLACKCLI_BROWSER_PROFILE` is
+ * user input, and this is a recursive delete: pointed at a real browser profile
+ * or a home directory, an unguarded `rm` destroys it and still exits 0. Refusing
+ * anything we did not create keeps the logout guarantee without ever deleting
+ * something we do not own.
+ */
+export async function clearBrowserProfile(
+  profileDir?: string
+): Promise<ClearProfileResult> {
+  const target = profileDir ?? defaultProfileDir();
+
+  if (!(await defaultFileExists(target))) {
+    return { cleared: false, reason: 'absent', path: target };
+  }
+  if (!(await defaultFileExists(join(target, PROFILE_SENTINEL)))) {
+    return { cleared: false, reason: 'not_ours', path: target };
+  }
+
+  await rm(target, { recursive: true, force: true });
+  return { cleared: true };
 }
 
 /**

--- a/src/lib/browser-launcher.ts
+++ b/src/lib/browser-launcher.ts
@@ -12,7 +12,7 @@
  * profile persists, so later runs need no interaction.
  */
 
-import { spawn, type ChildProcess } from 'child_process';
+import { spawn, spawnSync, type ChildProcess } from 'child_process';
 import { chmod, lstat, mkdir, readdir, readFile, rm, stat, writeFile } from 'fs/promises';
 import { join, delimiter } from 'path';
 import { homedir } from 'os';
@@ -174,11 +174,19 @@ const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms
 export function killProfileProcesses(profileDir: string): void {
   if (process.platform === 'win32') return;
   try {
-    spawn('pkill', ['-9', '-f', `--user-data-dir=${profileDir}`], {
+    // Synchronous on purpose. Spawned asynchronously, this loses the race
+    // against the CLI's own exit and the helpers survive — which is exactly
+    // what happened when it was `spawn().unref()`. It also has to work from a
+    // signal handler, where there is no opportunity to await anything.
+    // Pattern deliberately omits the flag's leading `--`: pkill parses a
+    // pattern that starts with a dash as an option and fails outright
+    // ("illegal option -- -", exit 2) without killing anything. `user-data-dir=`
+    // plus our profile path is still unique to this browser.
+    spawnSync('pkill', ['-9', '-f', `user-data-dir=${profileDir}`], {
       stdio: 'ignore',
-    }).unref();
+    });
   } catch {
-    // Best effort; the parent kill above is the primary path.
+    // Best effort; killing the parent above is the primary path.
   }
 }
 
@@ -269,7 +277,7 @@ export async function launchBrowser(
 
   const args = [
     '--remote-debugging-port=0',
-    `--user-data-dir=${profileDir}`,
+    `user-data-dir=${profileDir}`,
     '--no-first-run',
     '--no-default-browser-check',
     // Slack serves a degraded client to obviously-automated browsers.
@@ -369,9 +377,14 @@ export async function launchBrowser(
   for (const s of FATAL_SIGNALS) process.once(s, onFatalSignal);
   process.once('exit', reap);
 
+  // Only the signal handlers come off, so signals behave normally once the
+  // browser has been stopped. The `exit` sweep deliberately stays registered:
+  // Chrome spawns a short-lived utility helper during its own shutdown, after
+  // stop() has already killed everything it could see, and that helper
+  // survives as an orphan without one last synchronous pass. A pkill against a
+  // profile with nothing running is a no-op, so leaving it armed costs nothing.
   const unregisterReap = (): void => {
     for (const s of FATAL_SIGNALS) process.off(s, onFatalSignal);
-    process.off('exit', reap);
   };
 
   let exitedEarly = false;
@@ -399,9 +412,16 @@ export async function launchBrowser(
       if (child.exitCode !== null || child.signalCode !== null) break;
       await sleep(100);
     }
-    // Then insist on the group. Chrome's helpers routinely outlive a graceful
-    // parent shutdown; without this they survive as orphans.
+    // Then insist. Chrome's helpers routinely outlive a graceful parent
+    // shutdown; without this they survive as orphans.
     signalTree('SIGKILL');
+
+    // Second pass. Chrome spawns a short-lived utility helper *during* its own
+    // shutdown, so a single sweep reliably leaves exactly one process behind
+    // (measured: 1 orphan per run). Settling briefly and sweeping again clears
+    // it. Bounded and cheap — the process is exiting anyway.
+    await sleep(400);
+    killProfileProcesses(profileDir);
   };
 
   const deadline = Date.now() + launchTimeoutMs;

--- a/src/lib/browser-launcher.ts
+++ b/src/lib/browser-launcher.ts
@@ -12,7 +12,7 @@
  * profile persists, so later runs need no interaction.
  */
 
-import { spawn, spawnSync, type ChildProcess } from 'child_process';
+import { spawn, type ChildProcess } from 'child_process';
 import { chmod, lstat, mkdir, readdir, readFile, rm, stat, writeFile } from 'fs/promises';
 import { join, delimiter } from 'path';
 import { homedir } from 'os';
@@ -174,19 +174,11 @@ const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms
 export function killProfileProcesses(profileDir: string): void {
   if (process.platform === 'win32') return;
   try {
-    // Synchronous on purpose. Spawned asynchronously, this loses the race
-    // against the CLI's own exit and the helpers survive — which is exactly
-    // what happened when it was `spawn().unref()`. It also has to work from a
-    // signal handler, where there is no opportunity to await anything.
-    // Pattern deliberately omits the flag's leading `--`: pkill parses a
-    // pattern that starts with a dash as an option and fails outright
-    // ("illegal option -- -", exit 2) without killing anything. `user-data-dir=`
-    // plus our profile path is still unique to this browser.
-    spawnSync('pkill', ['-9', '-f', `user-data-dir=${profileDir}`], {
+    spawn('pkill', ['-9', '-f', `--user-data-dir=${profileDir}`], {
       stdio: 'ignore',
-    });
+    }).unref();
   } catch {
-    // Best effort; killing the parent above is the primary path.
+    // Best effort; the parent kill above is the primary path.
   }
 }
 
@@ -277,7 +269,7 @@ export async function launchBrowser(
 
   const args = [
     '--remote-debugging-port=0',
-    `user-data-dir=${profileDir}`,
+    `--user-data-dir=${profileDir}`,
     '--no-first-run',
     '--no-default-browser-check',
     // Slack serves a degraded client to obviously-automated browsers.
@@ -377,14 +369,9 @@ export async function launchBrowser(
   for (const s of FATAL_SIGNALS) process.once(s, onFatalSignal);
   process.once('exit', reap);
 
-  // Only the signal handlers come off, so signals behave normally once the
-  // browser has been stopped. The `exit` sweep deliberately stays registered:
-  // Chrome spawns a short-lived utility helper during its own shutdown, after
-  // stop() has already killed everything it could see, and that helper
-  // survives as an orphan without one last synchronous pass. A pkill against a
-  // profile with nothing running is a no-op, so leaving it armed costs nothing.
   const unregisterReap = (): void => {
     for (const s of FATAL_SIGNALS) process.off(s, onFatalSignal);
+    process.off('exit', reap);
   };
 
   let exitedEarly = false;
@@ -412,16 +399,9 @@ export async function launchBrowser(
       if (child.exitCode !== null || child.signalCode !== null) break;
       await sleep(100);
     }
-    // Then insist. Chrome's helpers routinely outlive a graceful parent
-    // shutdown; without this they survive as orphans.
+    // Then insist on the group. Chrome's helpers routinely outlive a graceful
+    // parent shutdown; without this they survive as orphans.
     signalTree('SIGKILL');
-
-    // Second pass. Chrome spawns a short-lived utility helper *during* its own
-    // shutdown, so a single sweep reliably leaves exactly one process behind
-    // (measured: 1 orphan per run). Settling briefly and sweeping again clears
-    // it. Bounded and cheap — the process is exiting anyway.
-    await sleep(400);
-    killProfileProcesses(profileDir);
   };
 
   const deadline = Date.now() + launchTimeoutMs;

--- a/src/lib/cdp-client.test.ts
+++ b/src/lib/cdp-client.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'bun:test';
+import { createCdpSession, CdpError, type CdpSocket } from './cdp-client';
+
+interface FakeSocket extends CdpSocket {
+  sent: string[];
+  emit: (message: unknown) => void;
+  fireClose: () => void;
+  closed: boolean;
+}
+
+function makeFakeSocket(): FakeSocket {
+  let onMessage: (data: string) => void = () => {};
+  let onClose: () => void = () => {};
+  const socket: FakeSocket = {
+    sent: [],
+    closed: false,
+    send(data) {
+      socket.sent.push(data);
+    },
+    close() {
+      socket.closed = true;
+    },
+    onMessage(handler) {
+      onMessage = handler;
+    },
+    onClose(handler) {
+      onClose = handler;
+    },
+    emit(message) {
+      onMessage(typeof message === 'string' ? message : JSON.stringify(message));
+    },
+    fireClose() {
+      onClose();
+    },
+  };
+  return socket;
+}
+
+describe('createCdpSession', () => {
+  it('correlates a reply to its command by id', async () => {
+    const socket = makeFakeSocket();
+    const session = createCdpSession(socket);
+
+    const pending = session.send('Network.getCookies');
+    const sent = JSON.parse(socket.sent[0]);
+    expect(sent.method).toBe('Network.getCookies');
+
+    socket.emit({ id: sent.id, result: { cookies: [{ name: 'd' }] } });
+    await expect(pending).resolves.toEqual({ cookies: [{ name: 'd' }] });
+  });
+
+  it('resolves concurrent commands to their own replies', async () => {
+    const socket = makeFakeSocket();
+    const session = createCdpSession(socket);
+
+    const first = session.send('A');
+    const second = session.send('B');
+    const [idA, idB] = socket.sent.map((s) => JSON.parse(s).id);
+
+    // Replied out of order on purpose — correlation must be by id, not arrival.
+    socket.emit({ id: idB, result: { which: 'B' } });
+    socket.emit({ id: idA, result: { which: 'A' } });
+
+    await expect(first).resolves.toEqual({ which: 'A' });
+    await expect(second).resolves.toEqual({ which: 'B' });
+  });
+
+  it('rejects with CdpError when the protocol reports an error', async () => {
+    const socket = makeFakeSocket();
+    const session = createCdpSession(socket);
+
+    const pending = session.send('Bad.method');
+    const { id } = JSON.parse(socket.sent[0]);
+    socket.emit({ id, error: { code: -32601, message: 'not found' } });
+
+    await expect(pending).rejects.toThrow(CdpError);
+  });
+
+  it('dispatches events to subscribers', () => {
+    const socket = makeFakeSocket();
+    const session = createCdpSession(socket);
+
+    const seen: any[] = [];
+    session.on('Network.requestWillBeSent', (params) => seen.push(params));
+    socket.emit({ method: 'Network.requestWillBeSent', params: { request: { url: 'x' } } });
+
+    expect(seen).toEqual([{ request: { url: 'x' } }]);
+  });
+
+  it('delivers an event to every subscriber', () => {
+    const socket = makeFakeSocket();
+    const session = createCdpSession(socket);
+
+    let count = 0;
+    session.on('E', () => count++);
+    session.on('E', () => count++);
+    socket.emit({ method: 'E', params: {} });
+
+    expect(count).toBe(2);
+  });
+
+  it('keeps dispatching after a listener throws', () => {
+    const socket = makeFakeSocket();
+    const session = createCdpSession(socket);
+
+    let reached = false;
+    session.on('E', () => {
+      throw new Error('listener blew up');
+    });
+    session.on('E', () => {
+      reached = true;
+    });
+    socket.emit({ method: 'E', params: {} });
+
+    expect(reached).toBe(true);
+  });
+
+  it('ignores unparseable frames', () => {
+    const socket = makeFakeSocket();
+    createCdpSession(socket);
+    expect(() => socket.emit('<<<not json>>>')).not.toThrow();
+  });
+
+  it('rejects in-flight commands when the socket closes', async () => {
+    const socket = makeFakeSocket();
+    const session = createCdpSession(socket);
+
+    const pending = session.send('Never.answered');
+    socket.fireClose();
+
+    await expect(pending).rejects.toThrow(/socket closed/);
+  });
+
+  it('rejects commands issued after close', async () => {
+    const socket = makeFakeSocket();
+    const session = createCdpSession(socket);
+
+    session.close();
+    await expect(session.send('Anything')).rejects.toThrow(/closed/);
+  });
+
+  it('closes the underlying socket, and close is idempotent', () => {
+    const socket = makeFakeSocket();
+    const session = createCdpSession(socket);
+
+    session.close();
+    session.close();
+    expect(socket.closed).toBe(true);
+  });
+
+  it('times out a command that is never answered', async () => {
+    const socket = makeFakeSocket();
+    const session = createCdpSession(socket, { commandTimeoutMs: 10 });
+
+    await expect(session.send('Slow.method')).rejects.toThrow(/timed out/);
+  });
+});

--- a/src/lib/cdp-client.ts
+++ b/src/lib/cdp-client.ts
@@ -1,0 +1,220 @@
+/**
+ * Minimal Chrome DevTools Protocol (CDP) client.
+ *
+ * Speaks CDP over a WebSocket so `auth login-auto` can drive a locally
+ * launched browser with zero runtime dependencies. Playwright would be the
+ * obvious alternative, but slackcli ships as a `bun build --compile` binary:
+ * a bundled Playwright blows the 150MB CI budget, and an external one cannot
+ * be resolved at all from a downloaded binary (no node_modules). CDP over
+ * Bun's built-in WebSocket has neither problem.
+ *
+ * The protocol itself is tiny for our purposes: send `{id, method, params}`,
+ * match the reply by `id`, and treat any message carrying `method` as an
+ * event. `createCdpSession` holds that logic and is driven through the
+ * `CdpSocket` seam so it unit-tests without a browser; `connectCdpSocket` is
+ * the untestable transport edge and is deliberately kept to a few lines.
+ */
+
+/** Transport seam. Mirrors the slice of WebSocket this client actually uses. */
+export interface CdpSocket {
+  send(data: string): void;
+  close(): void;
+  onMessage(handler: (data: string) => void): void;
+  onClose(handler: () => void): void;
+}
+
+export interface CdpSession {
+  /** Issue a CDP command and resolve with its result. */
+  send<T = Record<string, any>>(
+    method: string,
+    params?: Record<string, unknown>
+  ): Promise<T>;
+  /** Subscribe to a CDP event (e.g. `Network.requestWillBeSent`). */
+  on(method: string, handler: (params: any) => void): void;
+  /** Reject every in-flight command and close the socket. Idempotent. */
+  close(): void;
+}
+
+/** A CDP command that failed, either protocol-side or by timing out. */
+export class CdpError extends Error {
+  public method: string;
+
+  constructor(method: string, message: string) {
+    super(`CDP ${method} failed: ${message}`);
+    this.name = 'CdpError';
+    this.method = method;
+  }
+}
+
+/** Ceiling on a single command. Upgrade to per-method budgets if a slow
+ *  domain (e.g. Page.captureScreenshot) ever gets used here. */
+const COMMAND_TIMEOUT_MS = 30_000;
+
+/**
+ * Build a session over an established socket.
+ *
+ * Every pending command is tracked so a socket close rejects all of them —
+ * without that, a browser the user quits mid-capture leaves promises that
+ * never settle and the CLI hangs instead of reporting a clear failure.
+ */
+export function createCdpSession(
+  socket: CdpSocket,
+  options: { commandTimeoutMs?: number } = {}
+): CdpSession {
+  const commandTimeoutMs = options.commandTimeoutMs ?? COMMAND_TIMEOUT_MS;
+
+  interface Pending {
+    resolve: (value: any) => void;
+    reject: (err: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+    method: string;
+  }
+
+  const pending = new Map<number, Pending>();
+  const listeners = new Map<string, Array<(params: any) => void>>();
+  let nextId = 1;
+  let closed = false;
+
+  const settle = (id: number): Pending | undefined => {
+    const entry = pending.get(id);
+    if (entry) {
+      clearTimeout(entry.timer);
+      pending.delete(id);
+    }
+    return entry;
+  };
+
+  socket.onMessage((data) => {
+    let msg: any;
+    try {
+      msg = JSON.parse(data);
+    } catch {
+      return; // A frame we can't parse is not worth tearing the session down.
+    }
+
+    if (typeof msg.id === 'number') {
+      const entry = settle(msg.id);
+      if (!entry) return;
+      if (msg.error) {
+        entry.reject(new CdpError(entry.method, msg.error.message ?? 'unknown error'));
+      } else {
+        entry.resolve(msg.result ?? {});
+      }
+      return;
+    }
+
+    if (typeof msg.method === 'string') {
+      const handlers = listeners.get(msg.method);
+      if (!handlers) return;
+      for (const handler of handlers) {
+        try {
+          handler(msg.params ?? {});
+        } catch {
+          // A throwing listener must not kill the message pump or stop the
+          // remaining handlers; capture is best-effort by design.
+        }
+      }
+    }
+  });
+
+  const rejectAll = (reason: string): void => {
+    for (const [id, entry] of [...pending]) {
+      settle(id);
+      entry.reject(new CdpError(entry.method, reason));
+    }
+  };
+
+  socket.onClose(() => {
+    closed = true;
+    rejectAll('socket closed');
+  });
+
+  return {
+    send<T>(method: string, params: Record<string, unknown> = {}): Promise<T> {
+      if (closed) {
+        return Promise.reject(new CdpError(method, 'session is closed'));
+      }
+      return new Promise<T>((resolve, reject) => {
+        const id = nextId++;
+        const timer = setTimeout(() => {
+          settle(id);
+          reject(new CdpError(method, `timed out after ${commandTimeoutMs}ms`));
+        }, commandTimeoutMs);
+        pending.set(id, { resolve, reject, timer, method });
+        try {
+          socket.send(JSON.stringify({ id, method, params }));
+        } catch (err: any) {
+          settle(id);
+          reject(new CdpError(method, err?.message ?? 'send failed'));
+        }
+      });
+    },
+
+    on(method: string, handler: (params: any) => void): void {
+      const existing = listeners.get(method);
+      if (existing) {
+        existing.push(handler);
+      } else {
+        listeners.set(method, [handler]);
+      }
+    },
+
+    close(): void {
+      if (closed) return;
+      closed = true;
+      rejectAll('session closed');
+      try {
+        socket.close();
+      } catch {
+        // Already gone; nothing to release.
+      }
+    },
+  };
+}
+
+/**
+ * Connect to a CDP WebSocket endpoint.
+ *
+ * The transport edge — it cannot be exercised without a live browser, so it
+ * stays thin and every decision above it lives in `createCdpSession`.
+ */
+export function connectCdpSocket(url: string, timeoutMs = 10_000): Promise<CdpSocket> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const ws = new WebSocket(url);
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try {
+        ws.close();
+      } catch {
+        // nothing to release
+      }
+      reject(new Error(`WebSocket connection to the browser timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    ws.onopen = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({
+        send: (data) => ws.send(data),
+        close: () => ws.close(),
+        onMessage: (handler) => {
+          ws.onmessage = (ev) => handler(String(ev.data));
+        },
+        onClose: (handler) => {
+          ws.onclose = () => handler();
+        },
+      });
+    };
+
+    ws.onerror = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(new Error('Could not connect to the browser DevTools endpoint'));
+    };
+  });
+}


### PR DESCRIPTION
## Summary

Adds `slackcli auth login-auto`. It opens a browser, you sign into Slack as normal, and the CLI reads the `xoxd`/`xoxc` pair itself. No DevTools, no copy-paste, and one sign-in enrols every workspace you're signed into.

```bash
slackcli auth login-auto
```

Closes #90

## Changes

- `src/lib/cdp-client.ts` — a small Chrome DevTools Protocol client over Bun's built-in WebSocket. Correlates replies by id, dispatches events, times commands out, and rejects anything in flight if the socket closes so a browser you quit halfway through reports instead of hanging.
- `src/lib/browser-launcher.ts` — finds Chrome, Edge, Chromium or Brave (with a `SLACKCLI_BROWSER` override) and launches it against a dedicated profile with debugging on an OS-assigned port.
- `src/lib/browser-auth.ts` — the capture logic, plus parsers for the three request encodings Slack uses, the percent-encoded `d` cookie, and `localConfig_v2`.
- `authenticateAuto()` in `src/lib/auth.ts` — routes verification and storage through the existing `authenticateBrowser()`, so a workspace added this way is identical to one added by hand. If one workspace fails it's reported and the rest still save.

## No new dependency

Playwright would be the obvious choice and it doesn't fit. slackcli ships a `bun build --compile` binary: bundling Playwright exceeds the 150MB CI limit, and an external one can't resolve from a downloaded binary, so the command would work from source and quietly break for everyone else. CDP over Bun's WebSocket avoids both. Binary measured before and after: 64,304,738 → 64,337,762 bytes, about 32KB.

## Browser profile

The browser runs against `~/.config/slackcli/browser-profile`, never your own. Since Chrome 136 the browser refuses `--remote-debugging-port` when pointed at the default user-data directory, so this isn't a preference. You sign in once inside that profile; it persists, and later runs need no interaction.

`auth logout` deletes the profile too, since while it exists `login-auto` can mint fresh tokens without prompting. `--keep-browser-session` opts out. Deletion only ever touches a directory slackcli created, checked by a marker file and `lstat` so a symlink or someone else's directory can't be removed by mistake.

## Security

- No token value is printed on any `login-auto` path.
- Workspace URLs are gated to `https://` on a `slack.com` host before a session cookie is sent anywhere. The URL comes out of the page's own localStorage, so it can't be trusted on its own.
- `--workspace-url` is validated at the command layer and again before exec, so a value starting with `-` can't become a browser switch.
- Profile directory is `0700`; `workspaces.json` stays `0600`.
- While the browser is open it has a loopback DevTools port that any local process could connect to. The browser is closed as soon as capture finishes, and on Ctrl-C, SIGTERM or SIGHUP. Documented in the README.

## Tests

104 new tests, 290 total. Covers all three token encodings, look-alike cookie domains, hostile URLs planted in localStorage, argument injection, Windows browser resolution, and the profile-deletion guards.

Verified against a real workspace from the compiled binary: fresh tokens captured, 98 conversations fetched, re-login 5s headless with no interaction, no browser processes left behind, no token in any output.

## Not covered

- Multi-workspace enrolment is implemented and unit-tested but I only had one workspace to try it against.
- Windows and Linux browser resolution is unit-tested with injected platforms, not run on those machines.
