### PR TITLE
ci: warn on unsigned commits in pull requests

### DIFF
--- a/.github/workflows/signed-commits.yml
+++ b/.github/workflows/signed-commits.yml
@@ -16,6 +16,10 @@ name: Signed Commits
 
 on:
   pull_request_target:
+    # Scoped to the protected branches, matching ci.yml and test.yml. The
+    # comment asserts that the base branch requires signed commits, so it must
+    # not fire for a base branch where that is untrue.
+    branches: [ main, master ]
     types: [opened, synchronize, reopened]
 
 # Least-privilege default token for every job in this workflow.
@@ -142,14 +146,16 @@ jobs:
 
             const body = unsigned.length > 0 ? warning : resolved;
 
+            // GitHub may hand comment bodies back with CRLF line endings, so a
+            // raw === would report "changed" on every push and re-edit an
+            // identical comment forever.
+            const same = (a, b) => a.replace(/\r\n/g, '\n') === b.replace(/\r\n/g, '\n');
+
             if (unsigned.length === 0 && !existing) {
               // Nothing to say and nothing stale to clean up.
               core.info('All commits verified; no existing comment to update.');
-              return;
-            }
-
-            if (existing) {
-              if (existing.body === body) {
+            } else if (existing) {
+              if (same(existing.body, body)) {
                 core.info('Existing comment is already up to date.');
               } else {
                 await github.rest.issues.updateComment({

--- a/.github/workflows/signed-commits.yml
+++ b/.github/workflows/signed-commits.yml
@@ -1,0 +1,180 @@
+name: Signed Commits
+
+# Advisory check: tells contributors as early as possible when a PR contains
+# commits GitHub cannot verify. `main` is protected by a ruleset that requires
+# signed commits and has no bypass actors, so an unsigned commit makes the PR
+# unmergeable — for anyone, including admins. Surfacing it on the first push
+# means the fix (a rebase) is free, instead of invalidating an approval later.
+#
+# This job never fails the PR. The ruleset already blocks the merge; a red
+# check would add noise without adding protection.
+#
+# `pull_request_target` (not `pull_request`) is deliberate: fork PRs are the
+# case that most needs this comment, and `pull_request` hands forks a
+# read-only token. This is safe here because the job never checks out or
+# executes PR code — it only reads the GitHub API.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+# Least-privilege default token for every job in this workflow.
+permissions:
+  contents: read
+  pull-requests: write
+
+# One run per PR; a rapid series of pushes should not race on the comment.
+concurrency:
+  group: signed-commits-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-signatures:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check commit signatures and report
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const MARKER = '<!-- signed-commits-check -->';
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const baseRef = pr.base.ref;
+
+            // The PR commits endpoint is capped at 250 commits by GitHub.
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner,
+              repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            const truncated = commits.length >= 250;
+
+            const unsigned = commits.filter((c) => !c.commit?.verification?.verified);
+            core.info(`${commits.length - unsigned.length}/${commits.length} commits verified`);
+
+            // Only ever adopt a comment this workflow could have written. A
+            // human can paste the marker into their own comment, and the
+            // default token cannot edit someone else's — that would hard-fail
+            // the job on a PR that may be perfectly fine.
+            const existing = (
+              await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: pr.number,
+                per_page: 100,
+              })
+            ).find((c) => c.user?.type === 'Bot' && c.body?.includes(MARKER));
+
+            // Commit subjects are contributor-controlled and land inside a
+            // markdown table, so neutralise anything that could break out of
+            // the cell or inject markup.
+            const cell = (text) => {
+              const raw = text.replace(/\r/g, '').trim();
+              const clipped = raw.length > 72 ? `${raw.slice(0, 71)}…` : raw;
+              return clipped.replace(/[|`<>\\]/g, '\\$&') || '(no subject)';
+            };
+
+            const list = unsigned
+              .map((c) => {
+                const subject = cell(c.commit.message.split('\n')[0]);
+                const reason = c.commit.verification?.reason ?? 'unknown';
+                return `| \`${c.sha.slice(0, 7)}\` | ${subject} | \`${reason}\` |`;
+              })
+              .join('\n');
+
+            const warning = [
+              MARKER,
+              '## :lock: Unsigned commits detected',
+              '',
+              `${unsigned.length} of ${commits.length} commit(s) in this pull request are not signed.`,
+              '',
+              '`' + baseRef + '` is protected by a ruleset that requires signed commits and has',
+              'no bypass actors, so this PR **cannot be merged** — by anyone, including',
+              'maintainers — until every commit is verified.',
+              '',
+              '| Commit | Subject | Reason |',
+              '| --- | --- | --- |',
+              list,
+              '',
+              ...(truncated
+                ? ['> :warning: This PR has 250+ commits; the list above may be incomplete.', '']
+                : []),
+              '### How to fix',
+              '',
+              'If commit signing is already configured, re-sign the existing commits:',
+              '',
+              '```bash',
+              `git fetch origin ${baseRef}`,
+              `git rebase --exec 'git commit --amend --no-edit -S' origin/${baseRef}`,
+              'git push --force-with-lease',
+              '```',
+              '',
+              '<details>',
+              '<summary>Setting up signing for the first time (SSH)</summary>',
+              '',
+              '```bash',
+              'git config --global gpg.format ssh',
+              'git config --global user.signingkey ~/.ssh/id_ed25519.pub',
+              'git config --global commit.gpgsign true',
+              '```',
+              '',
+              'Then add the **same public key** to your GitHub account as a *Signing Key*',
+              '(Settings → SSH and GPG keys → New SSH key → Key type: **Signing Key**).',
+              'An authentication key alone will not make commits show as Verified.',
+              '',
+              'Docs: [Telling Git about your signing key]' +
+                '(https://docs.github.com/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key)',
+              '',
+              '</details>',
+              '',
+              '---',
+              '<sub>This comment updates itself on every push. Nothing else is required from you.</sub>',
+            ].join('\n');
+
+            const resolved = [
+              MARKER,
+              ':white_check_mark: **All commits are signed and verified.**',
+              '',
+              `<sub>${commits.length} commit(s) checked.</sub>`,
+            ].join('\n');
+
+            const body = unsigned.length > 0 ? warning : resolved;
+
+            if (unsigned.length === 0 && !existing) {
+              // Nothing to say and nothing stale to clean up.
+              core.info('All commits verified; no existing comment to update.');
+              return;
+            }
+
+            if (existing) {
+              if (existing.body === body) {
+                core.info('Existing comment is already up to date.');
+              } else {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body,
+                });
+                core.info(`Updated comment ${existing.id}.`);
+              }
+            } else {
+              const { data } = await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pr.number,
+                body,
+              });
+              core.info(`Created comment ${data.id}.`);
+            }
+
+            await core.summary
+              .addHeading('Signed commits', 2)
+              .addRaw(
+                unsigned.length > 0
+                  ? `:lock: ${unsigned.length} of ${commits.length} commit(s) unsigned.`
+                  : `:white_check_mark: All ${commits.length} commit(s) verified.`,
+              )
+              .write();

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,28 @@ Include documentation updates in the same pull request as the code changes.
 
 Write clear, descriptive commit messages. Use the imperative mood (e.g., "Add pagination to list endpoints" not "Added pagination").
 
+### Signed Commits (required)
+
+`main` is protected by a ruleset that requires **every commit to be signed and verified**, with no bypass actors. A pull request containing even one unsigned commit cannot be merged by anyone, including maintainers — so please configure signing before you start.
+
+```bash
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519.pub
+git config --global commit.gpgsign true
+```
+
+Then add the **same public key** to your GitHub account as a *Signing Key* (Settings → SSH and GPG keys → New SSH key → Key type: **Signing Key**). An authentication key alone will not make commits show as Verified. See [Telling Git about your signing key](https://docs.github.com/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key).
+
+If you already pushed unsigned commits, re-sign them in place:
+
+```bash
+git fetch origin main
+git rebase --exec 'git commit --amend --no-edit -S' origin/main
+git push --force-with-lease
+```
+
+The `Signed Commits` workflow posts (and keeps updated) a comment on any pull request with unverified commits, so you will hear about this on your first push rather than at merge time.
+
 ## For AI Agent Contributors
 
 AI-generated contributions are welcome and go through the same process as human contributions:


### PR DESCRIPTION
Closes #92

## What

Adds `.github/workflows/signed-commits.yml`, an **advisory** workflow that runs on every PR push, reads commit verification from the GitHub API, and maintains a **single self-updating comment** listing any unsigned commits and how to fix them. Also documents the signing requirement in `CONTRIBUTING.md`.

## Why

`main` is protected by the `default-branch-baseline` ruleset, which requires signed commits and has **no bypass actors** — one unsigned commit makes a PR unmergeable for everyone, maintainers included. Today that only surfaces at merge time, after review and a full green CI run, and the fix is a force-push that invalidates the approval already given (exactly what happened on #91). This moves the discovery to the first push, when a rebase is free.

## How

- **Trigger:** `pull_request_target` on `opened`/`synchronize`/`reopened`. Deliberate over `pull_request`: fork PRs are the case that most needs this comment, and `pull_request` hands forks a read-only token. Safe here because the job **never checks out or executes PR code** — it only reads the API.
- **Source of truth:** `GET /pulls/{n}/commits` → `commit.verification.verified`, paginated. Not `git verify-commit`, which doesn't know about GitHub-hosted keys or the web-flow signer.
- **Dedup:** finds its own comment by the hidden marker `<!-- signed-commits-check -->` and `PATCH`es it. Idempotent — if the body is unchanged it makes no API call at all, so a series of pushes doesn't churn the timeline.
- **Self-resolving:** once every commit verifies, the comment is rewritten to a short "all verified" note. A stale warning never outlives the problem. If all commits are verified and no comment exists, the job does nothing.
- **Advisory, never red.** The ruleset already blocks the merge; a failing check would add noise without adding protection.
- **Permissions:** `contents: read`, `pull-requests: write`, default `GITHUB_TOKEN`. Action pinned by SHA, matching the convention in the other workflows.
- **Concurrency group per PR** with `cancel-in-progress`, so rapid pushes can't race on the comment.

### Hardening

- Commit subjects are contributor-controlled and land inside a markdown table, so they're clipped to 72 chars and `` | ` < > \ `` are escaped. Without this, a crafted commit subject breaks the table or injects markup into a comment written by a token with `pull-requests: write`.
- The comment lookup requires `user.type === 'Bot'`. A human can paste the marker into their own comment, and the default token **cannot** edit someone else's — that would hard-fail the job on a PR that is otherwise fine.
- Handles a missing `verification` object (reports `unknown`) and notes when the 250-commit API cap truncates the list.

## Testing

Workflow logic can't run in CI before it's on `main`, so the embedded script was extracted and exercised against a mocked Octokit across six cases, all passing:

| Case | Expected | Result |
|---|---|---|
| Unsigned commits, no existing comment | create comment | ✅ |
| Unsigned, existing identical comment | no API call (idempotent) | ✅ |
| All verified, existing warning comment | patched to "all verified" | ✅ |
| All verified, no comment | no-op | ✅ |
| Commit with no `verification` field | listed, reason `unknown` | ✅ |
| Hostile subject + human comment carrying marker | subject escaped; creates own comment instead of 403-ing | ✅ |

YAML parses; the embedded script passes `node --check` as an async body.

## Note on rollout

`pull_request_target` workflows run from the **base** branch, so this will not run against this PR — it takes effect on the first PR opened after merge.