### PR TITLE
docs: embed the product demo video in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@
 
 A fast, developer-friendly command-line interface tool for interacting with Slack workspaces. Built with TypeScript and Bun, it enables AI agents, automation tools, and developers to access Slack functionality directly from the terminal.
 
+## Demo
+
+Sign in, browse conversations, search the workspace, read a thread from a permalink, reply, react, read a canvas as Markdown, and pipe `--json` into `jq` — all from the terminal.
+
+https://github.com/user-attachments/assets/90cf1c89-2859-4b84-a731-b0ff3e1172f3
+
 ## Features
 
 - 🔐 **Dual Authentication Support**: Standard Slack tokens (xoxb/xoxp) or browser tokens (xoxd/xoxc)


### PR DESCRIPTION
Closes #125

Adds a `## Demo` section to the README, between the intro paragraph and **Features**, embedding a 78s product demo video.

## What the video shows

An animated terminal typing real `slackcli` commands and painting their real output across 13 scenes: install, `auth login-auto`, `auth list` (multiple workspaces + named profiles), `conversations list`, `search messages`, `conversations read --permalink`, `messages send`, `messages react`, `canvas read`, `conversations unread --workspace`, and `search messages --json | jq`. It closes on the install command and the repo URL.

1920×1080, 30fps, quiet music bed, **no narration** — fully legible on mute.

## Why

The README explains the CLI well but never *shows* it. Today a reader has to install a binary and authenticate against a real Slack workspace before seeing a single line of output — a lot to ask before knowing whether the tool fits their problem.

The demo also carries things prose does not: that output is colour-coded and grouped, that permalinks work anywhere an ID does, that `--json` gives clean stdout for agents and scripts, and that multiple workspaces are first-class.

## Zero repo weight

Hosted as a GitHub user-attachment and embedded by URL rather than committed. The repo's `.git` is ~3.6 MB, so a 4.9 MB MP4 would have **more than doubled clone size permanently** — and git keeps the blob even if the file is later deleted.

An earlier revision of this branch did commit it to `docs/`; that was rewritten out (force-push, not a delete commit) so the blob never enters history. The MP4 never reached `main`.

**Diff is +6 / -0 lines, no binary.**

## Accuracy

Every command, flag and output line in the demo was verified against this repo's source before rendering — commands from `src/commands/*.ts`, output shapes from `src/lib/formatter.ts`, and the `✔ …` lines from the actual `ora` `spinner.succeed()` strings.

An early draft invented `auth login --browser` and `messages send --text`, and mislabelled the `conversations read` header (it prints the channel **ID**, since `formatConversationHistory` is called with `channelId`). All three were corrected against the source. Nothing on screen is a flag the CLI does not have.

## Maintenance

The source that produces the video — a deterministic self-contained HTML page plus its renderer — lives in `shaharia-lab/digital-marketing-assets` under `slackcli-demo/`, so re-rendering after a UI change adds no tooling to this repo.