### PR TITLE
feat: accept Slack URLs and permalink-style timestamps everywhere (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Slack URLs accepted wherever an ID is taken**: paste `https://team.slack.com/archives/C123…`, `/team/U123…`, or `/docs/T…/F…` in place of a channel, user, or canvas ID (#107)
+- **Permalink-style timestamps accepted wherever a timestamp is taken**: `p1234567890123456` and `1234567890123456` normalize to `1234567890.123456` (#107)
+- **`--permalink <url>`** on `messages send`, `messages react`, `messages edit`, `messages draft`, `conversations read`, and `conversations get` — supplies channel and timestamp from a single message link, resolving a threaded reply to its parent for `--thread-ts` (#107)
+- Clear errors instead of a misleading `message_not_found`: wrong-type IDs (a user URL passed to `--channel-id`), `--permalink` combined with explicit inputs, and a warning when a pasted link belongs to a different workspace than the authenticated one (browser auth) (#107)
+
 ## [0.8.0] - 2026-08-06
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,7 @@ Two auth types coexist throughout the codebase:
 | `src/lib/formatter.ts` | Chalk-colored terminal output helpers |
 | `src/lib/mrkdwn.ts` | Slack mrkdwn to rich_text block parser for draft messages |
 | `src/lib/curl-parser.ts` | cURL command parsing for token extraction |
+| `src/lib/slack-url-parser.ts` | Slack URL / permalink / timestamp normalization for CLI inputs |
 | `src/lib/clipboard.ts` | Cross-platform clipboard (`pbpaste`/PowerShell/xclip/xsel) |
 | `src/lib/interactive-input.ts` | Multi-line terminal input (double-Enter or Ctrl+D to submit) |
 | `src/lib/saved.ts` | Enriches saved-for-later items (resolves messages & channels) |

--- a/README.md
+++ b/README.md
@@ -244,6 +244,51 @@ Notes:
   workspace ID, or workspace name. If a bare workspace ID/name matches more than
   one profile, SlackCLI asks you to pick a profile instead of guessing.
 
+### Slack Links and Timestamps
+
+Anywhere the CLI takes a channel, user, or canvas ID, you can paste the Slack URL
+instead — the form "Copy link" actually gives you:
+
+```bash
+# These are equivalent
+slackcli conversations read C1234567890
+slackcli conversations read https://myteam.slack.com/archives/C1234567890
+```
+
+| Pasted value | Understood as |
+|---|---|
+| `https://myteam.slack.com/archives/C1234567890` | channel `C1234567890` |
+| `https://myteam.slack.com/archives/D0987654321` | DM `D0987654321` |
+| `https://myteam.slack.com/team/U9876543210` | user `U9876543210` |
+| `https://myteam.slack.com/docs/T012AB/F1234567890` | canvas `F1234567890` |
+
+Timestamps work the same way — the permalink form is accepted wherever the dotted
+API form is:
+
+| Pasted value | Understood as |
+|---|---|
+| `p1234567890123456` | `1234567890.123456` |
+| `1234567890123456` | `1234567890.123456` |
+| `1234567890.123456` | unchanged |
+
+For commands that target one specific message, `--permalink` replaces the channel
+and timestamp in one go:
+
+```bash
+# Instead of this
+slackcli messages react --channel-id=C1234567890 --timestamp=1234567890.123456 --emoji=heart
+
+# Just paste the link
+slackcli messages react --permalink="https://myteam.slack.com/archives/C1234567890/p1234567890123456" --emoji=heart
+```
+
+`--permalink` is available on `messages send`, `messages react`, `messages edit`,
+`messages draft`, `conversations read`, and `conversations get`. Pass either
+`--permalink` or the explicit inputs, not both. When the link points at a threaded
+reply, `--thread-ts` consumers correctly use the *parent* message.
+
+Bare IDs and dotted timestamps keep working exactly as before.
+
 ### Conversation Commands
 
 ```bash
@@ -267,6 +312,12 @@ slackcli conversations read C1234567890 --limit=50
 
 # Get JSON output (includes ts and thread_ts for replies)
 slackcli conversations read C1234567890 --json
+
+# Read the thread a message link points at
+slackcli conversations read --permalink="https://myteam.slack.com/archives/C1234567890/p1234567890123456"
+
+# Get one specific message from its link
+slackcli conversations get --permalink="https://myteam.slack.com/archives/C1234567890/p1234567890123456"
 ```
 
 ### Message Commands
@@ -297,6 +348,13 @@ slackcli messages react --channel-id=C1234567890 --timestamp=1234567890.123456 -
 slackcli messages react --channel-id=C1234567890 --timestamp=1234567890.123456 --emoji=heart
 slackcli messages react --channel-id=C1234567890 --timestamp=1234567890.123456 --emoji=fire
 slackcli messages react --channel-id=C1234567890 --timestamp=1234567890.123456 --emoji=eyes
+
+# Target a message by its permalink instead of channel + timestamp
+slackcli messages react --permalink="https://myteam.slack.com/archives/C1234567890/p1234567890123456" --emoji=+1
+slackcli messages edit --permalink="https://myteam.slack.com/archives/C1234567890/p1234567890123456" --message="Corrected message"
+
+# Reply in the thread a link points at
+slackcli messages send --permalink="https://myteam.slack.com/archives/C1234567890/p1234567890123456" --message="Great idea!"
 ```
 
 File uploads require Slack workspace permissions that allow file upload, such as `files:write` for standard Slack app tokens.
@@ -330,6 +388,9 @@ slackcli canvas read F1234567890 --raw
 
 # Read the canvas associated with a channel
 slackcli canvas read --channel=C1234567890
+
+# Read a canvas from its Slack URL
+slackcli canvas read https://myteam.slack.com/docs/T012AB/F1234567890
 ```
 
 ### Update Commands

--- a/src/commands/canvas.ts
+++ b/src/commands/canvas.ts
@@ -1,12 +1,21 @@
 import { Command } from 'commander';
 import ora from 'ora';
 import { getAuthenticatedClient } from '../lib/auth.ts';
-import { error, formatCanvasList, formatCanvasContent, writeJson } from '../lib/formatter.ts';
+import { error, formatCanvasList, formatCanvasContent, warning, writeJson } from '../lib/formatter.ts';
 import { canvasHtmlToMarkdown, isAuthPage } from '../lib/canvas-parser.ts';
+import { normalizeIdentifier, workspaceMismatchWarning, workspaceOf } from '../lib/slack-url-parser.ts';
+import type { SlackClient } from '../lib/slack-client.ts';
 import type { SlackCanvas, SlackUser } from '../types/index.ts';
 
 const CANVAS_ID_PATTERN = /^F[A-Z0-9]+$/i;
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+
+// Warn when a pasted link points at a different workspace than the one we will call,
+// rather than letting Slack answer with a misleading not-found error.
+function warnOnWorkspaceMismatch(client: SlackClient, linkWorkspace: string | undefined): void {
+  const message = workspaceMismatchWarning(linkWorkspace, client.workspaceHost);
+  if (message) warning(message);
+}
 
 export function createCanvasCommand(): Command {
   const canvas = new Command('canvas')
@@ -17,7 +26,7 @@ export function createCanvasCommand(): Command {
     .command('list')
     .description('List canvas documents in the workspace')
     .option('--limit <number>', 'Number of canvases to return', '20')
-    .option('--channel <id>', 'List canvases shared in a specific channel')
+    .option('--channel <id>', 'Channel ID or URL whose shared canvases to list')
     .option('--workspace <id|name>', 'Workspace to use')
     .option('--json', 'Output in JSON format', false)
     .action(async (options) => {
@@ -31,11 +40,16 @@ export function createCanvasCommand(): Command {
           process.exit(1);
         }
 
+        const channel = options.channel
+          ? normalizeIdentifier(options.channel, 'channel', '--channel')
+          : undefined;
+
         const client = await getAuthenticatedClient(options.workspace);
+        warnOnWorkspaceMismatch(client, workspaceOf(options.channel));
 
         const response = await client.listCanvases({
           limit,
-          channel: options.channel,
+          channel,
         });
 
         const files: SlackCanvas[] = response.files || [];
@@ -76,23 +90,31 @@ export function createCanvasCommand(): Command {
   canvas
     .command('read')
     .description('Read canvas content as markdown')
-    .argument('[canvas-id]', 'Canvas file ID (e.g., F1234567890)')
-    .option('--channel <id>', 'Read the canvas associated with a channel')
+    .argument('[canvas-id]', 'Canvas file ID or URL (e.g., F1234567890)')
+    .option('--channel <id>', 'Channel ID or URL whose canvas to read')
     .option('--raw', 'Output raw HTML instead of markdown', false)
     .option('--workspace <id|name>', 'Workspace to use')
     .option('--json', 'Output in JSON format', false)
-    .action(async (canvasId, options) => {
+    .action(async (canvasIdArg, options) => {
       const spinner = ora('Fetching canvas...').start();
 
       try {
+        const canvasId = canvasIdArg
+          ? normalizeIdentifier(canvasIdArg, 'file', '<canvas-id>')
+          : undefined;
+        const channel = options.channel
+          ? normalizeIdentifier(options.channel, 'channel', '--channel')
+          : undefined;
+
         const client = await getAuthenticatedClient(options.workspace);
+        warnOnWorkspaceMismatch(client, workspaceOf(canvasIdArg) ?? workspaceOf(options.channel));
 
         // Resolve canvas ID
-        let fileId = canvasId;
+        let fileId: string | null | undefined = canvasId;
 
-        if (!fileId && options.channel) {
+        if (!fileId && channel) {
           spinner.text = 'Looking up channel canvas...';
-          fileId = await client.getChannelCanvasId(options.channel);
+          fileId = await client.getChannelCanvasId(channel);
           if (!fileId) {
             spinner.fail('No canvas found for this channel');
             return;

--- a/src/commands/conversations.test.ts
+++ b/src/commands/conversations.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test';
+import { createConversationsCommand } from './conversations.ts';
+
+function subcommand(name: string) {
+  return createConversationsCommand().commands.find((command) => command.name() === name);
+}
+
+function longOptions(name: string): string[] {
+  return (subcommand(name)?.options ?? []).map((option) => option.long ?? '');
+}
+
+function argumentNames(name: string): Array<{ name: string; required: boolean }> {
+  return (subcommand(name)?.registeredArguments ?? []).map((argument) => ({
+    name: argument.name(),
+    required: argument.required,
+  }));
+}
+
+describe('conversations command', () => {
+  // The positionals became optional so --permalink can supply them; the requirement
+  // is enforced in resolveMessageTarget / resolveThreadTarget instead, which is what
+  // produces the "Missing <channel-id>" error when neither form is given.
+  it('makes read take an optional channel positional plus --permalink', () => {
+    expect(argumentNames('read')).toEqual([{ name: 'channel-id', required: false }]);
+    expect(longOptions('read')).toContain('--permalink');
+  });
+
+  it('makes get take optional channel and timestamp positionals plus --permalink', () => {
+    expect(argumentNames('get')).toEqual([
+      { name: 'channel-id', required: false },
+      { name: 'timestamp', required: false },
+    ]);
+    expect(longOptions('get')).toContain('--permalink');
+  });
+
+  it('keeps the range-bound options on read', () => {
+    expect(longOptions('read')).toContain('--oldest');
+    expect(longOptions('read')).toContain('--latest');
+    expect(longOptions('read')).toContain('--thread-ts');
+  });
+});

--- a/src/commands/conversations.ts
+++ b/src/commands/conversations.ts
@@ -2,10 +2,24 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 import ora from 'ora';
 import { getAuthenticatedClient } from '../lib/auth.ts';
-import { error, formatChannelList, formatConversationHistory, formatUnreadChannels, writeJson } from '../lib/formatter.ts';
+import { error, formatChannelList, formatConversationHistory, formatUnreadChannels, warning, writeJson } from '../lib/formatter.ts';
 import { fetchMessage } from '../lib/message.ts';
 import { fetchUnreadChannels } from '../lib/unread.ts';
+import {
+  normalizeTimestamp,
+  resolveMessageTarget,
+  resolveThreadTarget,
+  workspaceMismatchWarning,
+} from '../lib/slack-url-parser.ts';
+import type { SlackClient } from '../lib/slack-client.ts';
 import type { SlackChannel, SlackMessage, SlackUser } from '../types/index.ts';
+
+// Warn when a pasted link points at a different workspace than the one we will call,
+// rather than letting Slack answer with a misleading message_not_found.
+function warnOnWorkspaceMismatch(client: SlackClient, linkWorkspace: string | undefined): void {
+  const message = workspaceMismatchWarning(linkWorkspace, client.workspaceHost);
+  if (message) warning(message);
+}
 
 export function createConversationsCommand(): Command {
   const conversations = new Command('conversations')
@@ -72,30 +86,40 @@ export function createConversationsCommand(): Command {
   conversations
     .command('read')
     .description('Read conversation history or specific thread')
-    .argument('<channel-id>', 'Channel ID to read from')
+    .argument('[channel-id]', 'Channel ID or Slack URL to read from')
     .option('--thread-ts <timestamp>', 'Thread timestamp to read specific thread')
+    .option('--permalink <url>', 'Slack link; reads that channel, or that message\'s thread (replaces <channel-id> and --thread-ts)')
     .option('--exclude-replies', 'Exclude threaded replies (only top-level messages)', false)
     .option('--limit <number>', 'Number of messages to return', '100')
     .option('--oldest <timestamp>', 'Start of time range')
     .option('--latest <timestamp>', 'End of time range')
     .option('--workspace <id|name>', 'Workspace to use')
     .option('--json', 'Output in JSON format (includes timestamps for replies)', false)
-    .action(async (channelId, options) => {
+    .action(async (channelIdArg, options) => {
       const spinner = ora('Fetching messages...').start();
 
       try {
+        const target = resolveThreadTarget(
+          { permalink: options.permalink, channelId: channelIdArg, threadTs: options.threadTs },
+          { channel: '<channel-id>', timestamp: '--thread-ts' }
+        );
+        const channelId = target.channelId;
+        const oldest = options.oldest ? normalizeTimestamp(options.oldest, '--oldest') : undefined;
+        const latest = options.latest ? normalizeTimestamp(options.latest, '--latest') : undefined;
+
         const client = await getAuthenticatedClient(options.workspace);
+        warnOnWorkspaceMismatch(client, target.workspace);
 
         let response: any;
         let messages: SlackMessage[];
 
-        if (options.threadTs) {
+        if (target.threadTs) {
           // Fetch thread replies
           spinner.text = 'Fetching thread replies...';
-          response = await client.getConversationReplies(channelId, options.threadTs, {
+          response = await client.getConversationReplies(channelId, target.threadTs, {
             limit: parseInt(options.limit),
-            oldest: options.oldest,
-            latest: options.latest,
+            oldest,
+            latest,
           });
           messages = response.messages || [];
         } else {
@@ -103,8 +127,8 @@ export function createConversationsCommand(): Command {
           spinner.text = 'Fetching conversation history...';
           response = await client.getConversationHistory(channelId, {
             limit: parseInt(options.limit),
-            oldest: options.oldest,
-            latest: options.latest,
+            oldest,
+            latest,
           });
           messages = response.messages || [];
 
@@ -116,7 +140,7 @@ export function createConversationsCommand(): Command {
 
         // Channel history returns newest first, so reverse to show oldest first.
         // Thread replies already come in chronological order.
-        if (!options.threadTs) {
+        if (!target.threadTs) {
           messages.reverse();
         }
 
@@ -188,17 +212,25 @@ export function createConversationsCommand(): Command {
   conversations
     .command('get')
     .description('Get a specific message by channel ID and timestamp')
-    .argument('<channel-id>', 'Channel ID')
-    .argument('<timestamp>', 'Message timestamp')
+    .argument('[channel-id]', 'Channel ID or Slack URL')
+    .argument('[timestamp]', 'Message timestamp (1234567890.123456 or p1234567890123456)')
+    .option('--permalink <url>', 'Slack message link (replaces <channel-id> and <timestamp>)')
     .option('--workspace <id|name>', 'Workspace to use')
     .option('--json', 'Output in JSON format', false)
-    .action(async (channelId, timestamp, options) => {
+    .action(async (channelIdArg, timestampArg, options) => {
       const spinner = ora('Fetching message...').start();
 
       try {
-        const client = await getAuthenticatedClient(options.workspace);
+        const target = resolveMessageTarget(
+          { permalink: options.permalink, channelId: channelIdArg, timestamp: timestampArg },
+          { channel: '<channel-id>', timestamp: '<timestamp>' }
+        );
+        const channelId = target.channelId;
 
-        const msg = await fetchMessage(client, channelId, timestamp);
+        const client = await getAuthenticatedClient(options.workspace);
+        warnOnWorkspaceMismatch(client, target.workspace);
+
+        const msg = await fetchMessage(client, channelId, target.timestamp);
 
         if (!msg) {
           spinner.fail('Message not found');

--- a/src/commands/messages.test.ts
+++ b/src/commands/messages.test.ts
@@ -1,23 +1,52 @@
 import { describe, expect, it } from 'bun:test';
 import { createMessagesCommand } from './messages.ts';
 
+function subcommand(name: string) {
+  return createMessagesCommand().commands.find((command) => command.name() === name);
+}
+
+function longOptions(name: string): string[] {
+  return (subcommand(name)?.options ?? []).map((option) => option.long ?? '');
+}
+
+function mandatoryOptions(name: string): string[] {
+  return (subcommand(name)?.options ?? [])
+    .filter((option) => option.mandatory)
+    .map((option) => option.long ?? '')
+    .sort();
+}
+
 describe('messages command', () => {
   it('exposes a file option on messages send', () => {
-    const messages = createMessagesCommand();
-    const send = messages.commands.find((command) => command.name() === 'send');
-
-    expect(send?.options.some((option) => option.long === '--file')).toBe(true);
+    expect(longOptions('send')).toContain('--file');
   });
 
-  it('exposes an edit subcommand requiring channel, timestamp, and message', () => {
-    const messages = createMessagesCommand();
-    const edit = messages.commands.find((command) => command.name() === 'edit');
+  it('exposes an edit subcommand taking channel, timestamp, and message', () => {
+    expect(subcommand('edit')).toBeDefined();
+    expect(longOptions('edit')).toContain('--channel-id');
+    expect(longOptions('edit')).toContain('--timestamp');
+    expect(longOptions('edit')).toContain('--message');
+  });
 
-    expect(edit).toBeDefined();
-    const required = edit?.options
-      .filter((option) => option.mandatory)
-      .map((option) => option.long)
-      .sort();
-    expect(required).toEqual(['--channel-id', '--message', '--timestamp']);
+  // --channel-id / --timestamp are no longer Commander-mandatory because --permalink
+  // can supply both; the requirement is enforced in resolveMessageTarget instead
+  // (see slack-url-parser.test.ts), which is what lets either form be used.
+  it('leaves only --message mandatory on edit so --permalink can replace the rest', () => {
+    expect(mandatoryOptions('edit')).toEqual(['--message']);
+  });
+
+  it('leaves only --emoji mandatory on react so --permalink can replace the rest', () => {
+    expect(mandatoryOptions('react')).toEqual(['--emoji']);
+  });
+
+  it('keeps --message mandatory on send and draft', () => {
+    expect(mandatoryOptions('send')).toEqual(['--message']);
+    expect(mandatoryOptions('draft')).toEqual(['--message']);
+  });
+
+  it('offers --permalink on every message-targeting subcommand', () => {
+    for (const name of ['send', 'react', 'edit', 'draft']) {
+      expect(longOptions(name)).toContain('--permalink');
+    }
   });
 });

--- a/src/commands/messages.ts
+++ b/src/commands/messages.ts
@@ -1,7 +1,20 @@
 import { Command } from 'commander';
 import ora from 'ora';
 import { getAuthenticatedClient } from '../lib/auth.ts';
-import { success, error } from '../lib/formatter.ts';
+import { success, error, warning } from '../lib/formatter.ts';
+import {
+  resolveMessageTarget,
+  resolveThreadTarget,
+  workspaceMismatchWarning,
+} from '../lib/slack-url-parser.ts';
+import type { SlackClient } from '../lib/slack-client.ts';
+
+// Warn when a pasted link points at a different workspace than the one we will call,
+// rather than letting Slack answer with a misleading message_not_found.
+function warnOnWorkspaceMismatch(client: SlackClient, linkWorkspace: string | undefined): void {
+  const message = workspaceMismatchWarning(linkWorkspace, client.workspaceHost);
+  if (message) warning(message);
+}
 
 export function createMessagesCommand(): Command {
   const messages = new Command('messages')
@@ -11,22 +24,30 @@ export function createMessagesCommand(): Command {
   messages
     .command('send')
     .description('Send a message to a channel or user')
-    .requiredOption('--recipient-id <id>', 'Channel ID or User ID')
+    .option('--recipient-id <id>', 'Channel ID, User ID, or Slack URL')
     .requiredOption('--message <text>', 'Message text content')
     .option('--thread-ts <timestamp>', 'Send as reply to thread')
+    .option('--permalink <url>', 'Slack message link; replies in that message\'s thread (replaces --recipient-id and --thread-ts)')
     .option('--file <path>', 'Attach a file to the message')
     .option('--workspace <id|name>', 'Workspace to use')
     .action(async (options) => {
       const spinner = ora('Sending message...').start();
 
       try {
+        const target = resolveThreadTarget(
+          { permalink: options.permalink, channelId: options.recipientId, threadTs: options.threadTs },
+          { channel: '--recipient-id', timestamp: '--thread-ts' },
+          'channel-or-user'
+        );
+
         const client = await getAuthenticatedClient(options.workspace);
+        warnOnWorkspaceMismatch(client, target.workspace);
 
         // Check if recipient is a user ID (starts with U) and needs DM opened
-        let channelId = options.recipientId;
-        if (options.recipientId.startsWith('U')) {
+        let channelId = target.channelId;
+        if (channelId.startsWith('U')) {
           spinner.text = 'Opening direct message...';
-          const dmResponse = await client.openConversation(options.recipientId);
+          const dmResponse = await client.openConversation(channelId);
           channelId = dmResponse.channel.id;
         }
 
@@ -34,7 +55,7 @@ export function createMessagesCommand(): Command {
         if (options.file) {
           await client.uploadFileExternal(channelId, options.file, {
             initial_comment: options.message,
-            thread_ts: options.threadTs,
+            thread_ts: target.threadTs,
           });
 
           spinner.succeed('Message sent successfully!');
@@ -43,7 +64,7 @@ export function createMessagesCommand(): Command {
         }
 
         const response = await client.postMessage(channelId, options.message, {
-          thread_ts: options.threadTs,
+          thread_ts: target.threadTs,
         });
 
         spinner.succeed('Message sent successfully!');
@@ -59,20 +80,27 @@ export function createMessagesCommand(): Command {
   messages
     .command('react')
     .description('Add a reaction to a message')
-    .requiredOption('--channel-id <id>', 'Channel ID where the message is')
-    .requiredOption('--timestamp <ts>', 'Message timestamp')
+    .option('--channel-id <id>', 'Channel ID or URL where the message is')
+    .option('--timestamp <ts>', 'Message timestamp (1234567890.123456 or p1234567890123456)')
+    .option('--permalink <url>', 'Slack message link (replaces --channel-id and --timestamp)')
     .requiredOption('--emoji <name>', 'Emoji name (e.g., thumbsup, heart, fire)')
     .option('--workspace <id|name>', 'Workspace to use')
     .action(async (options) => {
       const spinner = ora('Adding reaction...').start();
 
       try {
-        const client = await getAuthenticatedClient(options.workspace);
+        const target = resolveMessageTarget(
+          { permalink: options.permalink, channelId: options.channelId, timestamp: options.timestamp },
+          { channel: '--channel-id', timestamp: '--timestamp' }
+        );
 
-        await client.addReaction(options.channelId, options.timestamp, options.emoji);
+        const client = await getAuthenticatedClient(options.workspace);
+        warnOnWorkspaceMismatch(client, target.workspace);
+
+        await client.addReaction(target.channelId, target.timestamp, options.emoji);
 
         spinner.succeed('Reaction added successfully!');
-        success(`Added :${options.emoji}: to message ${options.timestamp}`);
+        success(`Added :${options.emoji}: to message ${target.timestamp}`);
       } catch (err: any) {
         spinner.fail('Failed to add reaction');
         error(err.message);
@@ -84,19 +112,26 @@ export function createMessagesCommand(): Command {
   messages
     .command('edit')
     .description('Update the text of an existing message you posted')
-    .requiredOption('--channel-id <id>', 'Channel ID where the message is')
-    .requiredOption('--timestamp <ts>', 'Message timestamp')
+    .option('--channel-id <id>', 'Channel ID or URL where the message is')
+    .option('--timestamp <ts>', 'Message timestamp (1234567890.123456 or p1234567890123456)')
+    .option('--permalink <url>', 'Slack message link (replaces --channel-id and --timestamp)')
     .requiredOption('--message <text>', 'New message text content')
     .option('--workspace <id|name>', 'Workspace to use')
     .action(async (options) => {
       const spinner = ora('Updating message...').start();
 
       try {
+        const target = resolveMessageTarget(
+          { permalink: options.permalink, channelId: options.channelId, timestamp: options.timestamp },
+          { channel: '--channel-id', timestamp: '--timestamp' }
+        );
+
         const client = await getAuthenticatedClient(options.workspace);
+        warnOnWorkspaceMismatch(client, target.workspace);
 
         const response = await client.updateMessage(
-          options.channelId,
-          options.timestamp,
+          target.channelId,
+          target.timestamp,
           options.message,
         );
 
@@ -113,26 +148,34 @@ export function createMessagesCommand(): Command {
   messages
     .command('draft')
     .description('Create a draft message in a channel or user. Note: Only works with Browser Session Tokens. Slack apps cannot create drafts.')
-    .requiredOption('--recipient-id <id>', 'Channel ID or User ID')
+    .option('--recipient-id <id>', 'Channel ID, User ID, or Slack URL')
     .requiredOption('--message <text>', 'Message text content')
     .option('--thread-ts <timestamp>', 'Create draft as reply to thread')
+    .option('--permalink <url>', 'Slack message link; drafts a reply in that message\'s thread (replaces --recipient-id and --thread-ts)')
     .option('--workspace <id|name>', 'Workspace to use')
     .action(async (options) => {
       const spinner = ora('Creating draft...').start();
 
       try {
-        const client = await getAuthenticatedClient(options.workspace);
+        const target = resolveThreadTarget(
+          { permalink: options.permalink, channelId: options.recipientId, threadTs: options.threadTs },
+          { channel: '--recipient-id', timestamp: '--thread-ts' },
+          'channel-or-user'
+        );
 
-        let channelId = options.recipientId;
-        if (options.recipientId.startsWith('U')) {
+        const client = await getAuthenticatedClient(options.workspace);
+        warnOnWorkspaceMismatch(client, target.workspace);
+
+        let channelId = target.channelId;
+        if (channelId.startsWith('U')) {
           spinner.text = 'Opening direct message...';
-          const dmResponse = await client.openConversation(options.recipientId);
+          const dmResponse = await client.openConversation(channelId);
           channelId = dmResponse.channel.id;
         }
 
         spinner.text = 'Creating draft...';
         const response = await client.createDraft(channelId, options.message, {
-          thread_ts: options.threadTs,
+          thread_ts: target.threadTs,
         });
 
         spinner.succeed('Draft created successfully!');

--- a/src/lib/slack-client.ts
+++ b/src/lib/slack-client.ts
@@ -3,6 +3,7 @@ import { basename } from 'node:path';
 import { readFile, stat } from 'node:fs/promises';
 import type { WorkspaceConfig, SlackAuthTestResponse } from '../types/index.ts';
 import { parseMrkdwn } from './mrkdwn.ts';
+import { extractSlackWorkspaceName } from './curl-parser.ts';
 
 interface ExternalUploadUrlResponse {
   upload_url?: string;
@@ -464,5 +465,13 @@ export class SlackClient {
   // Check auth type
   get authType(): string {
     return this.config.auth_type;
+  }
+
+  // Workspace subdomain, used to spot links pasted from a different workspace.
+  // Only browser auth stores a workspace URL; standard auth has no reliable
+  // subdomain (its workspace_name is chosen by the user at login).
+  get workspaceHost(): string | undefined {
+    if (this.config.auth_type !== 'browser') return undefined;
+    return extractSlackWorkspaceName(this.config.workspace_url);
   }
 }

--- a/src/lib/slack-url-parser.test.ts
+++ b/src/lib/slack-url-parser.test.ts
@@ -1,0 +1,452 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  identifierKind,
+  isSlackUrl,
+  normalizeIdentifier,
+  normalizeTimestamp,
+  parsePermalink,
+  parseSlackLink,
+  resolveMessageTarget,
+  resolveThreadTarget,
+  SlackUrlParseError,
+  threadParentOf,
+  workspaceMismatchWarning,
+  workspaceOf,
+} from './slack-url-parser';
+
+const CHANNEL = 'C0BHFPKJMC2';
+const TEAM_URL = 'https://myteam.slack.com';
+const ENTERPRISE_URL = 'https://myorg.enterprise.slack.com';
+
+describe('isSlackUrl', () => {
+  it('recognises standard and enterprise Slack hosts', () => {
+    expect(isSlackUrl(`${TEAM_URL}/archives/${CHANNEL}`)).toBe(true);
+    expect(isSlackUrl(`${ENTERPRISE_URL}/archives/${CHANNEL}`)).toBe(true);
+    expect(isSlackUrl('http://myteam.slack.com/team/U012ABCDEFG')).toBe(true);
+  });
+
+  it('rejects bare IDs and non-Slack URLs', () => {
+    expect(isSlackUrl(CHANNEL)).toBe(false);
+    expect(isSlackUrl('https://example.com/archives/C0BHFPKJMC2')).toBe(false);
+    expect(isSlackUrl('https://notslack.com')).toBe(false);
+  });
+
+  it('sees through angle brackets and whitespace as pasted out of Slack', () => {
+    expect(isSlackUrl(`  <${TEAM_URL}/archives/${CHANNEL}>  `)).toBe(true);
+  });
+});
+
+describe('identifierKind', () => {
+  it('classifies Slack ID prefixes', () => {
+    expect(identifierKind('C0BHFPKJMC2')).toBe('channel');
+    expect(identifierKind('D048XXXXXXX')).toBe('channel');
+    expect(identifierKind('G012ABCDEFG')).toBe('channel');
+    expect(identifierKind('U012ABCDEFG')).toBe('user');
+    expect(identifierKind('W012ABCDEFG')).toBe('user');
+    expect(identifierKind('F0123ABCDEF')).toBe('file');
+    expect(identifierKind('T012ABCDEFG')).toBe('team');
+  });
+
+  it('returns unknown for anything that does not look like a Slack ID', () => {
+    expect(identifierKind('general')).toBe('unknown');
+    expect(identifierKind('C123')).toBe('unknown'); // too short
+    expect(identifierKind('c0bhfpkjmc2')).toBe('unknown'); // lowercase
+    expect(identifierKind('')).toBe('unknown');
+  });
+});
+
+describe('normalizeIdentifier', () => {
+  describe('bare IDs pass through unchanged (backward compatibility)', () => {
+    it('keeps a channel ID byte-for-byte', () => {
+      expect(normalizeIdentifier(CHANNEL, 'channel', '--channel-id')).toBe(CHANNEL);
+    });
+
+    it('keeps a user ID byte-for-byte', () => {
+      expect(normalizeIdentifier('U012ABCDEFG', 'user', '--recipient-id')).toBe('U012ABCDEFG');
+    });
+
+    it('passes through values it cannot classify rather than rejecting them', () => {
+      expect(normalizeIdentifier('general', 'channel', '--channel-id')).toBe('general');
+      expect(normalizeIdentifier('c0bhfpkjmc2', 'channel', '--channel-id')).toBe('c0bhfpkjmc2');
+    });
+  });
+
+  describe('URL forms', () => {
+    it('extracts a channel ID from an archives URL', () => {
+      expect(normalizeIdentifier(`${TEAM_URL}/archives/${CHANNEL}`, 'channel', '--channel-id')).toBe(CHANNEL);
+    });
+
+    it('extracts a channel ID from a full message permalink', () => {
+      expect(
+        normalizeIdentifier(`${TEAM_URL}/archives/${CHANNEL}/p1786816800107789`, 'channel', '--channel-id')
+      ).toBe(CHANNEL);
+    });
+
+    it('extracts a DM conversation ID', () => {
+      expect(normalizeIdentifier(`${TEAM_URL}/archives/D048XXXXXXX`, 'channel', '--recipient-id')).toBe('D048XXXXXXX');
+    });
+
+    it('extracts a private group ID', () => {
+      expect(normalizeIdentifier(`${TEAM_URL}/archives/G012ABCDEFG`, 'channel', '--channel-id')).toBe('G012ABCDEFG');
+    });
+
+    it('extracts a user ID from a profile URL', () => {
+      expect(normalizeIdentifier(`${TEAM_URL}/team/U012ABCDEFG`, 'user', '--recipient-id')).toBe('U012ABCDEFG');
+    });
+
+    it('extracts a canvas file ID from a docs URL', () => {
+      expect(normalizeIdentifier(`${TEAM_URL}/docs/T012AB/F0123ABCD`, 'file', '<canvas-id>')).toBe('F0123ABCD');
+    });
+
+    it('handles enterprise grid hosts', () => {
+      expect(normalizeIdentifier(`${ENTERPRISE_URL}/archives/${CHANNEL}`, 'channel', '--channel-id')).toBe(CHANNEL);
+    });
+
+    it('ignores trailing query junk', () => {
+      expect(
+        normalizeIdentifier(`${TEAM_URL}/archives/${CHANNEL}?cid=${CHANNEL}&web=1`, 'channel', '--channel-id')
+      ).toBe(CHANNEL);
+    });
+
+    it('strips angle brackets and surrounding whitespace', () => {
+      expect(normalizeIdentifier(`  <${TEAM_URL}/archives/${CHANNEL}>  `, 'channel', '--channel-id')).toBe(CHANNEL);
+    });
+  });
+
+  describe('type validation against the call site', () => {
+    it('rejects a user URL where a channel is expected', () => {
+      expect(() => normalizeIdentifier(`${TEAM_URL}/team/U012ABCDEFG`, 'channel', '--channel-id')).toThrow(
+        /expects a channel ID, but got a user ID/
+      );
+    });
+
+    it('rejects a bare user ID where a channel is expected', () => {
+      expect(() => normalizeIdentifier('U012ABCDEFG', 'channel', '--channel-id')).toThrow(SlackUrlParseError);
+    });
+
+    it('accepts either a channel or a user for channel-or-user call sites', () => {
+      expect(normalizeIdentifier(CHANNEL, 'channel-or-user', '--recipient-id')).toBe(CHANNEL);
+      expect(normalizeIdentifier('U012ABCDEFG', 'channel-or-user', '--recipient-id')).toBe('U012ABCDEFG');
+      expect(() => normalizeIdentifier('F0123ABCDEF', 'channel-or-user', '--recipient-id')).toThrow(
+        /expects a channel or user ID/
+      );
+    });
+
+    it('rejects a channel URL where a canvas file is expected', () => {
+      expect(() => normalizeIdentifier(`${TEAM_URL}/archives/${CHANNEL}`, 'file', '<canvas-id>')).toThrow(
+        /expects a file ID, but got a channel ID/
+      );
+    });
+  });
+
+  describe('malformed input', () => {
+    it('rejects an empty value', () => {
+      expect(() => normalizeIdentifier('   ', 'channel', '--channel-id')).toThrow(/requires a value/);
+    });
+
+    it('rejects a Slack URL with no recognised path', () => {
+      expect(() => normalizeIdentifier(`${TEAM_URL}/customize/emoji`, 'channel', '--channel-id')).toThrow(
+        /could not read an ID out of this Slack URL/
+      );
+    });
+
+    it('rejects a Slack URL with no path at all', () => {
+      expect(() => normalizeIdentifier(TEAM_URL, 'channel', '--channel-id')).toThrow(SlackUrlParseError);
+    });
+
+    it('treats a non-Slack host as a bare identifier rather than a URL', () => {
+      expect(normalizeIdentifier('https://example.com/archives/C0BHFPKJMC2', 'channel', '--channel-id')).toBe(
+        'https://example.com/archives/C0BHFPKJMC2'
+      );
+    });
+  });
+});
+
+describe('normalizeTimestamp', () => {
+  it('converts the permalink form', () => {
+    expect(normalizeTimestamp('p1786816800107789', '--timestamp')).toBe('1786816800.107789');
+  });
+
+  it('converts a bare 16-digit timestamp', () => {
+    expect(normalizeTimestamp('1786816800107789', '--timestamp')).toBe('1786816800.107789');
+  });
+
+  it('leaves an already-dotted API timestamp unchanged', () => {
+    expect(normalizeTimestamp('1786816800.107789', '--timestamp')).toBe('1786816800.107789');
+  });
+
+  it('leaves plain epoch seconds unchanged for range bounds', () => {
+    // --oldest / --latest legitimately take whole seconds; normalizing them would
+    // silently move the range by ~six orders of magnitude.
+    expect(normalizeTimestamp('1786816800', '--oldest')).toBe('1786816800');
+  });
+
+  it('strips angle brackets and whitespace', () => {
+    expect(normalizeTimestamp('  p1786816800107789  ', '--timestamp')).toBe('1786816800.107789');
+  });
+
+  it('rejects an empty value', () => {
+    expect(() => normalizeTimestamp('  ', '--timestamp')).toThrow(/requires a value/);
+  });
+
+  it('points at --permalink when handed a URL', () => {
+    expect(() => normalizeTimestamp(`${TEAM_URL}/archives/${CHANNEL}/p1786816800107789`, '--timestamp')).toThrow(
+      /Use --permalink/
+    );
+  });
+
+  it('rejects a p-prefixed timestamp of the wrong length', () => {
+    expect(() => normalizeTimestamp('p17868168001077', '--timestamp')).toThrow(/expected 16/);
+  });
+
+  it('rejects non-numeric input', () => {
+    expect(() => normalizeTimestamp('not-a-timestamp', '--timestamp')).toThrow(/not a valid Slack timestamp/);
+  });
+});
+
+describe('parseSlackLink', () => {
+  it('parses a standard message permalink', () => {
+    const parsed = parseSlackLink(`${TEAM_URL}/archives/${CHANNEL}/p1786816800107789`);
+    expect(parsed.channelId).toBe(CHANNEL);
+    expect(parsed.timestamp).toBe('1786816800.107789');
+    expect(parsed.threadTs).toBeUndefined();
+    expect(parsed.workspace).toBe('myteam');
+  });
+
+  it('parses a bare channel link with no message', () => {
+    const parsed = parseSlackLink(`${TEAM_URL}/archives/${CHANNEL}`);
+    expect(parsed.channelId).toBe(CHANNEL);
+    expect(parsed.timestamp).toBeUndefined();
+  });
+
+  it('parses a DM link', () => {
+    const parsed = parseSlackLink(`${TEAM_URL}/archives/D048XXXXXXX/p1786816800107789`);
+    expect(parsed.channelId).toBe('D048XXXXXXX');
+  });
+
+  it('parses an enterprise host and reports the org subdomain', () => {
+    const parsed = parseSlackLink(`${ENTERPRISE_URL}/archives/${CHANNEL}/p1786816800107789`);
+    expect(parsed.channelId).toBe(CHANNEL);
+    expect(parsed.workspace).toBe('myorg');
+  });
+
+  it('ignores extra query parameters', () => {
+    const parsed = parseSlackLink(`${TEAM_URL}/archives/${CHANNEL}/p1786816800107789?cid=${CHANNEL}&web=1`);
+    expect(parsed.timestamp).toBe('1786816800.107789');
+    expect(parsed.threadTs).toBeUndefined();
+  });
+
+  it('strips angle brackets', () => {
+    const parsed = parseSlackLink(`<${TEAM_URL}/archives/${CHANNEL}/p1786816800107789>`);
+    expect(parsed.timestamp).toBe('1786816800.107789');
+  });
+
+  describe('threaded replies', () => {
+    // The path holds the REPLY timestamp; ?thread_ts= holds the PARENT. Confusing the
+    // two silently targets the wrong message.
+    const REPLY_LINK = `${TEAM_URL}/archives/${CHANNEL}/p1786816999222333?thread_ts=1786816800.107789&cid=${CHANNEL}`;
+
+    it('keeps the reply timestamp as the message timestamp', () => {
+      expect(parseSlackLink(REPLY_LINK).timestamp).toBe('1786816999.222333');
+    });
+
+    it('reads the parent timestamp out of thread_ts', () => {
+      expect(parseSlackLink(REPLY_LINK).threadTs).toBe('1786816800.107789');
+    });
+
+    it('resolves the thread parent to thread_ts for a reply', () => {
+      expect(threadParentOf(parseSlackLink(REPLY_LINK))).toBe('1786816800.107789');
+    });
+
+    it('resolves the thread parent to the message itself for a top-level message', () => {
+      expect(threadParentOf(parseSlackLink(`${TEAM_URL}/archives/${CHANNEL}/p1786816800107789`))).toBe(
+        '1786816800.107789'
+      );
+    });
+
+    it('normalizes a permalink-form thread_ts too', () => {
+      const parsed = parseSlackLink(
+        `${TEAM_URL}/archives/${CHANNEL}/p1786816999222333?thread_ts=1786816800107789`
+      );
+      expect(parsed.threadTs).toBe('1786816800.107789');
+    });
+  });
+
+  describe('malformed input', () => {
+    it('rejects a non-Slack URL', () => {
+      expect(() => parseSlackLink('https://example.com/archives/C0BHFPKJMC2')).toThrow(/Not a Slack URL/);
+    });
+
+    it('rejects a Slack URL without an /archives/ segment', () => {
+      expect(() => parseSlackLink(`${TEAM_URL}/team/U012ABCDEFG`)).toThrow(/Not a Slack message link/);
+    });
+
+    it('rejects a user ID in the channel position', () => {
+      expect(() => parseSlackLink(`${TEAM_URL}/archives/U012ABCDEFG/p1786816800107789`)).toThrow(
+        /names a user ID .* where a channel was expected/
+      );
+    });
+
+    it('rejects a non-numeric message segment', () => {
+      expect(() => parseSlackLink(`${TEAM_URL}/archives/${CHANNEL}/notamessage`)).toThrow(
+        /unexpected message segment/
+      );
+    });
+  });
+});
+
+describe('parsePermalink', () => {
+  it('returns a guaranteed timestamp for a message link', () => {
+    expect(parsePermalink(`${TEAM_URL}/archives/${CHANNEL}/p1786816800107789`).timestamp).toBe('1786816800.107789');
+  });
+
+  it('rejects a link that names only a channel', () => {
+    expect(() => parsePermalink(`${TEAM_URL}/archives/${CHANNEL}`)).toThrow(/does not point at a message/);
+  });
+});
+
+describe('workspaceOf', () => {
+  it('reports the subdomain of a Slack URL', () => {
+    expect(workspaceOf(`${TEAM_URL}/archives/${CHANNEL}`)).toBe('myteam');
+    expect(workspaceOf(`${ENTERPRISE_URL}/archives/${CHANNEL}`)).toBe('myorg');
+  });
+
+  it('reports nothing for a bare ID or a missing value', () => {
+    expect(workspaceOf(CHANNEL)).toBeUndefined();
+    expect(workspaceOf(undefined)).toBeUndefined();
+  });
+});
+
+describe('workspaceMismatchWarning', () => {
+  it('warns when the link belongs to another workspace', () => {
+    expect(workspaceMismatchWarning('other', 'myteam')).toMatch(/"other".*"myteam"/);
+  });
+
+  it('stays silent when they match, ignoring case', () => {
+    expect(workspaceMismatchWarning('MyTeam', 'myteam')).toBeNull();
+  });
+
+  it('stays silent when either side is unknown (standard auth has no subdomain)', () => {
+    expect(workspaceMismatchWarning('myteam', undefined)).toBeNull();
+    expect(workspaceMismatchWarning(undefined, 'myteam')).toBeNull();
+  });
+});
+
+describe('resolveMessageTarget', () => {
+  const flags = { channel: '--channel-id', timestamp: '--timestamp' };
+
+  it('resolves explicit inputs, normalizing both', () => {
+    const target = resolveMessageTarget(
+      { channelId: `${TEAM_URL}/archives/${CHANNEL}`, timestamp: 'p1786816800107789' },
+      flags
+    );
+    expect(target).toEqual({ channelId: CHANNEL, timestamp: '1786816800.107789', workspace: 'myteam' });
+  });
+
+  it('resolves a permalink into both inputs at once', () => {
+    const target = resolveMessageTarget(
+      { permalink: `${TEAM_URL}/archives/${CHANNEL}/p1786816800107789` },
+      flags
+    );
+    expect(target).toEqual({ channelId: CHANNEL, timestamp: '1786816800.107789', workspace: 'myteam' });
+  });
+
+  it('targets the reply itself, not its parent, for a threaded-reply permalink', () => {
+    const target = resolveMessageTarget(
+      { permalink: `${TEAM_URL}/archives/${CHANNEL}/p1786816999222333?thread_ts=1786816800.107789` },
+      flags
+    );
+    expect(target.timestamp).toBe('1786816999.222333');
+  });
+
+  it('reports no workspace when explicit inputs are bare IDs', () => {
+    const target = resolveMessageTarget({ channelId: CHANNEL, timestamp: '1786816800.107789' }, flags);
+    expect(target.workspace).toBeUndefined();
+  });
+
+  it('rejects --permalink combined with an explicit input', () => {
+    expect(() =>
+      resolveMessageTarget(
+        { permalink: `${TEAM_URL}/archives/${CHANNEL}/p1786816800107789`, channelId: CHANNEL },
+        flags
+      )
+    ).toThrow(/pass one or the other, not both/);
+    expect(() =>
+      resolveMessageTarget(
+        { permalink: `${TEAM_URL}/archives/${CHANNEL}/p1786816800107789`, timestamp: '1786816800.107789' },
+        flags
+      )
+    ).toThrow(/pass one or the other, not both/);
+  });
+
+  it('names every missing input when neither form is complete', () => {
+    expect(() => resolveMessageTarget({}, flags)).toThrow(/Missing --channel-id and --timestamp/);
+    expect(() => resolveMessageTarget({ channelId: CHANNEL }, flags)).toThrow(/Missing --timestamp/);
+  });
+
+  it('rejects a channel-only link as a message target', () => {
+    expect(() => resolveMessageTarget({ permalink: `${TEAM_URL}/archives/${CHANNEL}` }, flags)).toThrow(
+      /does not point at a message/
+    );
+  });
+});
+
+describe('resolveThreadTarget', () => {
+  const flags = { channel: '--recipient-id', timestamp: '--thread-ts' };
+
+  it('resolves explicit inputs, normalizing both', () => {
+    const target = resolveThreadTarget(
+      { channelId: `${TEAM_URL}/archives/${CHANNEL}`, threadTs: 'p1786816800107789' },
+      flags
+    );
+    expect(target).toEqual({ channelId: CHANNEL, threadTs: '1786816800.107789', workspace: 'myteam' });
+  });
+
+  it('leaves the thread unset when no thread timestamp is given', () => {
+    const target = resolveThreadTarget({ channelId: CHANNEL }, flags);
+    expect(target.threadTs).toBeUndefined();
+  });
+
+  it('resolves a top-level message permalink to that message as thread parent', () => {
+    const target = resolveThreadTarget(
+      { permalink: `${TEAM_URL}/archives/${CHANNEL}/p1786816800107789` },
+      flags
+    );
+    expect(target).toEqual({ channelId: CHANNEL, threadTs: '1786816800.107789', workspace: 'myteam' });
+  });
+
+  it('resolves a threaded-reply permalink to the PARENT timestamp', () => {
+    const target = resolveThreadTarget(
+      { permalink: `${TEAM_URL}/archives/${CHANNEL}/p1786816999222333?thread_ts=1786816800.107789` },
+      flags
+    );
+    expect(target.threadTs).toBe('1786816800.107789');
+  });
+
+  it('resolves a bare channel link to the channel with no thread', () => {
+    const target = resolveThreadTarget({ permalink: `${TEAM_URL}/archives/${CHANNEL}` }, flags);
+    expect(target).toEqual({ channelId: CHANNEL, threadTs: undefined, workspace: 'myteam' });
+  });
+
+  it('accepts a user profile URL for channel-or-user call sites', () => {
+    const target = resolveThreadTarget(
+      { channelId: `${TEAM_URL}/team/U012ABCDEFG` },
+      flags,
+      'channel-or-user'
+    );
+    expect(target.channelId).toBe('U012ABCDEFG');
+  });
+
+  it('rejects --permalink combined with an explicit input', () => {
+    expect(() =>
+      resolveThreadTarget(
+        { permalink: `${TEAM_URL}/archives/${CHANNEL}`, channelId: CHANNEL },
+        flags
+      )
+    ).toThrow(/pass one or the other, not both/);
+  });
+
+  it('requires a channel when no permalink is given', () => {
+    expect(() => resolveThreadTarget({}, flags)).toThrow(/Missing --recipient-id/);
+  });
+});

--- a/src/lib/slack-url-parser.test.ts
+++ b/src/lib/slack-url-parser.test.ts
@@ -230,6 +230,12 @@ describe('parseSlackLink', () => {
     expect(parsed.workspace).toBe('myorg');
   });
 
+  it('reports the real subdomain for a mixed-case host', () => {
+    expect(parseSlackLink('https://myteam.SLACK.COM/archives/C0BHFPKJMC2/p1786816800107789').workspace).toBe(
+      'myteam'
+    );
+  });
+
   it('ignores extra query parameters', () => {
     const parsed = parseSlackLink(`${TEAM_URL}/archives/${CHANNEL}/p1786816800107789?cid=${CHANNEL}&web=1`);
     expect(parsed.timestamp).toBe('1786816800.107789');
@@ -311,6 +317,13 @@ describe('workspaceOf', () => {
     expect(workspaceOf(`${ENTERPRISE_URL}/archives/${CHANNEL}`)).toBe('myorg');
   });
 
+  it('reports the real subdomain even when the host is not all lowercase', () => {
+    // The URL parser lowercases the host; a case-sensitive regex over the raw
+    // string would fall back to the literal "workspace" and warn spuriously.
+    expect(workspaceOf('https://myteam.SLACK.COM/archives/C0BHFPKJMC2')).toBe('myteam');
+    expect(workspaceOf('HTTPS://MyTeam.Slack.Com/archives/C0BHFPKJMC2')).toBe('myteam');
+  });
+
   it('reports nothing for a bare ID or a missing value', () => {
     expect(workspaceOf(CHANNEL)).toBeUndefined();
     expect(workspaceOf(undefined)).toBeUndefined();
@@ -364,19 +377,32 @@ describe('resolveMessageTarget', () => {
     expect(target.workspace).toBeUndefined();
   });
 
-  it('rejects --permalink combined with an explicit input', () => {
+  it('names only the input that actually collides with --permalink', () => {
     expect(() =>
       resolveMessageTarget(
         { permalink: `${TEAM_URL}/archives/${CHANNEL}/p1786816800107789`, channelId: CHANNEL },
         flags
       )
-    ).toThrow(/pass one or the other, not both/);
+    ).toThrow(/--permalink already supplies --channel-id; pass one or the other, not both/);
     expect(() =>
       resolveMessageTarget(
         { permalink: `${TEAM_URL}/archives/${CHANNEL}/p1786816800107789`, timestamp: '1786816800.107789' },
         flags
       )
-    ).toThrow(/pass one or the other, not both/);
+    ).toThrow(/--permalink already supplies --timestamp; pass one or the other, not both/);
+  });
+
+  it('names both inputs when both collide with --permalink', () => {
+    expect(() =>
+      resolveMessageTarget(
+        {
+          permalink: `${TEAM_URL}/archives/${CHANNEL}/p1786816800107789`,
+          channelId: CHANNEL,
+          timestamp: '1786816800.107789',
+        },
+        flags
+      )
+    ).toThrow(/already supplies --channel-id and --timestamp/);
   });
 
   it('names every missing input when neither form is complete', () => {
@@ -443,7 +469,13 @@ describe('resolveThreadTarget', () => {
         { permalink: `${TEAM_URL}/archives/${CHANNEL}`, channelId: CHANNEL },
         flags
       )
-    ).toThrow(/pass one or the other, not both/);
+    ).toThrow(/--permalink already supplies --recipient-id; pass one or the other, not both/);
+    expect(() =>
+      resolveThreadTarget(
+        { permalink: `${TEAM_URL}/archives/${CHANNEL}`, threadTs: '1786816800.107789' },
+        flags
+      )
+    ).toThrow(/--permalink already supplies --thread-ts; pass one or the other, not both/);
   });
 
   it('requires a channel when no permalink is given', () => {

--- a/src/lib/slack-url-parser.ts
+++ b/src/lib/slack-url-parser.ts
@@ -83,7 +83,20 @@ export function isSlackUrl(input: string): boolean {
 export function workspaceOf(input: string | undefined): string | undefined {
   if (!input) return undefined;
   const value = clean(input);
-  return isSlackUrl(value) ? extractSlackWorkspaceName(value) : undefined;
+  if (!isSlackUrl(value)) return undefined;
+  try {
+    return workspaceOfUrl(new URL(value));
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The workspace subdomain of an already-parsed Slack URL. Reads from `origin`, which
+ * the URL parser has lowercased, so a host typed as `MyTeam.SLACK.com` still resolves.
+ */
+function workspaceOfUrl(url: URL): string {
+  return extractSlackWorkspaceName(url.origin);
 }
 
 /** Classify a bare Slack identifier by its prefix letter. */
@@ -248,7 +261,7 @@ export function parseSlackLink(input: string): ParsedPermalink {
 
   const result: ParsedPermalink = {
     channelId,
-    workspace: extractSlackWorkspaceName(value),
+    workspace: workspaceOfUrl(url),
   };
 
   const messageSegment = segments[2];
@@ -326,12 +339,12 @@ interface TargetFlags {
   timestamp: string;
 }
 
-function assertNoConflict(input: { channelId?: string; permalink?: string }, flags: TargetFlags, others: string[]): void {
-  if (!input.permalink) return;
-  const conflicting = others.filter(Boolean);
+/** `--permalink` supplies both inputs, so pairing it with either of them is ambiguous. */
+function assertNoConflict(supplied: Array<[flag: string, value: string | undefined]>): void {
+  const conflicting = supplied.filter(([, value]) => value).map(([flag]) => flag);
   if (conflicting.length > 0) {
     throw new SlackUrlParseError(
-      `--permalink already supplies ${flags.channel} and ${flags.timestamp}; pass one or the other, not both.`
+      `--permalink already supplies ${conflicting.join(' and ')}; pass one or the other, not both.`
     );
   }
 }
@@ -345,7 +358,7 @@ export function resolveMessageTarget(
   flags: TargetFlags
 ): ResolvedMessageTarget {
   if (input.permalink) {
-    assertNoConflict(input, flags, [input.channelId ?? '', input.timestamp ?? '']);
+    assertNoConflict([[flags.channel, input.channelId], [flags.timestamp, input.timestamp]]);
     const parsed = parsePermalink(input.permalink);
     return {
       channelId: parsed.channelId,
@@ -383,7 +396,7 @@ export function resolveThreadTarget(
   expected: ExpectedKind = 'channel'
 ): ResolvedThreadTarget {
   if (input.permalink) {
-    assertNoConflict(input, flags, [input.channelId ?? '', input.threadTs ?? '']);
+    assertNoConflict([[flags.channel, input.channelId], [flags.timestamp, input.threadTs]]);
     const parsed = parseSlackLink(input.permalink);
     return {
       channelId: parsed.channelId,

--- a/src/lib/slack-url-parser.ts
+++ b/src/lib/slack-url-parser.ts
@@ -1,0 +1,423 @@
+/**
+ * Parser for the Slack URLs and permalink-style timestamps that Slack's "Copy link"
+ * actually produces, so the CLI can accept them wherever it takes an ID or timestamp.
+ *
+ * Everything here is pure input widening: bare IDs and dotted API timestamps pass
+ * through untouched, so every previously-valid invocation keeps working.
+ */
+
+import { extractSlackWorkspaceName } from './curl-parser.ts';
+
+/** A parsed Slack message permalink. */
+export interface ParsedPermalink {
+  channelId: string;
+  /** Dotted API form. Absent when the link points at a channel rather than a message. */
+  timestamp?: string;
+  /** Parent timestamp from ?thread_ts=, present when the link points at a threaded reply. */
+  threadTs?: string;
+  /** Workspace subdomain, for cross-workspace validation. */
+  workspace?: string;
+}
+
+/** What a Slack identifier refers to, derived from its prefix letter. */
+export type IdentifierKind = 'channel' | 'user' | 'file' | 'team' | 'unknown';
+
+/** What a call site is willing to accept. */
+export type ExpectedKind = 'channel' | 'user' | 'file' | 'channel-or-user';
+
+export class SlackUrlParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SlackUrlParseError';
+  }
+}
+
+// Matches standard (myteam.slack.com) and enterprise (myorg.enterprise.slack.com) hosts.
+const SLACK_URL_PATTERN = /^https?:\/\/[\w.-]+\.slack\.com(?:\/|$)/i;
+
+// Slack IDs are uppercase letter + alphanumerics. Deliberately strict: anything that
+// does not look like a real ID is classified 'unknown' and passed through rather than
+// rejected, so we never reject an input the API would have accepted.
+const SLACK_ID_PATTERN = /^([CDGUWFTE])[A-Z0-9]{6,}$/;
+
+const KIND_BY_PREFIX: Record<string, IdentifierKind> = {
+  C: 'channel', // public channel
+  D: 'channel', // DM conversation
+  G: 'channel', // private channel / MPIM
+  U: 'user',
+  W: 'user', // enterprise-grid user
+  F: 'file', // files, including canvases
+  T: 'team',
+  E: 'team', // enterprise org
+};
+
+const KIND_LABEL: Record<IdentifierKind, string> = {
+  channel: 'channel',
+  user: 'user',
+  file: 'file',
+  team: 'workspace',
+  unknown: 'value',
+};
+
+/**
+ * Strip the wrapping Slack itself adds when a link is pasted out of a message
+ * (`<https://…>`) plus surrounding whitespace.
+ */
+function clean(input: string): string {
+  const trimmed = input.trim();
+  if (trimmed.startsWith('<') && trimmed.endsWith('>')) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+}
+
+/** True when the input looks like a Slack web URL. */
+export function isSlackUrl(input: string): boolean {
+  return SLACK_URL_PATTERN.test(clean(input));
+}
+
+/**
+ * The workspace subdomain an input belongs to, or undefined when it is not a Slack URL
+ * (a bare ID carries no workspace).
+ */
+export function workspaceOf(input: string | undefined): string | undefined {
+  if (!input) return undefined;
+  const value = clean(input);
+  return isSlackUrl(value) ? extractSlackWorkspaceName(value) : undefined;
+}
+
+/** Classify a bare Slack identifier by its prefix letter. */
+export function identifierKind(id: string): IdentifierKind {
+  const match = id.match(SLACK_ID_PATTERN);
+  if (!match) return 'unknown';
+  return KIND_BY_PREFIX[match[1]] ?? 'unknown';
+}
+
+function accepts(expected: ExpectedKind, kind: IdentifierKind): boolean {
+  // 'unknown' always passes: we only reject an input we positively recognise
+  // as the wrong type.
+  if (kind === 'unknown') return true;
+  if (expected === 'channel-or-user') return kind === 'channel' || kind === 'user';
+  return kind === expected;
+}
+
+function expectedLabel(expected: ExpectedKind): string {
+  return expected === 'channel-or-user' ? 'channel or user' : expected;
+}
+
+function assertKind(id: string, expected: ExpectedKind, flag: string): string {
+  const kind = identifierKind(id);
+  if (!accepts(expected, kind)) {
+    throw new SlackUrlParseError(
+      `${flag} expects a ${expectedLabel(expected)} ID, but got a ${KIND_LABEL[kind]} ID (${id}).`
+    );
+  }
+  return id;
+}
+
+/**
+ * Parse the path of a Slack URL into the identifier it names.
+ * Returns null when the URL is a Slack URL but not one we recognise.
+ */
+function identifierFromUrl(url: string): string | null {
+  let path: string;
+  try {
+    path = new URL(url).pathname;
+  } catch {
+    return null;
+  }
+
+  const segments = path.split('/').filter(Boolean);
+  if (segments.length < 2) return null;
+
+  const [area, first, second] = segments;
+
+  // /archives/<channel>[/p<ts>] and /team/<user>
+  if (area === 'archives' || area === 'team') return first;
+
+  // /docs/<team>/<file> — canvas documents
+  if (area === 'docs' && second) return second;
+
+  return null;
+}
+
+/**
+ * A Slack URL or a bare ID -> a bare ID. Bare IDs pass through unchanged.
+ *
+ * `flag` names the CLI input in error messages (e.g. `--channel-id`).
+ */
+export function normalizeIdentifier(input: string, expected: ExpectedKind, flag: string): string {
+  const value = clean(input);
+  if (!value) {
+    throw new SlackUrlParseError(`${flag} requires a value.`);
+  }
+
+  if (!isSlackUrl(value)) {
+    return assertKind(value, expected, flag);
+  }
+
+  const id = identifierFromUrl(value);
+  if (!id) {
+    throw new SlackUrlParseError(
+      `${flag} could not read an ID out of this Slack URL: ${value}. ` +
+        `Supported forms are /archives/<channel>, /team/<user>, and /docs/<team>/<file>.`
+    );
+  }
+
+  return assertKind(id, expected, flag);
+}
+
+/**
+ * A permalink-style or bare timestamp -> the dotted API form.
+ *
+ * Slack permalinks carry `p<10 second digits><6 microsecond digits>`; the API wants
+ * those two halves separated by a dot. Plain epoch seconds (used for `--oldest` /
+ * `--latest` range bounds) and already-dotted values pass through unchanged.
+ */
+export function normalizeTimestamp(input: string, flag: string): string {
+  const value = clean(input);
+  if (!value) {
+    throw new SlackUrlParseError(`${flag} requires a value.`);
+  }
+
+  if (isSlackUrl(value)) {
+    throw new SlackUrlParseError(
+      `${flag} expects a timestamp, but got a Slack URL. Use --permalink ${value} instead.`
+    );
+  }
+
+  // Already in API form.
+  if (/^\d+\.\d+$/.test(value)) return value;
+
+  const permalinkForm = value.match(/^p(\d+)$/);
+  if (permalinkForm) {
+    const digits = permalinkForm[1];
+    if (digits.length !== 16) {
+      throw new SlackUrlParseError(
+        `${flag} got a permalink-style timestamp with ${digits.length} digits; expected 16 (p<10 second digits><6 microsecond digits>).`
+      );
+    }
+    return `${digits.slice(0, 10)}.${digits.slice(10)}`;
+  }
+
+  if (/^\d+$/.test(value)) {
+    // 16 digits is the permalink form without its `p`; anything shorter is epoch
+    // seconds, which Slack accepts as-is for range bounds.
+    if (value.length === 16) return `${value.slice(0, 10)}.${value.slice(10)}`;
+    return value;
+  }
+
+  throw new SlackUrlParseError(
+    `${flag} is not a valid Slack timestamp: ${value}. ` +
+      `Expected 1234567890.123456, 1234567890123456, or p1234567890123456.`
+  );
+}
+
+/**
+ * A Slack link -> the channel it names, plus the message timestamp when the link
+ * points at one. Accepts both `/archives/<channel>` and `/archives/<channel>/p<ts>`.
+ */
+export function parseSlackLink(input: string): ParsedPermalink {
+  const value = clean(input);
+
+  if (!isSlackUrl(value)) {
+    throw new SlackUrlParseError(`Not a Slack URL: ${value}.`);
+  }
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new SlackUrlParseError(`Not a valid URL: ${value}.`);
+  }
+
+  const segments = url.pathname.split('/').filter(Boolean);
+  if (segments[0] !== 'archives' || !segments[1]) {
+    throw new SlackUrlParseError(
+      `Not a Slack message link: ${value}. Expected https://<workspace>.slack.com/archives/<channel>/p<timestamp>.`
+    );
+  }
+
+  const channelId = segments[1];
+  const kind = identifierKind(channelId);
+  if (kind !== 'channel' && kind !== 'unknown') {
+    throw new SlackUrlParseError(
+      `Slack link names a ${KIND_LABEL[kind]} ID (${channelId}) where a channel was expected: ${value}.`
+    );
+  }
+
+  const result: ParsedPermalink = {
+    channelId,
+    workspace: extractSlackWorkspaceName(value),
+  };
+
+  const messageSegment = segments[2];
+  if (messageSegment) {
+    if (!/^p\d+$/.test(messageSegment)) {
+      throw new SlackUrlParseError(
+        `Slack link has an unexpected message segment (${messageSegment}): ${value}.`
+      );
+    }
+    result.timestamp = normalizeTimestamp(messageSegment, 'permalink');
+  }
+
+  // On a link to a threaded reply the path holds the *reply* timestamp and
+  // ?thread_ts= holds the parent — the value every --thread-ts consumer wants.
+  const threadTs = url.searchParams.get('thread_ts');
+  if (threadTs) {
+    result.threadTs = normalizeTimestamp(threadTs, 'permalink thread_ts');
+  }
+
+  return result;
+}
+
+/**
+ * Strict form of {@link parseSlackLink}: the link must point at a specific message.
+ */
+export function parsePermalink(input: string): ParsedPermalink & { timestamp: string } {
+  const parsed = parseSlackLink(input);
+  if (!parsed.timestamp) {
+    throw new SlackUrlParseError(
+      `Slack link does not point at a message: ${clean(input)}. ` +
+        `Expected https://<workspace>.slack.com/archives/<channel>/p<timestamp>.`
+    );
+  }
+  return parsed as ParsedPermalink & { timestamp: string };
+}
+
+/**
+ * The thread a link belongs to: the parent timestamp for a reply, otherwise the
+ * message's own timestamp (a top-level message is its own thread parent).
+ */
+export function threadParentOf(parsed: ParsedPermalink): string | undefined {
+  return parsed.threadTs ?? parsed.timestamp;
+}
+
+/** Raw CLI inputs for a command that targets one specific message. */
+export interface MessageTargetInput {
+  permalink?: string;
+  channelId?: string;
+  timestamp?: string;
+}
+
+/** Raw CLI inputs for a command that targets a conversation, optionally a thread in it. */
+export interface ThreadTargetInput {
+  permalink?: string;
+  channelId?: string;
+  threadTs?: string;
+}
+
+export interface ResolvedMessageTarget {
+  channelId: string;
+  timestamp: string;
+  workspace?: string;
+}
+
+export interface ResolvedThreadTarget {
+  channelId: string;
+  threadTs?: string;
+  workspace?: string;
+}
+
+interface TargetFlags {
+  /** Name of the channel/recipient input, for error messages. */
+  channel: string;
+  /** Name of the timestamp input, for error messages. */
+  timestamp: string;
+}
+
+function assertNoConflict(input: { channelId?: string; permalink?: string }, flags: TargetFlags, others: string[]): void {
+  if (!input.permalink) return;
+  const conflicting = others.filter(Boolean);
+  if (conflicting.length > 0) {
+    throw new SlackUrlParseError(
+      `--permalink already supplies ${flags.channel} and ${flags.timestamp}; pass one or the other, not both.`
+    );
+  }
+}
+
+/**
+ * Resolve the channel + timestamp of a command targeting one specific message,
+ * from either `--permalink` or the explicit inputs (never both).
+ */
+export function resolveMessageTarget(
+  input: MessageTargetInput,
+  flags: TargetFlags
+): ResolvedMessageTarget {
+  if (input.permalink) {
+    assertNoConflict(input, flags, [input.channelId ?? '', input.timestamp ?? '']);
+    const parsed = parsePermalink(input.permalink);
+    return {
+      channelId: parsed.channelId,
+      timestamp: parsed.timestamp,
+      workspace: parsed.workspace,
+    };
+  }
+
+  if (!input.channelId || !input.timestamp) {
+    const missing = [!input.channelId ? flags.channel : '', !input.timestamp ? flags.timestamp : '']
+      .filter(Boolean)
+      .join(' and ');
+    throw new SlackUrlParseError(
+      `Missing ${missing}. Pass ${flags.channel} and ${flags.timestamp}, or a single --permalink <url>.`
+    );
+  }
+
+  return {
+    channelId: normalizeIdentifier(input.channelId, 'channel', flags.channel),
+    timestamp: normalizeTimestamp(input.timestamp, flags.timestamp),
+    workspace: workspaceOf(input.channelId),
+  };
+}
+
+/**
+ * Resolve the conversation (and thread, when one is named) of a command that reads or
+ * posts into a channel, from either `--permalink` or the explicit inputs.
+ *
+ * A permalink pointing at a message resolves to that message's thread; a bare channel
+ * link resolves to the channel with no thread.
+ */
+export function resolveThreadTarget(
+  input: ThreadTargetInput,
+  flags: TargetFlags,
+  expected: ExpectedKind = 'channel'
+): ResolvedThreadTarget {
+  if (input.permalink) {
+    assertNoConflict(input, flags, [input.channelId ?? '', input.threadTs ?? '']);
+    const parsed = parseSlackLink(input.permalink);
+    return {
+      channelId: parsed.channelId,
+      threadTs: threadParentOf(parsed),
+      workspace: parsed.workspace,
+    };
+  }
+
+  if (!input.channelId) {
+    throw new SlackUrlParseError(
+      `Missing ${flags.channel}. Pass ${flags.channel}, or a single --permalink <url>.`
+    );
+  }
+
+  return {
+    channelId: normalizeIdentifier(input.channelId, expected, flags.channel),
+    threadTs: input.threadTs ? normalizeTimestamp(input.threadTs, flags.timestamp) : undefined,
+    workspace: workspaceOf(input.channelId),
+  };
+}
+
+/**
+ * Warning text when a pasted link belongs to a different workspace than the one the
+ * command will run against — otherwise Slack answers with a misleading
+ * `message_not_found`. Returns null when there is nothing to warn about.
+ */
+export function workspaceMismatchWarning(
+  linkWorkspace: string | undefined,
+  clientWorkspace: string | undefined
+): string | null {
+  if (!linkWorkspace || !clientWorkspace) return null;
+  if (linkWorkspace.toLowerCase() === clientWorkspace.toLowerCase()) return null;
+  return (
+    `This link belongs to the "${linkWorkspace}" workspace but you are authenticated ` +
+    `against "${clientWorkspace}". Use --workspace to pick the matching workspace if this fails.`
+  );
+}


### PR DESCRIPTION
Closes #107

## WHAT

Wherever the CLI takes a Slack **identifier** (channel, user, canvas) or a **timestamp**, it now also accepts the form Slack's "Copy link" actually gives you, and normalizes it internally.

**Part 1 — identifiers (8 call sites).** `messages send/draft --recipient-id`, `messages react/edit --channel-id`, `conversations read/get <channel-id>`, `canvas list --channel`, `canvas read --channel` and `[canvas-id]` all accept a Slack URL:

| Pasted | Understood as |
|---|---|
| `https://team.slack.com/archives/C0BHFPKJMC2` | `C0BHFPKJMC2` |
| `https://team.slack.com/archives/D048XXXXXXX` | `D048XXXXXXX` |
| `https://team.slack.com/team/U012ABCDEFG` | `U012ABCDEFG` |
| `https://team.slack.com/docs/T012AB/F0123ABCD` | `F0123ABCD` |

**Part 2 — timestamps (8 call sites).** `messages react/edit --timestamp`, `messages send/draft --thread-ts`, `conversations read --thread-ts/--oldest/--latest`, `conversations get <timestamp>`: `p1786816800107789` and `1786816800107789` both become `1786816800.107789`.

**Part 3 — `--permalink <url>`** on `messages send`, `messages react`, `messages edit`, `messages draft`, `conversations read`, `conversations get`, replacing channel + timestamp in one value:

```bash
# Before
slackcli messages react --channel-id C0BHFPKJMC2 --timestamp 1786816800.107789 --emoji heart
# After
slackcli messages react --permalink https://team.slack.com/archives/C0BHFPKJMC2/p1786816800107789 --emoji heart
```

## WHY

Slack's UI offers "Copy link". It does not offer a bare ID or a dotted API timestamp. Every one of those 16 inputs previously forced the user to hand-extract a field — and for timestamps, to strip a `p` and insert a decimal point exactly six digits from the end. Getting it wrong returned `message_not_found`, which implies the message doesn't exist rather than "you're missing a dot".

This is the same bet `src/lib/curl-parser.ts` already makes: parsing what the browser gives you beats making the user extract fields from it.

## HOW

**New `src/lib/slack-url-parser.ts`** (zero dependencies), mirroring `curl-parser.ts`:

- `normalizeIdentifier(input, expected, flag)` — URL or bare ID → bare ID
- `normalizeTimestamp(input, flag)` — permalink-style or bare → dotted API form
- `parseSlackLink` / `parsePermalink` / `threadParentOf` — link → channel + timestamp + thread parent
- `resolveMessageTarget` / `resolveThreadTarget` — `--permalink` vs explicit inputs, mutually exclusive
- `workspaceOf` / `workspaceMismatchWarning` — cross-workspace detection

Covered: standard + enterprise-grid hosts, DMs and private groups, user profiles, canvas docs, trailing query junk, whitespace, and `<https://…>` wrapping as pasted out of Slack.

**Threaded replies** get dedicated handling and tests: a reply permalink carries the *reply* timestamp in `/p…` and the *parent* in `?thread_ts=`. `--timestamp` consumers get the reply; `--thread-ts` consumers get the parent. Confusing the two silently targets the wrong message, so it is tested both ways.

**Type validation.** A user URL passed to `--channel-id` now errors with `--channel-id expects a channel ID, but got a user ID (U012ABCDEFG)` instead of a downstream API error. Deliberately conservative: only inputs positively recognised as the wrong type are rejected; anything unrecognised passes through, so nothing the API used to accept is now refused.

**Cross-workspace warning.** When a pasted link's subdomain differs from the authenticated workspace, the command warns rather than issuing a request that fails as `message_not_found`. Scoped to **browser auth**, the only auth type that stores a `workspace_url`; standard auth's `workspace_name` is user-chosen at login and would produce false warnings. New `SlackClient.workspaceHost` accessor.

## Backward compatibility

Parts 1 and 2 are pure input widening — bare IDs and dotted timestamps pass through byte-for-byte. Plain epoch seconds on `--oldest`/`--latest` are explicitly left alone (normalizing them would move the range by six orders of magnitude); there is a test for that.

## Acceptance criteria

- [x] All 8 identifier inputs accept the corresponding Slack URL
- [x] All 8 timestamp inputs accept `p…` and bare-16-digit forms
- [x] `--permalink` on all 6 message-targeting commands, mutually exclusive with the explicit inputs
- [x] Threaded-reply permalinks resolve `--thread-ts` to the *parent*
- [x] Wrong-type identifiers produce a clear error, not a downstream API failure
- [x] Every previously-valid invocation still works unchanged
- [x] `src/lib/slack-url-parser.test.ts` covers every URL shape plus malformed input

## Out of scope (per #107)

Auto-switching workspaces from a URL subdomain (warning only), `--workspace` accepting a workspace URL, and resolving `#channel-name` to an ID.

## Deviations from the issue's HOW

1. **Cross-workspace validation is warn-only and browser-auth only** — decided during refinement; standard auth has no reliable subdomain to compare against.
2. **`--channel-id`/`--timestamp` are no longer Commander-`requiredOption`s** (and `conversations read/get` positionals are now optional) — they have to be, for `--permalink` to replace them. The requirement is enforced in `resolveMessageTarget`/`resolveThreadTarget`, which produce a clearer message than Commander did: `Missing --channel-id and --timestamp. Pass --channel-id and --timestamp, or a single --permalink <url>.` `src/commands/messages.test.ts` was updated to assert this new contract.

## Known limitation

Address-bar URLs of the form `https://app.slack.com/client/T…/C…` are not among the forms #107 enumerated and are not parsed. They fail with an explicit "supported forms are …" error rather than silently, so they are a dead end with a signpost. Worth a follow-up issue if it comes up in practice.

## Testing

`src/lib/slack-url-parser.test.ts` (new, 60 cases), `src/commands/conversations.test.ts` (new), `src/commands/messages.test.ts` (extended). **404 tests pass**, type-check clean, build 91 MB (limit 150 MB), all pre-commit hooks pass. Error paths were also exercised against the real CLI.
