### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-06
+
 ### Added
-- **Automatic browser login** (`auth login-auto`): sign into Slack in a browser and let SlackCLI capture the `xoxd`/`xoxc` tokens — no DevTools, no copy-paste
+- **Automatic browser login** (`auth login-auto`): sign into Slack in a browser and let SlackCLI capture the `xoxd`/`xoxc` tokens — no DevTools, no copy-paste (#91)
   - Enrols every workspace the user is signed into from a single sign-in
   - Drives an already-installed Chrome/Edge/Chromium/Brave over the Chrome DevTools Protocol; **no new runtime dependency** and no change to binary size
   - Uses a dedicated browser profile (required: Chrome 136+ refuses remote debugging against the default profile), so only the first run needs interaction
   - `--workspace-url`, `--timeout`, `--headless`; `SLACKCLI_BROWSER` and `SLACKCLI_BROWSER_PROFILE` env overrides
   - Typed failure reasons (browser not found, launch timeout, capture timeout, browser closed, missing cookie) each with actionable guidance
   - Workspace URLs are gated to `https://` on a `slack.com` host before any session cookie is sent to them
+- **Multiple authentication profiles per workspace**: store and switch between more than one set of credentials for the same workspace (#89, #99)
+- **Edit messages** (`messages edit`): update the text of an existing Slack message you posted (#88)
 
 ### Fixed
 - `login-auto` now asks Chrome to close itself (CDP `Browser.close`) before falling back to signals, then sweeps any helper the browser leaves behind — previously each run stranded ~5 Chrome processes. Order matters: sweeping *instead of* a clean shutdown leaves the profile unopenable.
+- `auth parse-curl` now parses cURL commands that pass the URL via the `--url` flag (#97)
 
 ### Changed
 - `auth logout` now also deletes the `login-auto` browser profile, which is a credential store in its own right — while it exists, `login-auto` re-mints working tokens without prompting. Use `--keep-browser-session` to retain the old behaviour.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slackcli",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "A fast, developer-friendly CLI tool for interacting with Slack workspaces",
   "main": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary
Bumps `package.json` `0.7.1` -> `0.8.0` and prepares the `CHANGELOG` for the **v0.8.0** release. This must land on `main` before the `v0.8.0` tag is pushed, since `release.yml` fails when the tag disagrees with `package.json` version (#82).

## Included since v0.7.1
- `feat(auth)`: multiple authentication profiles per workspace (#89, #99)
- `feat(auth)`: `login-auto` automated browser token capture (#91)
- `feat(messages)`: `edit` command to update existing messages (#88)
- `fix(auth)`: parse cURL commands passing the URL via `--url` (#97)

## Changes in this PR
- `package.json`: version `0.7.1` -> `0.8.0`
- `CHANGELOG.md`: promote `[Unreleased]` into `[0.8.0]` and add the auth-profiles, `messages edit`, and `parse-curl --url` entries

## Checks
- `bun run type-check` — passes
- `bun test` — 313 pass / 0 fail

## Release steps after merge
Push annotated tag `v0.8.0` -> `release.yml` builds binaries, publishes the GitHub release, and updates the Homebrew tap.

Closes #101
