### PR TITLE
feat(auth): support multiple authentication profiles per workspace (#89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,46 @@ slackcli auth logout
 slackcli auth logout --keep-browser-session
 ```
 
+### Multiple Profiles for One Workspace
+
+By default each Slack workspace is stored once. To keep **more than one identity
+for the same workspace** — for example a browser-authenticated user for search
+and drafts alongside a bot token for unattended jobs — give each login a
+`--profile` name:
+
+```bash
+# A user identity (browser auth)
+slackcli auth login-browser \
+  --xoxd=xoxd-... --xoxc=xoxc-... \
+  --workspace-url=https://example.slack.com \
+  --profile=rafael
+
+# A bot identity in the same workspace
+slackcli auth login \
+  --token=xoxb-... \
+  --workspace-name=example \
+  --profile=automation-bot
+```
+
+Select a profile anywhere `--workspace` is accepted:
+
+```bash
+slackcli search messages "after:2026-07-01" --workspace=rafael --json
+slackcli messages send --recipient-id=C123 --message="Done" --workspace=automation-bot
+```
+
+Notes:
+
+- **Backward compatible.** Existing `workspaces.json` files and single-identity
+  setups keep working unchanged — `--profile` is optional.
+- Re-authenticating the **same** identity refreshes its stored tokens in place.
+- Logging in a **second** identity for a workspace **without** `--profile` is
+  saved under an auto-generated key (e.g. `T123-2`) instead of overwriting the
+  first. The chosen key is printed after login.
+- `auth list`, `auth set-default`, and `auth remove` accept a profile name,
+  workspace ID, or workspace name. If a bare workspace ID/name matches more than
+  one profile, SlackCLI asks you to pick a profile instead of guessing.
+
 ### Conversation Commands
 
 ```bash

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import ora from 'ora';
 import { authenticateStandard, authenticateBrowser, authenticateAuto, AutoLoginError } from '../lib/auth.ts';
 import {
-  getAllWorkspaces,
+  getAllWorkspaceEntries,
   setDefaultWorkspace,
   removeWorkspace,
   clearAllWorkspaces,
@@ -26,18 +26,21 @@ export function createAuthCommand(): Command {
     .description('Login with standard Slack app token (xoxb-* or xoxp-*)')
     .requiredOption('--token <token>', 'Slack bot or user token')
     .requiredOption('--workspace-name <name>', 'Workspace name for identification')
+    .option('--profile <name>', 'Store under a named profile (keeps multiple identities for one workspace)')
     .action(async (options) => {
       const spinner = ora('Authenticating...').start();
 
       try {
-        const config = await authenticateStandard(
+        const { config, profileKey } = await authenticateStandard(
           options.token,
-          options.workspaceName
+          options.workspaceName,
+          options.profile
         );
 
         spinner.succeed('Authentication successful!');
         success(`Authenticated as workspace: ${config.workspace_name}`);
         info(`Workspace ID: ${config.workspace_id}`);
+        info(`Profile: ${profileKey}`);
         if (config.auth_type === 'standard') {
           info(`Token Type: ${config.token_type}`);
         }
@@ -56,20 +59,23 @@ export function createAuthCommand(): Command {
     .requiredOption('--xoxc <token>', 'Browser API token (xoxc-*)')
     .requiredOption('--workspace-url <url>', 'Workspace URL (e.g., https://myteam.slack.com)')
     .option('--workspace-name <name>', 'Optional workspace name for identification')
+    .option('--profile <name>', 'Store under a named profile (keeps multiple identities for one workspace)')
     .action(async (options) => {
       const spinner = ora('Authenticating...').start();
 
       try {
-        const config = await authenticateBrowser(
+        const { config, profileKey } = await authenticateBrowser(
           options.xoxd,
           options.xoxc,
           options.workspaceUrl,
-          options.workspaceName
+          options.workspaceName,
+          options.profile
         );
 
         spinner.succeed('Authentication successful!');
         success(`Authenticated as workspace: ${config.workspace_name}`);
         info(`Workspace ID: ${config.workspace_id}`);
+        info(`Profile: ${profileKey}`);
         if (config.auth_type === 'browser') {
           info(`Workspace URL: ${config.workspace_url}`);
         }
@@ -156,20 +162,20 @@ export function createAuthCommand(): Command {
     .description('List all authenticated workspaces')
     .action(async () => {
       try {
-        const workspaces = await getAllWorkspaces();
-        const defaultId = await getDefaultWorkspaceId();
+        const entries = await getAllWorkspaceEntries();
+        const defaultKey = await getDefaultWorkspaceId();
 
-        if (workspaces.length === 0) {
+        if (entries.length === 0) {
           info('No authenticated workspaces found.');
           info('Run "slackcli auth login" or "slackcli auth login-browser" to authenticate.');
           return;
         }
 
-        console.log(chalk.bold(`\n📋 Authenticated Workspaces (${workspaces.length}):\n`));
+        console.log(chalk.bold(`\n📋 Authenticated Workspaces (${entries.length}):\n`));
 
-        workspaces.forEach((ws, idx) => {
-          const isDefault = ws.workspace_id === defaultId;
-          console.log(`${idx + 1}. ${formatWorkspace(ws, isDefault)}\n`);
+        entries.forEach(({ key, config }, idx) => {
+          const isDefault = key === defaultKey;
+          console.log(`${idx + 1}. ${formatWorkspace(config, isDefault, key)}\n`);
         });
       } catch (err: any) {
         error('Failed to list workspaces', err.message);
@@ -181,11 +187,11 @@ export function createAuthCommand(): Command {
   auth
     .command('set-default')
     .description('Set default workspace')
-    .argument('<workspace-id>', 'Workspace ID to set as default')
-    .action(async (workspaceId) => {
+    .argument('<workspace>', 'Profile name, workspace ID, or workspace name')
+    .action(async (identifier) => {
       try {
-        await setDefaultWorkspace(workspaceId);
-        success(`Set ${workspaceId} as default workspace`);
+        await setDefaultWorkspace(identifier);
+        success(`Set ${identifier} as default workspace`);
       } catch (err: any) {
         error('Failed to set default workspace', err.message);
         process.exit(1);
@@ -196,11 +202,11 @@ export function createAuthCommand(): Command {
   auth
     .command('remove')
     .description('Remove a workspace')
-    .argument('<workspace-id>', 'Workspace ID to remove')
-    .action(async (workspaceId) => {
+    .argument('<workspace>', 'Profile name, workspace ID, or workspace name')
+    .action(async (identifier) => {
       try {
-        await removeWorkspace(workspaceId);
-        success(`Removed workspace ${workspaceId}`);
+        await removeWorkspace(identifier);
+        success(`Removed workspace ${identifier}`);
       } catch (err: any) {
         error('Failed to remove workspace', err.message);
         process.exit(1);
@@ -349,10 +355,11 @@ export function createAuthCommand(): Command {
         if (options.login) {
           const spinner = ora('Authenticating with extracted tokens...').start();
           try {
-            const config = await authenticateBrowser(parsed.xoxd, parsed.xoxc, parsed.workspaceUrl, parsed.workspaceName);
+            const { config, profileKey } = await authenticateBrowser(parsed.xoxd, parsed.xoxc, parsed.workspaceUrl, parsed.workspaceName);
             spinner.succeed('Authentication successful!');
             success(`Authenticated as workspace: ${config.workspace_name}`);
             info(`Workspace ID: ${config.workspace_id}`);
+            info(`Profile: ${profileKey}`);
           } catch (err: any) {
             spinner.fail('Authentication failed');
             error(err.message);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -11,11 +11,19 @@ import {
 } from './browser-auth.ts';
 import type { BrowserSessionFailure } from './browser-auth.ts';
 
+// Result of a successful login: the stored config plus the profile key it was
+// saved under (which may be user-chosen, the team_id, or auto-generated).
+export interface AuthResult {
+  config: WorkspaceConfig;
+  profileKey: string;
+}
+
 // Authenticate with standard token
 export async function authenticateStandard(
   token: string,
-  workspaceName: string
-): Promise<WorkspaceConfig> {
+  workspaceName: string,
+  profile?: string
+): Promise<AuthResult> {
   // Create a temporary config to test the token
   const tempConfig: StandardAuthConfig = {
     workspace_id: 'temp',
@@ -35,12 +43,13 @@ export async function authenticateStandard(
       ...tempConfig,
       workspace_id: authTest.team_id,
       workspace_name: workspaceName || authTest.team,
+      user_id: authTest.user_id,
     };
 
     // Save the workspace
-    await addWorkspace(config);
+    const profileKey = await addWorkspace(config, profile);
 
-    return config;
+    return { config, profileKey };
   } catch (error: any) {
     throw new Error(`Authentication failed: ${error.message}`);
   }
@@ -51,8 +60,9 @@ export async function authenticateBrowser(
   xoxdToken: string,
   xoxcToken: string,
   workspaceUrl: string,
-  workspaceName?: string
-): Promise<WorkspaceConfig> {
+  workspaceName?: string,
+  profile?: string
+): Promise<AuthResult> {
   // Extract workspace name from URL if not provided
   const defaultName = extractSlackWorkspaceName(workspaceUrl);
 
@@ -76,12 +86,13 @@ export async function authenticateBrowser(
       ...tempConfig,
       workspace_id: authTest.team_id,
       workspace_name: workspaceName || authTest.team,
+      user_id: authTest.user_id,
     };
 
     // Save the workspace
-    await addWorkspace(config);
+    const profileKey = await addWorkspace(config, profile);
 
-    return config;
+    return { config, profileKey };
   } catch (error: any) {
     throw new Error(`Authentication failed: ${error.message}`);
   }
@@ -171,7 +182,9 @@ export async function authenticateAuto(
     }
 
     try {
-      const config = await authenticateBrowser(
+      // login-auto enrols every captured workspace at once, so a single
+      // --profile can't map to it; these keep the default team_id keying.
+      const { config } = await authenticateBrowser(
         capture.xoxd,
         workspace.xoxc,
         workspace.workspaceUrl,

--- a/src/lib/formatter.ts
+++ b/src/lib/formatter.ts
@@ -38,12 +38,22 @@ export function formatTimestamp(ts: string): string {
 }
 
 // Format workspace info
-export function formatWorkspace(config: WorkspaceConfig, isDefault: boolean = false): string {
+export function formatWorkspace(
+  config: WorkspaceConfig,
+  isDefault: boolean = false,
+  profileKey?: string,
+): string {
   const defaultBadge = isDefault ? chalk.green('(default)') : '';
   const authType = config.auth_type === 'browser' ? '🌐 Browser' : '🔑 Standard';
 
+  // Only surface the profile line when it adds information beyond the ID (i.e. a
+  // named or auto-generated key), keeping single-identity output unchanged.
+  const profileLine = profileKey && profileKey !== config.workspace_id
+    ? `\n  Profile: ${chalk.cyan(profileKey)}`
+    : '';
+
   return `${chalk.bold(config.workspace_name)} ${defaultBadge}
-  ID: ${config.workspace_id}
+  ID: ${config.workspace_id}${profileLine}
   Auth: ${authType}`;
 }
 

--- a/src/lib/workspaces.test.ts
+++ b/src/lib/workspaces.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  resolveWorkspace,
+  deriveStorageKey,
+  AmbiguousWorkspaceError,
+} from './workspaces.ts';
+import type {
+  WorkspacesData,
+  StandardAuthConfig,
+  BrowserAuthConfig,
+} from '../types/index.ts';
+
+// Test builders --------------------------------------------------------------
+
+function standard(overrides: Partial<StandardAuthConfig> = {}): StandardAuthConfig {
+  return {
+    workspace_id: 'T1',
+    workspace_name: 'Acme',
+    auth_type: 'standard',
+    token: 'xoxb-abc',
+    token_type: 'bot',
+    ...overrides,
+  };
+}
+
+function browser(overrides: Partial<BrowserAuthConfig> = {}): BrowserAuthConfig {
+  return {
+    workspace_id: 'T1',
+    workspace_name: 'Acme',
+    workspace_url: 'https://acme.slack.com',
+    auth_type: 'browser',
+    xoxd_token: 'xoxd-abc',
+    xoxc_token: 'xoxc-abc',
+    ...overrides,
+  };
+}
+
+// A pre-profiles config: keyed by team_id, no `profile` or `user_id` fields.
+function legacyData(): WorkspacesData {
+  return {
+    default_workspace: 'T1',
+    workspaces: {
+      T1: standard(),
+    },
+  };
+}
+
+describe('resolveWorkspace', () => {
+  it('returns the default workspace when no identifier is given', () => {
+    const resolved = resolveWorkspace(legacyData());
+    expect(resolved?.key).toBe('T1');
+    expect(resolved?.config.workspace_name).toBe('Acme');
+  });
+
+  it('returns null when there is no default and no identifier', () => {
+    expect(resolveWorkspace({ workspaces: {} })).toBeNull();
+  });
+
+  // Backward compatibility: legacy files keyed by team_id keep resolving by id
+  // and by name exactly as before profiles existed.
+  it('resolves a legacy record by workspace id', () => {
+    expect(resolveWorkspace(legacyData(), 'T1')?.key).toBe('T1');
+  });
+
+  it('resolves a legacy record by workspace name', () => {
+    expect(resolveWorkspace(legacyData(), 'Acme')?.key).toBe('T1');
+  });
+
+  it('returns null for an unknown identifier', () => {
+    expect(resolveWorkspace(legacyData(), 'nope')).toBeNull();
+  });
+
+  it('resolves two profiles in one team by their profile keys', () => {
+    const data: WorkspacesData = {
+      default_workspace: 'rafael',
+      workspaces: {
+        rafael: browser({ profile: 'rafael', user_id: 'U1' }),
+        'automation-bot': standard({ profile: 'automation-bot', user_id: 'U2' }),
+      },
+    };
+
+    expect(resolveWorkspace(data, 'rafael')?.config.auth_type).toBe('browser');
+    expect(resolveWorkspace(data, 'automation-bot')?.config.auth_type).toBe('standard');
+  });
+
+  it('throws an ambiguity error when a workspace id maps to multiple profiles', () => {
+    const data: WorkspacesData = {
+      default_workspace: 'rafael',
+      workspaces: {
+        rafael: browser({ profile: 'rafael', user_id: 'U1' }),
+        'automation-bot': standard({ profile: 'automation-bot', user_id: 'U2' }),
+      },
+    };
+
+    expect(() => resolveWorkspace(data, 'T1')).toThrow(AmbiguousWorkspaceError);
+    try {
+      resolveWorkspace(data, 'T1');
+    } catch (err) {
+      expect((err as AmbiguousWorkspaceError).keys.sort()).toEqual(['automation-bot', 'rafael']);
+    }
+  });
+
+  it('throws an ambiguity error when a workspace name maps to multiple profiles', () => {
+    const data: WorkspacesData = {
+      workspaces: {
+        rafael: browser({ profile: 'rafael', user_id: 'U1' }),
+        'automation-bot': standard({ profile: 'automation-bot', user_id: 'U2' }),
+      },
+    };
+
+    expect(() => resolveWorkspace(data, 'Acme')).toThrow(AmbiguousWorkspaceError);
+  });
+
+  it('prefers an exact profile key over an id/name collision', () => {
+    // A record whose key happens to equal another record's workspace_id must
+    // still resolve by the exact key first.
+    const data: WorkspacesData = {
+      workspaces: {
+        rafael: browser({ profile: 'rafael', user_id: 'U1' }),
+        'automation-bot': standard({ profile: 'automation-bot', user_id: 'U2' }),
+      },
+    };
+    expect(resolveWorkspace(data, 'rafael')?.config.user_id).toBe('U1');
+  });
+});
+
+describe('deriveStorageKey', () => {
+  it('keeps the team_id key for the first identity of a team', () => {
+    const data: WorkspacesData = { workspaces: {} };
+    expect(deriveStorageKey(data, standard())).toBe('T1');
+  });
+
+  // Backward compatibility: re-authenticating the same identity (e.g. rotating a
+  // token) updates the existing record in place instead of duplicating it.
+  it('refreshes a legacy record in place when no profile is given', () => {
+    const data = legacyData();
+    const rotated = standard({ token: 'xoxb-new' });
+    expect(deriveStorageKey(data, rotated)).toBe('T1');
+  });
+
+  it('refreshes the same identity in place when user_id matches', () => {
+    const data: WorkspacesData = {
+      workspaces: { T1: standard({ user_id: 'U1' }) },
+    };
+    expect(deriveStorageKey(data, standard({ user_id: 'U1', token: 'xoxb-new' }))).toBe('T1');
+  });
+
+  // The core guarantee: a second, different identity for the same team must not
+  // overwrite the first when no --profile is supplied.
+  it('auto-generates a suffixed key for a different identity in the same team', () => {
+    const data: WorkspacesData = {
+      workspaces: { T1: standard({ user_id: 'U1' }) },
+    };
+    const other = browser({ user_id: 'U2' });
+    expect(deriveStorageKey(data, other)).toBe('T1-2');
+  });
+
+  it('increments the suffix until it finds a free key', () => {
+    const data: WorkspacesData = {
+      workspaces: {
+        T1: standard({ user_id: 'U1' }),
+        'T1-2': browser({ profile: 'T1-2', user_id: 'U2' }),
+      },
+    };
+    expect(deriveStorageKey(data, standard({ user_id: 'U3', token_type: 'user' }))).toBe('T1-3');
+  });
+
+  it('does not treat a different token_type as the same identity', () => {
+    // Legacy bot record; logging in with a user token is a distinct identity.
+    const data: WorkspacesData = {
+      workspaces: { T1: standard({ token_type: 'bot' }) },
+    };
+    const userToken = standard({ token_type: 'user', token: 'xoxp-x', user_id: 'U9' });
+    expect(deriveStorageKey(data, userToken)).toBe('T1-2');
+  });
+
+  it('uses an explicit profile name as the key', () => {
+    const data: WorkspacesData = { workspaces: { T1: standard() } };
+    expect(deriveStorageKey(data, browser({ user_id: 'U2' }), 'rafael')).toBe('rafael');
+  });
+
+  it('reuses an explicit profile key when it belongs to the same team (refresh)', () => {
+    const data: WorkspacesData = {
+      workspaces: { rafael: browser({ profile: 'rafael', user_id: 'U1' }) },
+    };
+    expect(deriveStorageKey(data, browser({ user_id: 'U1' }), 'rafael')).toBe('rafael');
+  });
+
+  it('refuses an explicit profile key already used by a different team', () => {
+    const data: WorkspacesData = {
+      workspaces: { rafael: browser({ workspace_id: 'T9', profile: 'rafael' }) },
+    };
+    expect(() => deriveStorageKey(data, standard({ workspace_id: 'T1' }), 'rafael')).toThrow(
+      /already belongs to workspace/,
+    );
+  });
+});

--- a/src/lib/workspaces.ts
+++ b/src/lib/workspaces.ts
@@ -36,32 +36,180 @@ export async function saveWorkspaces(data: WorkspacesData): Promise<void> {
   await writeFile(WORKSPACES_FILE, JSON.stringify(data, null, 2), { mode: 0o600 });
 }
 
-// Add or update a workspace
-export async function addWorkspace(config: WorkspaceConfig): Promise<void> {
+// ---------------------------------------------------------------------------
+// Profile-key resolution (pure — no IO — so it is straightforward to unit test)
+//
+// The map key of `data.workspaces` is a "profile key". For legacy files and for
+// the first identity of a team it is the `team_id` (unchanged from before
+// profiles existed); additional identities in the same team get a distinct key.
+// ---------------------------------------------------------------------------
+
+export interface ResolvedWorkspace {
+  key: string;
+  config: WorkspaceConfig;
+}
+
+// A selector matched more than one stored profile. Surfaced instead of silently
+// picking one, so the caller can disambiguate with an explicit profile name.
+export class AmbiguousWorkspaceError extends Error {
+  public identifier: string;
+  public keys: string[];
+
+  constructor(identifier: string, keys: string[]) {
+    super(
+      `"${identifier}" matches multiple profiles: ${keys.join(', ')}. ` +
+      `Re-run with --workspace=<profile> (see "slackcli auth list").`
+    );
+    this.name = 'AmbiguousWorkspaceError';
+    this.identifier = identifier;
+    this.keys = keys;
+  }
+}
+
+// Resolve a selector to a single stored record.
+//
+// Order: exact profile key -> explicit `profile` field -> unambiguous
+// workspace_id -> unambiguous workspace_name. A selector that resolves to more
+// than one record at any stage throws AmbiguousWorkspaceError rather than
+// guessing. Returns null when nothing matches. With no identifier, returns the
+// default workspace (legacy behavior).
+export function resolveWorkspace(
+  data: WorkspacesData,
+  identifier?: string,
+): ResolvedWorkspace | null {
+  if (!identifier) {
+    const key = data.default_workspace;
+    if (!key) return null;
+    const config = data.workspaces[key];
+    return config ? { key, config } : null;
+  }
+
+  // 1. Exact profile key (the map key). Preserves legacy `team_id` selection.
+  const direct = data.workspaces[identifier];
+  if (direct) return { key: identifier, config: direct };
+
+  const entries = Object.entries(data.workspaces);
+
+  // 2. Explicit `profile` field match.
+  const byProfile = entries.filter(([, c]) => c.profile === identifier);
+  if (byProfile.length === 1) return { key: byProfile[0][0], config: byProfile[0][1] };
+  if (byProfile.length > 1) {
+    throw new AmbiguousWorkspaceError(identifier, byProfile.map(([k]) => k));
+  }
+
+  // 3. Workspace id — only when it maps to exactly one profile.
+  const byId = entries.filter(([, c]) => c.workspace_id === identifier);
+  if (byId.length === 1) return { key: byId[0][0], config: byId[0][1] };
+  if (byId.length > 1) {
+    throw new AmbiguousWorkspaceError(identifier, byId.map(([k]) => k));
+  }
+
+  // 4. Workspace name — again only when unambiguous.
+  const byName = entries.filter(([, c]) => c.workspace_name === identifier);
+  if (byName.length === 1) return { key: byName[0][0], config: byName[0][1] };
+  if (byName.length > 1) {
+    throw new AmbiguousWorkspaceError(identifier, byName.map(([k]) => k));
+  }
+
+  return null;
+}
+
+// Two records describe the same identity when they are the same team, the same
+// auth mode, and — when both know it — the same authenticated user id. Legacy
+// records predate `user_id`, so a token-only match falls back to the team_id
+// slot (see deriveStorageKey) to keep refresh-in-place working for them.
+function isSameIdentity(a: WorkspaceConfig, b: WorkspaceConfig): boolean {
+  if (a.workspace_id !== b.workspace_id) return false;
+  if (a.auth_type !== b.auth_type) return false;
+  if (a.auth_type === 'standard' && b.auth_type === 'standard') {
+    if (a.token_type !== b.token_type) return false;
+  }
+  if (a.user_id && b.user_id) return a.user_id === b.user_id;
+  return true;
+}
+
+// Decide which map key a newly authenticated config should occupy.
+//
+// - With an explicit profile: use it, but refuse to reuse a key that already
+//   belongs to a different team (prevents clobbering an unrelated record).
+// - Without a profile: refresh the same identity in place (backward compatible
+//   token rotation); otherwise take the free team_id slot for the first
+//   identity, or append a numeric suffix so a second identity never silently
+//   replaces the first.
+export function deriveStorageKey(
+  data: WorkspacesData,
+  config: WorkspaceConfig,
+  profile?: string,
+): string {
+  if (profile) {
+    const existing = data.workspaces[profile];
+    if (existing && existing.workspace_id !== config.workspace_id) {
+      throw new Error(
+        `Profile "${profile}" already belongs to workspace ${existing.workspace_name} ` +
+        `(${existing.workspace_id}). Choose a different --profile name.`
+      );
+    }
+    return profile;
+  }
+
+  // Refresh an existing identity in place (keeps its key, default, and any name).
+  for (const [key, existing] of Object.entries(data.workspaces)) {
+    if (!isSameIdentity(existing, config)) continue;
+    // For legacy records lacking user_id, only the team_id slot is treated as a
+    // refresh target; a namespaced profile is left untouched.
+    if (existing.user_id && config.user_id) return key;
+    if (!existing.user_id && key === config.workspace_id) return key;
+  }
+
+  // First identity for this team keeps the historical team_id key.
+  if (!data.workspaces[config.workspace_id]) return config.workspace_id;
+
+  // A different identity already holds the team_id slot: never overwrite it.
+  let n = 2;
+  while (data.workspaces[`${config.workspace_id}-${n}`]) n++;
+  return `${config.workspace_id}-${n}`;
+}
+
+// Add or update a workspace. Returns the profile key it was stored under.
+export async function addWorkspace(
+  config: WorkspaceConfig,
+  profile?: string,
+): Promise<string> {
   const data = await loadWorkspaces();
 
-  data.workspaces[config.workspace_id] = config;
+  const key = deriveStorageKey(data, config, profile);
+
+  // Only persist a `profile` field when the key carries meaning (an explicit
+  // name or an auto-generated one). A first identity stored under its team_id
+  // stays shaped exactly like a pre-profiles record.
+  const stored: WorkspaceConfig = key === config.workspace_id
+    ? config
+    : { ...config, profile: key };
+
+  data.workspaces[key] = stored;
 
   // Set as default if it's the first workspace
   if (!data.default_workspace) {
-    data.default_workspace = config.workspace_id;
+    data.default_workspace = key;
   }
 
   await saveWorkspaces(data);
+  return key;
 }
 
-// Remove a workspace
-export async function removeWorkspace(workspaceId: string): Promise<void> {
+// Remove a workspace by profile key, workspace id, or name.
+export async function removeWorkspace(identifier: string): Promise<void> {
   const data = await loadWorkspaces();
 
-  if (!data.workspaces[workspaceId]) {
-    throw new Error(`Workspace ${workspaceId} not found`);
+  const resolved = resolveWorkspace(data, identifier);
+  if (!resolved) {
+    throw new Error(`Workspace ${identifier} not found`);
   }
 
-  delete data.workspaces[workspaceId];
+  delete data.workspaces[resolved.key];
 
   // Update default if we removed it
-  if (data.default_workspace === workspaceId) {
+  if (data.default_workspace === resolved.key) {
     const remainingIds = Object.keys(data.workspaces);
     data.default_workspace = remainingIds.length > 0 ? remainingIds[0] : undefined;
   }
@@ -69,47 +217,35 @@ export async function removeWorkspace(workspaceId: string): Promise<void> {
   await saveWorkspaces(data);
 }
 
-// Set default workspace
-export async function setDefaultWorkspace(workspaceId: string): Promise<void> {
+// Set default workspace by profile key, workspace id, or name.
+export async function setDefaultWorkspace(identifier: string): Promise<void> {
   const data = await loadWorkspaces();
 
-  if (!data.workspaces[workspaceId]) {
-    throw new Error(`Workspace ${workspaceId} not found`);
+  const resolved = resolveWorkspace(data, identifier);
+  if (!resolved) {
+    throw new Error(`Workspace ${identifier} not found`);
   }
 
-  data.default_workspace = workspaceId;
+  data.default_workspace = resolved.key;
   await saveWorkspaces(data);
 }
 
-// Get workspace by ID or name
+// Get workspace by profile key, id, or name (or the default when omitted).
 export async function getWorkspace(identifier?: string): Promise<WorkspaceConfig | null> {
   const data = await loadWorkspaces();
-
-  // If no identifier, return default workspace
-  if (!identifier) {
-    if (!data.default_workspace) {
-      return null;
-    }
-    return data.workspaces[data.default_workspace] || null;
-  }
-
-  // Try to find by ID first
-  if (data.workspaces[identifier]) {
-    return data.workspaces[identifier];
-  }
-
-  // Try to find by name
-  const workspaceByName = Object.values(data.workspaces).find(
-    w => w.workspace_name === identifier
-  );
-
-  return workspaceByName || null;
+  return resolveWorkspace(data, identifier)?.config ?? null;
 }
 
 // Get all workspaces
 export async function getAllWorkspaces(): Promise<WorkspaceConfig[]> {
   const data = await loadWorkspaces();
   return Object.values(data.workspaces);
+}
+
+// Get all workspaces paired with their profile keys.
+export async function getAllWorkspaceEntries(): Promise<ResolvedWorkspace[]> {
+  const data = await loadWorkspaces();
+  return Object.entries(data.workspaces).map(([key, config]) => ({ key, config }));
 }
 
 // Clear all workspaces

--- a/src/lib/workspaces.ts
+++ b/src/lib/workspaces.ts
@@ -236,12 +236,6 @@ export async function getWorkspace(identifier?: string): Promise<WorkspaceConfig
   return resolveWorkspace(data, identifier)?.config ?? null;
 }
 
-// Get all workspaces
-export async function getAllWorkspaces(): Promise<WorkspaceConfig[]> {
-  const data = await loadWorkspaces();
-  return Object.values(data.workspaces);
-}
-
 // Get all workspaces paired with their profile keys.
 export async function getAllWorkspaceEntries(): Promise<ResolvedWorkspace[]> {
   const data = await loadWorkspaces();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,12 @@ export type ConversationType = 'public_channel' | 'private_channel' | 'mpim' | '
 export interface StandardAuthConfig {
   workspace_id: string;
   workspace_name: string;
+  // Unique, user-selected profile name for this record. Optional and additive:
+  // legacy records without it are keyed by workspace_id and keep working.
+  profile?: string;
+  // Authenticated user/bot id (from auth.test). Distinguishes a token refresh of
+  // the same identity from a genuinely new identity within the same team.
+  user_id?: string;
   auth_type: 'standard';
   token: string;
   token_type: TokenType;
@@ -17,6 +23,8 @@ export interface BrowserAuthConfig {
   workspace_id: string;
   workspace_name: string;
   workspace_url: string;
+  profile?: string;
+  user_id?: string;
   auth_type: 'browser';
   xoxd_token: string;
   xoxc_token: string;
@@ -138,6 +146,7 @@ export interface MessageDraftOptions {
 export interface AuthLoginOptions {
   token: string;
   workspaceName: string;
+  profile?: string;
 }
 
 export interface AuthLoginBrowserOptions {
@@ -145,6 +154,7 @@ export interface AuthLoginBrowserOptions {
   xoxc: string;
   workspaceUrl: string;
   workspaceName?: string;
+  profile?: string;
 }
 
 // Saved items


### PR DESCRIPTION
## Summary

Implements #89 — lets a single Slack team hold **more than one authentication record**, each addressable by a unique, user-chosen **profile name**. This enables the common automation setup of a browser-authenticated user profile (search/drafts) alongside a bot-token profile (unattended jobs) in the same workspace, instead of the second login silently replacing the first.

Closes #89.

## What changed

- **`--profile <name>`** added to `auth login` and `auth login-browser`.
- Credential records are now keyed by a **profile key** instead of solely by `team_id`.
- **`--workspace` resolution order**: exact profile key → `profile` field → unambiguous `workspace_id` → unambiguous `workspace_name`. Ambiguous selectors raise a clear error (`AmbiguousWorkspaceError`) asking for a profile name instead of guessing.
- `auth list` / `auth set-default` / `auth remove` operate on and display profile keys.
- Added optional `user_id` to stored config so a **token refresh of the same identity** can be told apart from a **new identity**.
- README documents the feature.

## Backward compatibility (hard requirement)

Fully preserved and verified:

- Existing `workspaces.json` files load and resolve unchanged — no migration, no forced rewrite. A first identity is still stored under its `team_id`, and its on-disk shape/`auth list` output is byte-identical to before (`profile` field only written when the key is a named/auto key).
- Single-identity users see zero behavior change.
- Re-authenticating the **same** identity refreshes tokens **in place** (no duplicate).
- A **second, different** identity logged in **without** `--profile` is stored under an auto-generated key (`T123-2`, …) — never silently overwriting the first.
- `login-auto` intentionally keeps `team_id` keying (out of scope per the refined issue; noted as follow-up).

## Testing

- New `src/lib/workspaces.test.ts` covers legacy compat (by id/name, refresh-in-place), two profiles in one team, ambiguous id/name selection, exact-key precedence, suffix-collision increment, token-type distinction, and explicit-profile reuse vs cross-team refusal.
- `bun run type-check` clean; `bun test` → **310 pass / 0 fail**.

## Review

An automated adversarial code review was run against this branch and returned **APPROVE** (no blockers/majors); the one clearly-correct nit — a now-unused accessor — was removed.
