### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-08-16
+
 ### Added
 - **Slack URLs accepted wherever an ID is taken**: paste `https://team.slack.com/archives/C123…`, `/team/U123…`, or `/docs/T…/F…` in place of a channel, user, or canvas ID (#107)
 - **Permalink-style timestamps accepted wherever a timestamp is taken**: `p1234567890123456` and `1234567890123456` normalize to `1234567890.123456` (#107)
 - **`--permalink <url>`** on `messages send`, `messages react`, `messages edit`, `messages draft`, `conversations read`, and `conversations get` — supplies channel and timestamp from a single message link, resolving a threaded reply to its parent for `--thread-ts` (#107)
 - Clear errors instead of a misleading `message_not_found`: wrong-type IDs (a user URL passed to `--channel-id`), `--permalink` combined with explicit inputs, and a warning when a pasted link belongs to a different workspace than the authenticated one (browser auth) (#107)
+
+### Fixed
+- **mrkdwn emphasis now requires word boundaries**: an `_` inside a URL or identifier (for example the `merge_requests` segment of a GitLab link) no longer pairs with an unrelated `_` later in the message, which previously italicised the span between them and destroyed both URLs (#103)
+  - Scoped to `_` only — Slack applies `*bold*`, `~strike~` and `` `code` `` mid-word, and those are unchanged
+  - Behaviour change: `_hello_world_` is now left fully literal, matching Slack leaving `snake_case` unformatted
 
 ## [0.8.0] - 2026-08-06
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slackcli",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A fast, developer-friendly CLI tool for interacting with Slack workspaces",
   "main": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary
Bumps `package.json` `0.8.0` -> `0.9.0` and prepares the `CHANGELOG` for the **v0.9.0** release. This must land on `main` before the `v0.9.0` tag is pushed, since `release.yml` fails when the tag disagrees with `package.json` version (#82).

## Included since v0.8.0
- `feat`: accept Slack URLs and permalink-style timestamps everywhere, plus a new `--permalink <url>` flag on `messages send/react/edit/draft` and `conversations read/get` (#107, #108)
- `fix`: require word boundaries for mrkdwn emphasis markers, so an `_` inside a URL no longer italicises the span between it and a later `_` and destroys both links (#96, #103)

Non-shipping changes also on `main`: stale issue/PR lifecycle + mandatory linked-issue CI (#110), and `actions/github-script` 8 -> 9 (#100).

## Changes in this PR
- `package.json`: version `0.8.0` -> `0.9.0`
- `CHANGELOG.md`: promote `[Unreleased]` into `[0.9.0]`, and add the missing `### Fixed` entry for the mrkdwn word-boundary fix (#103), which had landed without a changelog entry

## Not included
Open `ready-for-pr` bugs #104 (self-update integrity) and #106 (`messages edit` breaking links) are intentionally deferred to a later release.

## Checks
- `bun run type-check` — passes
- `bun test` — 404 pass / 0 fail

## Release steps after merge
Push annotated tag `v0.9.0` -> `release.yml` builds binaries, publishes the GitHub release, and updates the Homebrew tap.

Closes #111
