### PR TITLE
chore: release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-08-21
+
+### Fixed
+- **Editing a message no longer destroys its links**: `messages edit` now sends `parse=none` on `chat.update`, so `<https://example.com|labelled link>` survives an edit instead of being rewritten to escaped literal text (#106)
+  - `chat.update` defaults `parse` to `client`, unlike `chat.postMessage`, and omitting the field overwrites the value the message was posted with — it does not inherit it
+  - A message broken by an earlier edit stays broken until it is edited again with a fixed build; mentions (`<@U…>`) were never affected
+
+### Security
+- **`update` verifies the downloaded binary before installing it**: the release asset is hashed and checked against the `sha256` digest GitHub publishes for it, before anything is written to disk (#104)
+  - Fails closed — a missing digest, or one that is not `sha256`, aborts the update and tells the user how to install by hand
+  - The download is now staged in a `mkdtemp` directory (created 0700, never reusing a path) instead of the predictable `slackcli-update-${Date.now()}` path, and is removed on every exit path
+
 ## [0.9.0] - 2026-08-16
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slackcli",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A fast, developer-friendly CLI tool for interacting with Slack workspaces",
   "main": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
Cuts **v0.9.1** — a patch release carrying the two user-facing fixes that have been sitting on `main` since `v0.9.0`.

`release.yml` fails when the pushed tag disagrees with `package.json` (#82), so this bump has to be merged **before** `v0.9.1` is tagged.

## Included since v0.9.0

| Change | Issue / PR |
|---|---|
| `messages edit` no longer destroys links — `chat.update` now sends `parse=none` | #106 / #120 |
| `update` verifies the downloaded binary's `sha256` digest before installing, and stages via `mkdtemp` | #104 / #119 |

Not shipping: `ci:` workflow repairs (#116 / #117) — no CLI behaviour changes.

Both are fixes, no new commands, flags, or accepted input formats — hence patch, not minor.

## Changes in this PR

- `package.json` — `version` `0.9.0` → `0.9.1`.
- `CHANGELOG.md` — new `## [0.9.1] - 2026-08-21` section, `[Unreleased]` left in place and empty.

Both entries are **backfilled**: `[Unreleased]` was empty, so neither fix was recorded in the changelog when it merged. The `update` fix is filed under `### Security` since it closes a hole in the install path rather than fixing a malfunction.

## Checks

- `bun run type-check` — clean
- `bun test` — 413 pass / 0 fail
- `pre-commit` hooks — passed
- commit is signed

## After merge

```bash
git checkout main && git pull
git tag -a v0.9.1 -m "Release v0.9.1"
git push origin v0.9.1
```

The tag must land on the merged bump commit, otherwise `verify-version` fails immediately.

Closes #122
