### PR TITLE
ci: repair the unparseable stale.yml and gate workflow files (#116)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,46 @@ permissions:
   contents: read
 
 jobs:
+  # Validate every workflow file. An invalid workflow is a STARTUP failure and
+  # therefore the easiest kind of breakage to miss: the run appears in the
+  # Actions list already failed with no logs, labelled by file path rather than
+  # its `name:`, and -- the damage that actually matters -- GitHub cannot
+  # resolve the `on:` triggers, so the file's SCHEDULED runs are never created.
+  # stale.yml shipped in exactly that state and never ran successfully once,
+  # because Actions expressions have no arithmetic operators and it used `+`.
+  #
+  # Nothing validated workflow files before, in CI or in pre-commit. This runs
+  # the SAME hook id as .pre-commit-config.yaml, against the same pinned
+  # actionlint, so the local hook and this job can never disagree.
+  workflow-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.x'
+
+      # Keyed on the config, so the hook environment (which builds actionlint)
+      # is rebuilt only when the pinned rev changes.
+      - name: Cache pre-commit environments
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      # Scoped to the one hook id on purpose: the other hooks already run as
+      # their own CI steps, and `pre-commit run --all-files` here would execute
+      # the type-check and test suites a second time.
+      - name: Lint workflows
+        run: pre-commit run actionlint --all-files
+
   test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -66,6 +66,27 @@ jobs:
     name: Mark, remind & close stale issues and PRs
     runs-on: ubuntu-latest
     steps:
+      # Actions expressions have NO arithmetic operators: the supported set is
+      # `!`, comparisons, `&&`, `||` and functions. `${{ a + b }}` does not
+      # evaluate to a+b -- it makes the whole FILE unparseable, so the workflow
+      # never starts and its scheduled run is never created. This file had
+      # never run successfully before this step was added.
+      #
+      # The messages below quote the windows as totals ("closed after 21 days
+      # of inactivity"), matching what stage 2's own comments say, so the two
+      # components still have to be added up somewhere. Doing it in shell keeps
+      # `env` the single source of truth; hardcoding 14/21 as literals here
+      # would silently drift the moment a threshold above is retuned.
+      - name: Compute the reminder and close windows
+        id: windows
+        run: |
+          {
+            echo "issue_remind=$(( ISSUE_DAYS_BEFORE_STALE + ISSUE_DAYS_AFTER_LABEL_REMIND ))"
+            echo "issue_close=$(( ISSUE_DAYS_BEFORE_STALE + ISSUE_DAYS_AFTER_LABEL_CLOSE ))"
+            echo "pr_remind=$(( PR_DAYS_BEFORE_STALE + PR_DAYS_AFTER_LABEL_REMIND ))"
+            echo "pr_close=$(( PR_DAYS_BEFORE_STALE + PR_DAYS_AFTER_LABEL_CLOSE ))"
+          } >> "$GITHUB_OUTPUT"
+
       # Stage 1 -- mark inactive issues and PRs stale.
       # Closing and un-staling are handled in stage 2 (see header comment).
       - name: Mark stale issues and PRs
@@ -84,9 +105,9 @@ jobs:
             This issue has had no activity for
             ${{ env.ISSUE_DAYS_BEFORE_STALE }} days and is now marked
             **${{ env.STALE_LABEL }}**. It will receive one reminder at
-            ${{ fromJSON(env.ISSUE_DAYS_BEFORE_STALE) + fromJSON(env.ISSUE_DAYS_AFTER_LABEL_REMIND) }}
+            ${{ steps.windows.outputs.issue_remind }}
             days and be closed after
-            ${{ fromJSON(env.ISSUE_DAYS_BEFORE_STALE) + fromJSON(env.ISSUE_DAYS_AFTER_LABEL_CLOSE) }}
+            ${{ steps.windows.outputs.issue_close }}
             days of inactivity. Any comment or update removes the
             `${{ env.STALE_LABEL }}` label and resets the clock.
 
@@ -98,9 +119,9 @@ jobs:
             This pull request has had no activity for
             ${{ env.PR_DAYS_BEFORE_STALE }} days and is now marked
             **${{ env.STALE_LABEL }}**. It will receive one reminder at
-            ${{ fromJSON(env.PR_DAYS_BEFORE_STALE) + fromJSON(env.PR_DAYS_AFTER_LABEL_REMIND) }}
+            ${{ steps.windows.outputs.pr_remind }}
             days and be closed after
-            ${{ fromJSON(env.PR_DAYS_BEFORE_STALE) + fromJSON(env.PR_DAYS_AFTER_LABEL_CLOSE) }}
+            ${{ steps.windows.outputs.pr_close }}
             days of inactivity. Pushing a commit, leaving a comment or
             submitting a review removes the `${{ env.STALE_LABEL }}` label and
             resets the clock. If you are waiting on a maintainer review, say so

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,22 @@ repos:
       - id: no-commit-to-branch
         args: [--branch, main, --branch, master]
 
+  # An invalid workflow file is a STARTUP failure: GitHub cannot parse it, so
+  # it never resolves the `on:` triggers, the run carries no logs and is
+  # labelled by file path instead of its `name:`, and its SCHEDULED runs are
+  # never created. stale.yml shipped that way and never ran once. The CI
+  # `workflow-lint` job runs this same hook id, so hook and CI cannot drift.
+  #
+  # -shellcheck= / -pyflakes= disable actionlint's optional linting of `run:`
+  # script bodies. Those binaries ship on ubuntu-latest but not on a typical
+  # dev machine, so leaving them on would make the local hook weaker than CI
+  # and hand contributors failures they cannot reproduce.
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint
+        args: [-shellcheck=, -pyflakes=]
+
   - repo: local
     hooks:
       - id: bun-type-check


### PR DESCRIPTION
Fixes #116

## What

Repairs `.github/workflows/stale.yml`, which has been unparseable — and therefore has **never run** — since it was introduced in #110, and adds the missing gate so an invalid workflow cannot merge again.

## Why

GitHub Actions expressions have **no arithmetic operators**. The four `${{ a + b }}` expressions did not evaluate to a sum — they made the whole file unparseable, which is a **startup failure**:

- the run appears in the Actions list already failed, with no logs;
- it is labelled `.github/workflows/stale.yml` rather than `Stale issue & PR lifecycle`, because it never got far enough to read the `name:` key (still visible in `gh workflow list` today);
- GitHub cannot resolve the `on:` triggers, so the **daily 03:00 UTC run has never been created** — not once. Nothing has ever been marked stale, reminded, or closed;
- and every push since has carried a red check unrelated to its own change.

Every run of this workflow, from the commit that added it, is a failure, and there is no `schedule` entry in the history at all.

## How

**1. Remove the arithmetic.** A `run:` step computes the four totals into `$GITHUB_OUTPUT`; the messages reference `steps.windows.outputs.*`. The `env` block stays the single source of truth — hardcoding `14`/`21`/`28` as literals would drift silently the first time a threshold is retuned. The rendered wording is unchanged and still agrees with what stage 2's own comments compute (`remindTotal` / `closeTotal`).

Verified against the real `env` values:

| output | value | matches |
|---|---|---|
| `issue_remind` | 14 | issues 7 → **14** → 21 |
| `issue_close` | 21 | |
| `pr_remind` | 21 | PRs 14 → **21** → 28 |
| `pr_close` | 28 | |

**2. Gate it.** Adds the upstream `rhysd/actionlint` pre-commit hook at a pinned `rev`, plus a CI **`workflow-lint`** job that runs **the same hook id** (`pre-commit run actionlint --all-files`) — one definition, so the local hook and CI can never disagree. The pre-commit environment is cached on the config hash, so actionlint is built only when the pinned rev changes.

Both pass `-shellcheck= -pyflakes=` deliberately: those linters ship on `ubuntu-latest` but not on a typical dev machine, so leaving them enabled would make the local hook strictly **weaker** than CI and hand contributors failures they cannot reproduce. The gate is scoped to workflow **validity**, which is what this issue is about.

The CI job runs only that one hook id, not `--all-files` across every hook — the type-check and test suites already have their own CI steps and should not run twice.

## Verification

The gate is proven to bite, not merely to pass — restoring `stale.yml` from `main`:

```
$ git show main:.github/workflows/stale.yml > .github/workflows/stale.yml
$ pre-commit run actionlint --all-files
Lint GitHub Actions workflow files.......................................Failed
.github/workflows/stale.yml:83:227: got unexpected character '+' while lexing expression ...
.github/workflows/stale.yml:97:225: got unexpected character '+' while lexing expression ...

$ # on this branch
Lint GitHub Actions workflow files.......................................Passed
```

`actionlint` reports **zero** findings across every other workflow in the repo, so the new job lands green rather than immediately red.

**Local hooks:** all pass except `bun-type-check` and `bun-test`, which could not run here — `bun` is not installed on this machine ("Executable `bun` not found"). This diff contains no TypeScript, and both are covered by their existing CI steps.

## Acceptance criteria

- [x] `actionlint .github/workflows/stale.yml` exits clean.
- [x] The reminder and close windows still derive from the `env` block, with no duplicated literals.
- [x] An invalid workflow file fails a check before merge (pre-commit hook + CI `workflow-lint` job, one shared hook id).
- [ ] The workflow's run entry shows as `Stale issue & PR lifecycle`, not the file path — *resolved from the default branch, so only observable after merge.*
- [ ] A scheduled run appears and succeeds — *same; `schedule` is read from the default branch.*
- [x] Pushes no longer produce a `.github/workflows/stale.yml` failure.

The two unchecked boxes are not deferrals: `schedule` triggers are resolved from the copy of the file on the **default branch**, so neither can be exercised from this PR. They should be confirmed after merge.

## Context

This file is kept in sync with the copy in `vibexp/vibexp`, which carried the identical bug at the same four lines. It was fixed there in vibexp/vibexp#842 (issue vibexp/vibexp#816); this is the same fix, adapted to this repo's toolchain — the gate here runs through pre-commit rather than a Makefile target, since this repo has no Go toolchain.
