### PR TITLE
fix: require word boundaries for mrkdwn emphasis markers

### DIFF
--- a/src/lib/mrkdwn.test.ts
+++ b/src/lib/mrkdwn.test.ts
@@ -136,4 +136,29 @@ describe('parseMrkdwn', () => {
       }],
     }]);
   });
+
+  it('does not pair underscores across two unrelated URLs', () => {
+    const text =
+      'https://example.com/a/merge_requests/1 and https://example.com/b/merge_requests/2';
+    expect(elements(text)).toEqual([{ type: 'text', text }]);
+  });
+
+  it('does not treat an underscore inside a single identifier as emphasis', () => {
+    expect(elements('see file_name.txt for details')).toEqual([
+      { type: 'text', text: 'see file_name.txt for details' },
+    ]);
+  });
+
+  it('still parses _italic_ when a later word also contains an underscore', () => {
+    expect(elements('_this_ is about file_name.txt')).toEqual([
+      { type: 'text', text: 'this', style: { italic: true } },
+      { type: 'text', text: ' is about file_name.txt' },
+    ]);
+  });
+
+  it('does not open emphasis on a marker directly after a word character', () => {
+    expect(elements('snake_case_name stays literal')).toEqual([
+      { type: 'text', text: 'snake_case_name stays literal' },
+    ]);
+  });
 });

--- a/src/lib/mrkdwn.ts
+++ b/src/lib/mrkdwn.ts
@@ -32,6 +32,10 @@ const MARKERS: [string, keyof RichTextStyle][] = [
   ['~', 'strike'],
 ];
 
+function isWordChar(ch: string | undefined): boolean {
+  return ch !== undefined && /[A-Za-z0-9]/.test(ch);
+}
+
 function parseInline(text: string): RichTextElement[] {
   const elements: RichTextElement[] = [];
 
@@ -42,8 +46,26 @@ function parseInline(text: string): RichTextElement[] {
     for (const [marker, styleKey] of MARKERS) {
       if (text[i] !== marker) continue;
 
-      // Look for the closing marker
-      const end = text.indexOf(marker, i + 1);
+      // A marker immediately preceded by a word character (the "_" in "merge_requests")
+      // never opens a span. Without this, the underscore in one URL or identifier pairs
+      // with the underscore in a completely unrelated one later in the message, and
+      // everything between the two gets consumed as styled text.
+      if (isWordChar(text[i - 1])) continue;
+
+      // Look for a closing marker that also isn't mid-word, skipping past any candidate
+      // that fails that check (e.g. the "_" inside "file_name") instead of stopping at
+      // the first occurrence.
+      let searchFrom = i + 1;
+      let end = -1;
+      while (searchFrom < text.length) {
+        const candidate = text.indexOf(marker, searchFrom);
+        if (candidate === -1) break;
+        if (!isWordChar(text[candidate + 1])) {
+          end = candidate;
+          break;
+        }
+        searchFrom = candidate + 1;
+      }
       if (end === -1) continue;
 
       const inner = text.substring(i + 1, end);


### PR DESCRIPTION
## Summary
- `parseInline` paired a marker with the next occurrence of the same character anywhere later in the text, with no check on what came before or after either marker.
- An underscore inside one identifier or URL (for example the merge_requests path segment in a GitLab link) would pair with an unrelated underscore much later in the message, italicising everything between them and deleting both underscores from the rendered text, destroying both URLs in the process.
- A marker can now only open a span if it is not immediately preceded by a letter or digit, and can only close one if it is not immediately followed by a letter or digit, matching Slack's own word-boundary behavior for _italic_ and the other markers. Closing search now skips past mid-word candidates instead of stopping at the first occurrence of the marker.

## Test plan
- [x] `bun test src/lib/mrkdwn.test.ts` covers: two unrelated URLs with underscores no longer pair, a single underscore inside an identifier stays literal, `_italic_` still works when a later word also contains an underscore, and a multi-underscore identifier like `snake_case_name` stays literal.