### PR TITLE
fix(messages): send parse=none on chat.update so links survive an edit (#106)

### DIFF
--- a/src/lib/slack-client.test.ts
+++ b/src/lib/slack-client.test.ts
@@ -127,9 +127,25 @@ describe('SlackClient.updateMessage', () => {
     expect(client.calls).toEqual([
       {
         method: 'chat.update',
-        params: { channel: 'C123', ts: '1234567890.123456', text: 'Corrected message' },
+        params: {
+          channel: 'C123',
+          ts: '1234567890.123456',
+          text: 'Corrected message',
+          parse: 'none',
+        },
       },
     ]);
     expect(response.ts).toBe('1234567890.123456');
+  });
+
+  // Without this, Slack applies the chat.update default (`client`) and stores
+  // `&lt;https://example.com|label&gt;`, which renders as literal text: every
+  // link in an edited message dies, silently, on a call that returns ok.
+  it('sends parse=none so link markup survives the edit', async () => {
+    const client = new TestSlackClient();
+
+    await client.updateMessage('C123', '1234567890.123456', 'A <https://example.com|label> B');
+
+    expect(client.calls[0]!.params.parse).toBe('none');
   });
 });

--- a/src/lib/slack-client.ts
+++ b/src/lib/slack-client.ts
@@ -153,7 +153,10 @@ export class SlackClient {
   }
 
   async updateMessage(channel: string, ts: string, text: string): Promise<any> {
-    return this.request('chat.update', { channel, ts, text });
+    // `parse` must be explicit: chat.update defaults it to `client` (unlike
+    // chat.postMessage, which defaults to `none`), and that escapes the
+    // `<url|label>` markup in the text, so editing a message kills its links.
+    return this.request('chat.update', { channel, ts, text, parse: 'none' });
   }
 
   async uploadFileExternal(channel: string, filePath: string, options: {


### PR DESCRIPTION
Closes #106, which you labelled `ready-for-pr`.

## What changed

`src/lib/slack-client.ts` — one parameter:

```ts
return this.request('chat.update', { channel, ts, text, parse: 'none' });
```

The comment above it records why it has to be explicit, since the value looks redundant next to `chat.postMessage`: [the docs](https://docs.slack.dev/reference/methods/chat.update) say `parse` "Defaults to `client`, unlike `chat.postMessage`", and also that "If you do not specify a value for this field, the original value set for the message will be overwritten with the default" — so omitting it does not inherit what the message was posted with.

## Verified on a real workspace

v0.9.0 from source against browser (xoxc/xoxd) auth, in a DM, same text every time, reading `text` back with `conversations.history`:

| step | stored `text` |
|---|---|
| posted with `chat.postMessage` | `<https://example.com\|labelled link>` |
| edited by v0.9.0 (no `parse`) | `&lt;https://example.com\|labelled link&gt;` |
| edited with `parse: 'none'` | `<https://example.com\|labelled link>` |

Two details from the repro worth having on record:

- The corruption does not compound. Editing three more times leaves it at `&lt;…&gt;` rather than escaping the `&`, so a message is broken once and stays that way. It does not self-heal either — text posted as a link never becomes a link again without a corrected edit.
- `<@U…>` mentions came through all three steps intact, so this is specifically the `<url|label>` markup, not user references. `link_names` also defaults to `none` on `chat.update` per the docs; I left it alone since nothing in this repro needed it.

## Tests

`src/lib/slack-client.test.ts`: the existing `updateMessage` assertion now includes `parse: 'none'` in the expected params, plus one case named for the failure it prevents. The test double records `{method, params}`, so it pins the wire call — which is where the bug was.

`bun test` 405 pass / 0 fail, `bun run type-check` clean. `pre-commit` is not installed on this machine, so those hooks ran only in the form CI runs them.

## Not covered

`chat.postMessage` is untouched: its `parse` default is already `none`, and the repro confirms posted text arrives unescaped.