### PR TITLE
fix: require word boundaries for mrkdwn emphasis markers

### DIFF
--- a/src/lib/mrkdwn.test.ts
+++ b/src/lib/mrkdwn.test.ts
@@ -136,4 +136,88 @@ describe('parseMrkdwn', () => {
       }],
     }]);
   });
+
+  it('does not pair underscores across two unrelated URLs', () => {
+    const text =
+      'https://example.com/a/merge_requests/1 and https://example.com/b/merge_requests/2';
+    expect(elements(text)).toEqual([{ type: 'text', text }]);
+  });
+
+  it('does not treat an underscore inside a single identifier as emphasis', () => {
+    expect(elements('see file_name.txt for details')).toEqual([
+      { type: 'text', text: 'see file_name.txt for details' },
+    ]);
+  });
+
+  it('still parses _italic_ when a later word also contains an underscore', () => {
+    expect(elements('_this_ is about file_name.txt')).toEqual([
+      { type: 'text', text: 'this', style: { italic: true } },
+      { type: 'text', text: ' is about file_name.txt' },
+    ]);
+  });
+
+  it('does not open emphasis on a marker directly after a word character', () => {
+    expect(elements('snake_case_name stays literal')).toEqual([
+      { type: 'text', text: 'snake_case_name stays literal' },
+    ]);
+  });
+
+  it('does not open emphasis on a marker directly after a non-ASCII word character', () => {
+    // Both Unicode forms of the same word: precomposed U+00E9, then e + U+0301.
+    for (const cafe of ['caf\u00e9', 'cafe\u0301']) {
+      expect(elements(`${cafe}_italic_ stays literal`)).toEqual([
+        { type: 'text', text: `${cafe}_italic_ stays literal` },
+      ]);
+    }
+  });
+
+  it('does not open emphasis after an astral-plane word character', () => {
+    // U+1D400 is a letter but occupies two UTF-16 units.
+    expect(elements('\u{1D400}_italic_ stays literal')).toEqual([
+      { type: 'text', text: '\u{1D400}_italic_ stays literal' },
+    ]);
+  });
+
+  it('leaves an identifier-spanning underscore pair literal', () => {
+    expect(elements('_start with file_name inside_')).toEqual([
+      { type: 'text', text: '_start with file_name inside_' },
+    ]);
+  });
+
+  it('applies bold, strike and code mid-word', () => {
+    // Slack scopes the word-boundary rule to _italic_ only.
+    expect(elements('*a*b')).toEqual([
+      { type: 'text', text: 'a', style: { bold: true } },
+      { type: 'text', text: 'b' },
+    ]);
+    expect(elements('a`b`c')).toEqual([
+      { type: 'text', text: 'a' },
+      { type: 'text', text: 'b', style: { code: true } },
+      { type: 'text', text: 'c' },
+    ]);
+    expect(elements('~a~b')).toEqual([
+      { type: 'text', text: 'a', style: { strike: true } },
+      { type: 'text', text: 'b' },
+    ]);
+  });
+
+  it('does not let a doubled marker swallow the adjacent one', () => {
+    expect(elements('**bold**')).toEqual([
+      { type: 'text', text: '*' },
+      { type: 'text', text: 'bold', style: { bold: true } },
+      { type: 'text', text: '*' },
+    ]);
+    expect(elements('~~strike~~')).toEqual([
+      { type: 'text', text: '~' },
+      { type: 'text', text: 'strike', style: { strike: true } },
+      { type: 'text', text: '~' },
+    ]);
+  });
+
+  it('does not let a tilde in a URL swallow a later strike span', () => {
+    expect(elements('see https://host/~user and ~important~')).toEqual([
+      { type: 'text', text: 'see https://host/~user and ' },
+      { type: 'text', text: 'important', style: { strike: true } },
+    ]);
+  });
 });

--- a/src/lib/mrkdwn.ts
+++ b/src/lib/mrkdwn.ts
@@ -32,6 +32,27 @@ const MARKERS: [string, keyof RichTextStyle][] = [
   ['~', 'strike'],
 ];
 
+// Combining marks count as word characters so a decomposed "é" (e + U+0301)
+// behaves the same as its precomposed form.
+const WORD_CHAR = /[\p{L}\p{N}\p{M}]/u;
+
+function isWordCodePoint(cp: number | undefined): boolean {
+  return cp !== undefined && WORD_CHAR.test(String.fromCodePoint(cp));
+}
+
+// Both helpers work on whole code points; indexing by UTF-16 unit would hand a
+// lone surrogate to the regex and misclassify every astral letter.
+function wordCharBefore(text: string, i: number): boolean {
+  if (i <= 0) return false;
+  const prev = text.charCodeAt(i - 1);
+  const isTrailSurrogate = prev >= 0xdc00 && prev <= 0xdfff;
+  return isWordCodePoint(text.codePointAt(isTrailSurrogate && i >= 2 ? i - 2 : i - 1));
+}
+
+function wordCharAfter(text: string, i: number): boolean {
+  return isWordCodePoint(text.codePointAt(i + 1));
+}
+
 function parseInline(text: string): RichTextElement[] {
   const elements: RichTextElement[] = [];
 
@@ -42,9 +63,19 @@ function parseInline(text: string): RichTextElement[] {
     for (const [marker, styleKey] of MARKERS) {
       if (text[i] !== marker) continue;
 
-      // Look for the closing marker
+      // Only "_" requires word boundaries; Slack applies *bold*, ~strike~ and `code`
+      // mid-word. Without this, the underscore in one URL or identifier pairs with the
+      // underscore in a completely unrelated one later in the message, and everything
+      // between the two gets consumed as italic.
+      const needsBoundary = marker === '_';
+      if (needsBoundary && wordCharBefore(text, i)) continue;
+
       const end = text.indexOf(marker, i + 1);
       if (end === -1) continue;
+      // A mid-word "_" (the one in "file_name") does not close a span. Leave the text
+      // literal rather than searching on for a later candidate, which would swallow
+      // everything in between.
+      if (needsBoundary && wordCharAfter(text, end)) continue;
 
       const inner = text.substring(i + 1, end);
       // Don't match empty content or content that starts/ends with space


### PR DESCRIPTION
Fixes #103

## Summary

`parseInline` paired a marker with the next occurrence of the same character anywhere later in the text, with no check on what surrounded either marker. An underscore inside one identifier or URL (the `merge_requests` path segment in a GitLab link) paired with an unrelated underscore much later in the message, italicising everything between them and deleting both underscores, which destroyed both URLs.

An underscore now only opens a span when it is not preceded by a word character, and only closes one when it is not followed by one. The rule is scoped to underscores because Slack applies `*bold*`, `~strike~` and `` `code` `` mid-word. When the closing underscore sits mid-word the span stays literal rather than searching on for a later candidate, which would swallow the text in between.

The word-character test runs on whole code points and counts combining marks, so a decomposed `é` (e + U+0301) and astral letters are not mistaken for non-word characters.

## Behaviour change

One case differs from `main` beyond the bug itself: `_hello_world_` is now fully literal, where it previously rendered italic `hello` followed by plain `world_`. That matches Slack leaving `snake_case` unformatted, and literal is the safe failure mode for a parser whose output cannot be read back before it is sent.

`*bold*`, `~strike~` and `` `code` `` are unchanged in every case, including mid-word (`*a*b`, `` a`b`c ``), doubled markers (`**bold**`, `~~strike~~`) and a `~` inside a URL path followed by a later `~strike~` span.

## Test plan

- [x] `bun test` (323 pass, 0 fail) and `bun run type-check` clean.
- [x] New cases cover: two underscore-bearing URLs no longer pair, a single identifier stays literal, `_italic_` still works alongside a later `file_name`, an underscore pair spanning an identifier stays literal, both Unicode forms of `café_`, an astral letter before `_`, mid-word bold/strike/code, doubled markers, and a URL `~` against a later strike span.
