### PR TITLE
docs: add a docs/ directory with a user guide and developer documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,466 +91,134 @@ bun install
 bun run build
 ```
 
+
+## Documentation
+
+Full documentation lives in [`docs/`](docs/README.md).
+
+**User guide** — [installation](docs/user-guide/installation.md) ·
+[authentication](docs/user-guide/authentication.md) ·
+[workspaces & profiles](docs/user-guide/workspaces.md) ·
+[Slack links & timestamps](docs/user-guide/links-and-timestamps.md) ·
+[conversations](docs/user-guide/conversations.md) ·
+[messages](docs/user-guide/messages.md) ·
+[search](docs/user-guide/search.md) ·
+[saved items](docs/user-guide/saved.md) ·
+[canvas](docs/user-guide/canvas.md) ·
+[scripting & JSON](docs/user-guide/scripting.md) ·
+[troubleshooting](docs/user-guide/troubleshooting.md)
+
+**Developer docs** — [setup](docs/development/setup.md) ·
+[architecture](docs/development/architecture.md) ·
+[project structure](docs/development/project-structure.md) ·
+[testing](docs/development/testing.md) ·
+[build & release](docs/development/build-and-release.md) ·
+[adding a command](docs/development/adding-a-command.md)
+
 ## Authentication
 
-SlackCLI supports two authentication methods:
-
-### 1. Standard Slack App Tokens (Recommended for Production)
-
-Create a Slack app at [api.slack.com/apps](https://api.slack.com/apps) and obtain a bot token (xoxb-*) or user token (xoxp-*).
+SlackCLI works with two kinds of credentials: **standard** Slack app tokens
+(`xoxb-*` / `xoxp-*`) and **browser** session tokens (`xoxd-*` + `xoxc-*`). There
+are four ways to get signed in:
 
 ```bash
-slackcli auth login --token=xoxb-YOUR-TOKEN --workspace-name="My Team"
-```
-
-### 2. Automatic Browser Login (Easiest)
-
-Sign into Slack in a browser and let SlackCLI capture the tokens. No Slack app, no DevTools, no copy-paste.
-
-```bash
+# 1. Automatic browser login (easiest) — sign in once, every workspace enrolled
 slackcli auth login-auto
-```
 
-A browser window opens on Slack. Sign in as you normally would, and SlackCLI enrols **every workspace you are signed into** — one sign-in covers them all.
+# 2. Standard Slack app token
+slackcli auth login --token=xoxb-YOUR-TOKEN --workspace-name="My Team"
 
-| Option | Purpose |
-|---|---|
-| `--workspace-url <url>` | Open a specific workspace instead of the Slack home |
-| `--timeout <seconds>` | How long to wait for sign-in (default `300`) |
-| `--headless` | No visible window — only works once you are already signed in |
-| `SLACKCLI_BROWSER` | Path to a browser, if yours is not auto-detected |
-| `SLACKCLI_BROWSER_PROFILE` | Override the profile directory |
-
-**Requirements:** Chrome, Edge, Chromium, or Brave installed. Nothing is downloaded and no extra dependency is installed — SlackCLI drives the browser you already have.
-
-**Why you sign in again the first time.** SlackCLI runs the browser against its own profile in `~/.config/slackcli/browser-profile`, separate from your everyday browsing. It has to: since Chrome 136 the browser refuses remote debugging against the default profile, so your existing session cannot be reused. The profile persists, so **only the first run needs interaction** — after that the window opens and closes on its own.
-
-**Security notes.**
-
-- Token values are never printed.
-- **The browser profile is a credential store.** While it exists, `login-auto` can re-mint working tokens with no prompt. `slackcli auth logout` therefore deletes it along with `workspaces.json`; pass `--keep-browser-session` to keep it signed in.
-- Only `https://` URLs on a `slack.com` host are ever paired with your session cookie — a URL read from the browser that points anywhere else is refused.
-- While the browser is open it exposes a DevTools port on loopback that any local process could connect to. SlackCLI closes the browser as soon as capture finishes, and also on `Ctrl-C` or termination.
-- Credentials land in `~/.config/slackcli/workspaces.json` (mode `0600`); the profile directory is `0700` on macOS and Linux (Windows uses ACL defaults).
-
-### 3. Browser Session Tokens (Manual)
-
-Extract tokens from your browser session by hand. No Slack app creation required!
-
-```bash
-# Step 1: Get extraction guide
-slackcli auth extract-tokens
-
-# Step 2: Login with extracted tokens
-slackcli auth login-browser \
-  --xoxd=xoxd-YOUR-TOKEN \
-  --xoxc=xoxc-YOUR-TOKEN \
-  --workspace-url=https://yourteam.slack.com
-```
-
-**How to Extract Browser Tokens:**
-
-1. Open your Slack workspace in a web browser
-2. Open Developer Tools (F12)
-3. Go to Network tab
-4. Send a message or refresh
-5. Find a Slack API request
-6. Extract:
-   - `xoxd` token from Cookie header (d=xoxd-...)
-   - `xoxc` token from request payload ("token":"xoxc-...")
-
-### 4. Parse cURL Command
-
-The easiest way to extract browser tokens is to copy a Slack API request as cURL and let SlackCLI parse it automatically!
-
-```bash
-# Step 1: In browser DevTools, right-click any Slack API request
-#         → Copy → Copy as cURL
-
-# Step 2: Interactive mode (recommended) - just paste and press Enter twice
+# 3. Parse a cURL command copied from browser DevTools
 slackcli auth parse-curl --login
 
-# Alternative: Read directly from clipboard
-slackcli auth parse-curl --from-clipboard --login
-
-# Alternative: Pipe from clipboard or file
-pbpaste | slackcli auth parse-curl --login
-cat curl-command.txt | slackcli auth parse-curl --login
+# 4. Browser session tokens by hand
+slackcli auth extract-tokens          # prints the guide
+slackcli auth login-browser --xoxd=xoxd-... --xoxc=xoxc-... --workspace-url=https://yourteam.slack.com
 ```
 
-This automatically extracts:
-- Workspace URL and name
-- xoxd token from cookies
-- xoxc token from request data
+Which to pick, what `login-auto` does with your browser profile, the security
+model, and the OAuth scopes each command needs are all in the
+[authentication guide](docs/user-guide/authentication.md).
 
-## Usage
-
-### Authentication Commands
+## Quick tour
 
 ```bash
-# Sign in via a browser; tokens are captured automatically
-slackcli auth login-auto
-
-# Refresh tokens later without any interaction (profile stays signed in)
-slackcli auth login-auto --headless
-
-# List all authenticated workspaces
-slackcli auth list
-
-# Set default workspace
-slackcli auth set-default T1234567
-
-# Remove a workspace
-slackcli auth remove T1234567
-
-# Logout from all workspaces (also clears the login-auto browser profile)
-slackcli auth logout
-
-# Logout but keep the browser signed in
-slackcli auth logout --keep-browser-session
-```
-
-### Multiple Profiles for One Workspace
-
-By default each Slack workspace is stored once. To keep **more than one identity
-for the same workspace** — for example a browser-authenticated user for search
-and drafts alongside a bot token for unattended jobs — give each login a
-`--profile` name:
-
-```bash
-# A user identity (browser auth)
-slackcli auth login-browser \
-  --xoxd=xoxd-... --xoxc=xoxc-... \
-  --workspace-url=https://example.slack.com \
-  --profile=rafael
-
-# A bot identity in the same workspace
-slackcli auth login \
-  --token=xoxb-... \
-  --workspace-name=example \
-  --profile=automation-bot
-```
-
-Select a profile anywhere `--workspace` is accepted:
-
-```bash
-slackcli search messages "after:2026-07-01" --workspace=rafael --json
-slackcli messages send --recipient-id=C123 --message="Done" --workspace=automation-bot
-```
-
-Notes:
-
-- **Backward compatible.** Existing `workspaces.json` files and single-identity
-  setups keep working unchanged — `--profile` is optional.
-- Re-authenticating the **same** identity refreshes its stored tokens in place.
-- Logging in a **second** identity for a workspace **without** `--profile` is
-  saved under an auto-generated key (e.g. `T123-2`) instead of overwriting the
-  first. The chosen key is printed after login.
-- `auth list`, `auth set-default`, and `auth remove` accept a profile name,
-  workspace ID, or workspace name. If a bare workspace ID/name matches more than
-  one profile, SlackCLI asks you to pick a profile instead of guessing.
-
-### Slack Links and Timestamps
-
-Anywhere the CLI takes a channel, user, or canvas ID, you can paste the Slack URL
-instead — the form "Copy link" actually gives you:
-
-```bash
-# These are equivalent
-slackcli conversations read C1234567890
-slackcli conversations read https://myteam.slack.com/archives/C1234567890
-```
-
-| Pasted value | Understood as |
-|---|---|
-| `https://myteam.slack.com/archives/C1234567890` | channel `C1234567890` |
-| `https://myteam.slack.com/archives/D0987654321` | DM `D0987654321` |
-| `https://myteam.slack.com/team/U9876543210` | user `U9876543210` |
-| `https://myteam.slack.com/docs/T012AB/F1234567890` | canvas `F1234567890` |
-
-Timestamps work the same way — the permalink form is accepted wherever the dotted
-API form is:
-
-| Pasted value | Understood as |
-|---|---|
-| `p1234567890123456` | `1234567890.123456` |
-| `1234567890123456` | `1234567890.123456` |
-| `1234567890.123456` | unchanged |
-
-For commands that target one specific message, `--permalink` replaces the channel
-and timestamp in one go:
-
-```bash
-# Instead of this
-slackcli messages react --channel-id=C1234567890 --timestamp=1234567890.123456 --emoji=heart
-
-# Just paste the link
-slackcli messages react --permalink="https://myteam.slack.com/archives/C1234567890/p1234567890123456" --emoji=heart
-```
-
-`--permalink` is available on `messages send`, `messages react`, `messages edit`,
-`messages draft`, `conversations read`, and `conversations get`. Pass either
-`--permalink` or the explicit inputs, not both. When the link points at a threaded
-reply, `--thread-ts` consumers correctly use the *parent* message.
-
-Bare IDs and dotted timestamps keep working exactly as before.
-
-### Conversation Commands
-
-```bash
-# List all conversations
-slackcli conversations list
-
-# List only public channels
+# Conversations
 slackcli conversations list --types=public_channel
-
-# List DMs
-slackcli conversations list --types=im
-
-# Read recent messages from a channel
-slackcli conversations read C1234567890
-
-# Read a specific thread
-slackcli conversations read C1234567890 --thread-ts=1234567890.123456
-
-# Read with custom limit
 slackcli conversations read C1234567890 --limit=50
+slackcli conversations unread
 
-# Get JSON output (includes ts and thread_ts for replies)
-slackcli conversations read C1234567890 --json
-
-# Read the thread a message link points at
-slackcli conversations read --permalink="https://myteam.slack.com/archives/C1234567890/p1234567890123456"
-
-# Get one specific message from its link
-slackcli conversations get --permalink="https://myteam.slack.com/archives/C1234567890/p1234567890123456"
-```
-
-### Message Commands
-
-```bash
-# Send message to a channel
+# Messages — paste a Slack link instead of juggling IDs
 slackcli messages send --recipient-id=C1234567890 --message="Hello team!"
+slackcli messages send --permalink="https://myteam.slack.com/archives/C123/p1234567890123456" --message="On it"
+slackcli messages react --permalink="$LINK" --emoji=+1
+slackcli messages edit --channel-id=C123 --timestamp=1234567890.123456 --message="Corrected"
 
-# Send DM to a user
-slackcli messages send --recipient-id=U9876543210 --message="Hey there!"
-
-# Reply to a thread
-slackcli messages send --recipient-id=C1234567890 --thread-ts=1234567890.123456 --message="Great idea!"
-
-# Send a message with a file attachment
-slackcli messages send --recipient-id=C1234567890 --message="Here is the file" --file=./report.pdf
-
-# Send a native Block Kit table (not a Markdown or CSV code block)
-slackcli messages send \
-  --recipient-id=C1234567890 \
-  --message="Project status table" \
-  --blocks='[
-    {
-      "type": "table",
-      "column_settings": [{"is_wrapped": true}, {"align": "right"}],
-      "rows": [
-        [
-          {
-            "type": "rich_text",
-            "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": "Project", "style": {"bold": true}}]}]
-          },
-          {
-            "type": "rich_text",
-            "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": "Status", "style": {"bold": true}}]}]
-          }
-        ],
-        [
-          {
-            "type": "rich_text",
-            "elements": [{"type": "rich_text_section", "elements": [{"type": "link", "text": "SlackCLI", "url": "https://github.com/shaharia-lab/slackcli"}]}]
-          },
-          {"type": "raw_text", "text": "Ready"}
-        ]
-      ]
-    }
-  ]'
-
-# Send standard Markdown for Slack to render natively
-slackcli messages send \
-  --recipient-id=C1234567890 \
-  --message="Release notes" \
-  --blocks='[{"type":"markdown","text":"# Release notes\n\n- [x] Build\n- [ ] Deploy\n\nSee the [runbook](https://example.com/runbook)."}]'
-
-# Edit an existing message you posted
-slackcli messages edit --channel-id=C1234567890 --timestamp=1234567890.123456 --message="Corrected message"
-
-# Create a draft message in a channel (only works with browser session tokens)
-slackcli messages draft --recipient-id=C1234567890 --message="Hello team!"
-
-# Add emoji reaction to a message
-slackcli messages react --channel-id=C1234567890 --timestamp=1234567890.123456 --emoji=+1
-
-# More reaction examples
-slackcli messages react --channel-id=C1234567890 --timestamp=1234567890.123456 --emoji=heart
-slackcli messages react --channel-id=C1234567890 --timestamp=1234567890.123456 --emoji=fire
-slackcli messages react --channel-id=C1234567890 --timestamp=1234567890.123456 --emoji=eyes
-
-# Target a message by its permalink instead of channel + timestamp
-slackcli messages react --permalink="https://myteam.slack.com/archives/C1234567890/p1234567890123456" --emoji=+1
-slackcli messages edit --permalink="https://myteam.slack.com/archives/C1234567890/p1234567890123456" --message="Corrected message"
-
-# Reply in the thread a link points at
-slackcli messages send --permalink="https://myteam.slack.com/archives/C1234567890/p1234567890123456" --message="Great idea!"
-```
-
-File uploads require Slack workspace permissions that allow file upload, such as `files:write` for standard Slack app tokens.
-
-`--blocks` accepts a JSON array of [Block Kit blocks](https://docs.slack.dev/reference/block-kit/blocks/), including native [`table` blocks](https://docs.slack.dev/reference/block-kit/blocks/table-block/) and [`markdown` blocks](https://docs.slack.dev/reference/block-kit/blocks/markdown-block/). Native markdown blocks use standard Markdown rather than Slack mrkdwn and support features such as headings, task lists, syntax-highlighted code blocks, and Markdown tables. Pass JSON inline as above, or store the array in a file and use `--blocks=@blocks.json`. The required `--message` text is used as the notification and accessibility fallback. Structured blocks work with both standard Slack tokens and browser-session authentication. `--blocks` and `--file` cannot be used together.
-
-Editing only works on messages posted by the authenticated user or app; ephemeral messages cannot be edited.
-
-**Common emoji names:**
-- `+1` or `thumbsup` - 👍
-- `heart` - ❤️
-- `fire` - 🔥
-- `eyes` - 👀
-- `tada` - 🎉
-- `rocket` - 🚀
-
-### Canvas Commands
-
-```bash
-# List canvases in the workspace
-slackcli canvas list
-slackcli canvas list --limit=50
-slackcli canvas list --channel=C1234567890
-
-# Read canvas content as markdown
+# Search, saved items, canvases
+slackcli search messages "deploy failed" --in=engineering
+slackcli saved list --state=to_do
 slackcli canvas read F1234567890
 
-# Read canvas in JSON format (includes markdown field)
-slackcli canvas read F1234567890 --json
+# Anything that returns data speaks JSON
+slackcli conversations read C1234567890 --json | jq '.messages[].text'
 
-# Read raw HTML (no conversion)
-slackcli canvas read F1234567890 --raw
-
-# Read the canvas associated with a channel
-slackcli canvas read --channel=C1234567890
-
-# Read a canvas from its Slack URL
-slackcli canvas read https://myteam.slack.com/docs/T012AB/F1234567890
+# Several workspaces, or several identities in one workspace
+slackcli conversations list --workspace=automation-bot
 ```
 
-### Update Commands
-
-```bash
-# Check for updates
-slackcli update check
-
-# Update to latest version
-slackcli update
-```
-
-### Multi-Workspace Usage
-
-```bash
-# Use specific workspace by ID
-slackcli conversations list --workspace=T1234567
-
-# Use specific workspace by name
-slackcli conversations list --workspace="My Team"
-```
+`slackcli <group> --help` prints the authoritative options for your version. For
+everything else — Block Kit tables and Markdown blocks, file uploads, drafts,
+pagination, profiles — see the [user guide](docs/user-guide/README.md).
 
 ## Configuration
 
-Configuration is stored in `~/.config/slackcli/`:
+Configuration lives in `~/.config/slackcli/` (directory mode `0700`):
 
-- `workspaces.json` - Workspace credentials
-- `config.json` - User preferences (future)
+| File | Contents |
+|---|---|
+| `workspaces.json` | Workspace credentials (mode `0600`) |
+| `update-check.json` | Cached update check, refreshed at most daily |
+| `browser-profile/` | The browser profile used by `auth login-auto` |
+
+`workspaces.json` and `browser-profile/` both hold live credentials — do not
+commit, sync, or share them. `slackcli auth logout` clears both.
 
 ## Development
 
-### Prerequisites
-
-- Bun v1.0+
-- TypeScript 5.x+
-
-### Setup
-
 ```bash
-# Install dependencies
 bun install
-
-# Run in development mode
-bun run dev --help
-
-# Build binary
-bun run build
-
-# Build for all platforms
-bun run build:all
-
-# Type check
-bun run type-check
+pre-commit install          # enforces the same checks CI runs
+bun run dev --help          # run from source
+bun test                    # tests
+bun run type-check          # bunx tsc --noEmit
+bun run build               # ./dist/slackcli
 ```
 
-### Project Structure
-
-```
-slackcli/
-├── src/
-│   ├── index.ts              # CLI entry point
-│   ├── commands/             # Command implementations
-│   │   ├── auth.ts
-│   │   ├── conversations.ts
-│   │   ├── messages.ts
-│   │   └── update.ts
-│   ├── lib/                  # Core library
-│   │   ├── auth.ts
-│   │   ├── workspaces.ts
-│   │   ├── slack-client.ts
-│   │   ├── formatter.ts
-│   │   └── updater.ts
-│   └── types/                # Type definitions
-│       └── index.ts
-├── .github/workflows/        # CI/CD
-└── dist/                     # Build output
-```
+See the [developer docs](docs/development/README.md) for the architecture, the
+project layout, testing conventions, and the release process.
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+Contributions are welcome, and the process is a little stricter than most repos:
 
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+1. **Open an issue first**, describing WHAT the change is, WHY it is needed, and
+   optionally HOW.
+2. **Wait for the `ready-for-pr` label.** This is how the maintainer decides
+   which features belong in the CLI, and it locks the feature to your PR.
+3. Fork, branch, and open a pull request that **links the issue**. A workflow
+   enforces the link.
+4. Make sure type-check, tests, and pre-commit hooks pass, and that your commits
+   are signed.
+
+The full policy is in [CONTRIBUTING.md](CONTRIBUTING.md) and
+[CLAUDE.md](CLAUDE.md). Security issues go through [SECURITY.md](SECURITY.md),
+never a public issue.
 
 ## Troubleshooting
 
-### Authentication Issues
-
-**Standard Tokens:**
-- Ensure your token has the required OAuth scopes
-- Check token validity in your Slack app settings
-
-**Browser Tokens:**
-- Tokens expire with your browser session
-- Extract fresh tokens if authentication fails
-- Verify workspace URL format (https://yourteam.slack.com)
-
-### Permission Errors
-
-If you get permission errors when accessing conversations or sending messages:
-- Verify your bot/user has been added to the channel
-- Check OAuth scopes include required permissions
-- For browser tokens, ensure you have access in the web UI
-
-### Update Issues
-
-If installed via Homebrew, use `brew upgrade slackcli` instead of `slackcli update`.
-
-If `slackcli update` fails:
-- Ensure you have write permissions to the binary location
-- Try running with sudo if installed system-wide
-- Consider installing to user directory (~/.local/bin) instead
+Common problems — expired tokens, missing OAuth scopes, permission errors,
+`login-auto` not finding a browser, update failures — are covered in the
+[troubleshooting guide](docs/user-guide/troubleshooting.md).
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,49 @@
+# SlackCLI Documentation
+
+SlackCLI is an unofficial command-line interface for Slack workspaces, built with
+TypeScript and Bun. It talks to Slack either through a standard Slack app token
+or through the tokens a signed-in browser session already holds — so you can
+automate Slack without creating a Slack app.
+
+> **Disclaimer:** not affiliated with, endorsed by, or supported by Slack
+> Technologies. Slack has an [official CLI](https://docs.slack.dev/tools/slack-cli/).
+
+## User guide
+
+Start here if you want to *use* SlackCLI.
+
+| Page | What it covers |
+|---|---|
+| [Installation](user-guide/installation.md) | Homebrew, pre-built binaries, from source, updating |
+| [Authentication](user-guide/authentication.md) | The four ways to sign in, and which one to pick |
+| [Workspaces and profiles](user-guide/workspaces.md) | Several workspaces, several identities per workspace |
+| [Slack links and timestamps](user-guide/links-and-timestamps.md) | Paste a Slack URL anywhere an ID is expected |
+| [Conversations](user-guide/conversations.md) | List channels and DMs, read history, threads, unreads |
+| [Messages](user-guide/messages.md) | Send, reply, edit, react, draft, attach files, Block Kit |
+| [Search](user-guide/search.md) | Search messages, channels, and people |
+| [Saved items](user-guide/saved.md) | Read your "saved for later" list |
+| [Canvas](user-guide/canvas.md) | List canvases and read them as Markdown |
+| [Scripting and JSON output](user-guide/scripting.md) | Piping into `jq`, exit codes, automation patterns |
+| [Troubleshooting](user-guide/troubleshooting.md) | Auth failures, permissions, update problems |
+
+## Developer documentation
+
+Start here if you want to *work on* SlackCLI.
+
+| Page | What it covers |
+|---|---|
+| [Development setup](development/setup.md) | Toolchain, pre-commit hooks, the everyday loop |
+| [Architecture](development/architecture.md) | How the pieces fit: commands, client, auth, storage |
+| [Project structure](development/project-structure.md) | What each file in `src/` is responsible for |
+| [Testing](development/testing.md) | Test layout, conventions, and how to write a good one |
+| [Build and release](development/build-and-release.md) | Version injection, CI, tagging, Homebrew tap |
+| [Adding a command](development/adding-a-command.md) | A worked example, end to end |
+
+## Contributing
+
+Read [CONTRIBUTING.md](../CONTRIBUTING.md) before opening a pull request. In
+short: **every PR needs a linked GitHub issue, and that issue must carry the
+`ready-for-pr` label.** The full policy — which is binding on human and AI
+contributors alike — lives in [CLAUDE.md](../CLAUDE.md).
+
+For security reports, follow [SECURITY.md](../SECURITY.md).

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,0 +1,49 @@
+# Developer documentation
+
+## Start here
+
+```bash
+git clone https://github.com/shaharia-lab/slackcli.git
+cd slackcli
+bun install
+pre-commit install          # do not skip this
+bun run dev --help
+```
+
+## Pages
+
+| Page | What it covers |
+|---|---|
+| [Development setup](setup.md) | Toolchain, pre-commit hooks, signed commits, the everyday loop |
+| [Architecture](architecture.md) | Dual auth, `SlackClient` dispatch, workspace storage, browser capture |
+| [Project structure](project-structure.md) | What each file in `src/` is responsible for |
+| [Testing](testing.md) | Layout, conventions, and how to write a test that belongs here |
+| [Build and release](build-and-release.md) | Version injection, CI, tagging, Homebrew tap |
+| [Adding a command](adding-a-command.md) | A worked example, end to end |
+
+## The short version
+
+- **TypeScript on Bun.** No transpile step in development — `bun run dev` runs
+  the source. Ships as a single compiled binary per platform.
+- **Commands parse and print; `src/lib/` does the work.** If something is worth
+  testing, it does not belong in `src/commands/`.
+- **Two auth types, one seam.** `SlackClient.request()` dispatches to the Slack
+  SDK or to raw `fetch` based on `auth_type`. Add API calls there.
+- **Four dependencies** (`@slack/web-api`, `commander`, `chalk`, `ora`) and a
+  150 MB binary budget. New dependencies need a real justification.
+
+## Before opening a pull request
+
+This repository's contribution policy is stricter than most and is binding on
+human and AI contributors alike:
+
+1. **An issue must exist first**, stating WHAT, WHY, and optionally HOW.
+2. **The issue must carry the `ready-for-pr` label** before a PR is opened.
+3. The PR must link that issue — a workflow enforces it.
+4. Type-check, tests, and pre-commit hooks pass; commits are signed.
+
+Full text: [CONTRIBUTING.md](../../CONTRIBUTING.md), and the constitution at the
+top of [CLAUDE.md](../../CLAUDE.md).
+
+Security issues go through [SECURITY.md](../../SECURITY.md), never a public
+issue.

--- a/docs/development/adding-a-command.md
+++ b/docs/development/adding-a-command.md
@@ -1,0 +1,140 @@
+# Adding a command
+
+A worked example: adding `slackcli conversations members <channel-id>`.
+
+Before writing anything, satisfy the policy: open an issue describing WHAT, WHY
+and optionally HOW, and wait for the **`ready-for-pr`** label. See
+[CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## 1. Types first
+
+`src/types/index.ts` — model the data instead of passing `any` around.
+
+```ts
+export interface ChannelMember {
+  id: string;
+  name?: string;
+  real_name?: string;
+  is_bot?: boolean;
+}
+```
+
+## 2. Add the API call to `SlackClient`
+
+`src/lib/slack-client.ts`. Go through `this.request()` so both auth types work
+for free:
+
+```ts
+async listConversationMembers(channel: string, options: {
+  cursor?: string;
+  limit?: number;
+} = {}): Promise<any> {
+  const params: Record<string, any> = { channel };
+  if (options.cursor) params.cursor = options.cursor;
+  if (options.limit) params.limit = options.limit;
+  return this.request('conversations.members', params);
+}
+```
+
+Only branch on `this.config.auth_type` if Slack genuinely offers different
+endpoints for the two. If it does, document the divergence in the method, in
+`--help`, and in the [user guide](../user-guide/README.md).
+
+## 3. Put the logic in `src/lib/`
+
+If the command needs more than one call — here, resolving member IDs to names —
+that belongs in a lib module, not the command file. It keeps the command thin
+and makes the logic testable.
+
+```ts
+// src/lib/members.ts
+export async function fetchChannelMembers(
+  client: SlackClient,
+  channelId: string,
+  options: { limit?: number; onProgress?: (message: string) => void } = {},
+): Promise<ChannelMember[]> { /* … */ }
+```
+
+The `onProgress` callback is the house convention for feeding spinner text back
+to the command layer without the lib knowing about `ora` — see `unread.ts` and
+`saved.ts`.
+
+## 4. Add a formatter
+
+`src/lib/formatter.ts`, next to its siblings:
+
+```ts
+export function formatChannelMembers(members: ChannelMember[]): string { /* … */ }
+```
+
+## 5. Wire up the command
+
+`src/commands/conversations.ts`:
+
+```ts
+conversations
+  .command('members')
+  .description('List the members of a channel')
+  .argument('[channel-id]', 'Channel ID or Slack URL')
+  .option('--limit <number>', 'Number of members to return', '100')
+  .option('--workspace <id|name>', 'Workspace to use')
+  .option('--json', 'Output in JSON format', false)
+  .action(async (channelIdArg, options) => {
+    const spinner = ora('Fetching members...').start();
+    try {
+      const channelId = normalizeIdentifier(channelIdArg, 'channel', '<channel-id>');
+      const client = await getAuthenticatedClient(options.workspace);
+      warnOnWorkspaceMismatch(client, workspaceOf(channelIdArg));
+
+      const members = await fetchChannelMembers(client, channelId, {
+        limit: parseInt(options.limit),
+        onProgress: (msg) => { spinner.text = msg; },
+      });
+
+      spinner.succeed(`Found ${members.length} members`);
+
+      if (options.json) {
+        writeJson({ channel_id: channelId, member_count: members.length, members });
+        return;                          // never process.exit() after writeJson
+      }
+      console.log('\n' + formatChannelMembers(members));
+    } catch (err: any) {
+      spinner.fail('Failed to fetch members');
+      error(err.message);
+      process.exit(1);
+    }
+  });
+```
+
+A new **group** (rather than a subcommand) also needs a
+`create<Group>Command()` factory and a `program.addCommand()` line in
+`src/index.ts`.
+
+## 6. Tests
+
+`src/lib/members.test.ts`, using a `SlackClient` subclass that overrides
+`request()` and records calls. Cover both auth types if the method branches. See
+[testing](testing.md).
+
+## 7. Documentation
+
+Update the relevant page under `docs/user-guide/`, and the README if the feature
+belongs in the overview. A command that ships undocumented is not finished.
+
+## Checklist
+
+Conventions this codebase holds to — deviating from any of them will come up in
+review:
+
+- [ ] Accept a Slack URL wherever an ID is accepted (`normalizeIdentifier`), and
+      warn on workspace mismatch.
+- [ ] Support `--workspace <id|name>`.
+- [ ] Support `--json` on any command that returns data.
+- [ ] **Never call `process.exit()` after `writeJson()`** — set
+      `process.exitCode` and return. See
+      [architecture](architecture.md#output).
+- [ ] Spinner via `ora`; libs report progress through an `onProgress` callback.
+- [ ] Errors: `spinner.fail(...)`, `error(message)`, `process.exit(1)`.
+- [ ] Never print a token value.
+- [ ] `bun run type-check` and `bun test` pass; commits are signed.
+- [ ] The PR links a `ready-for-pr` issue.

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -1,0 +1,176 @@
+# Architecture
+
+SlackCLI is a thin, layered CLI. The shape is deliberately boring: commands
+parse and print, libraries do the work, and exactly one class knows how to talk
+to Slack.
+
+```
+src/index.ts                 Commander program; registers 7 command groups
+        │
+        ▼
+src/commands/*.ts            Parse flags, call lib, format output, set exit code
+        │
+        ▼
+src/lib/*.ts                 All logic: client, auth, storage, parsers, formatting
+        │
+        ▼
+src/types/index.ts           Shared interfaces
+```
+
+**The rule that keeps it navigable:** command files contain no Slack knowledge
+and no business logic beyond argument handling. Anything testable lives in
+`src/lib/`, which is why the lib modules have thorough unit tests and the
+command files have very few.
+
+## Dual authentication
+
+Two credential kinds coexist everywhere, and the split is the single most
+important thing to understand about this codebase.
+
+| | Standard | Browser |
+|---|---|---|
+| Tokens | `xoxb-*` / `xoxp-*` | `xoxd-*` cookie + `xoxc-*` token |
+| Transport | `@slack/web-api` `WebClient` | raw `fetch` to `<workspace_url>/api/<method>` |
+| Auth carried by | SDK bearer token | `Cookie: d=<urlencoded xoxd>` + `token` form field |
+| Discriminated by | `config.auth_type === 'standard'` | `config.auth_type === 'browser'` |
+
+`SlackClient.request()` in `src/lib/slack-client.ts` is the fork:
+
+```ts
+async request(method: string, params = {}) {
+  return this.config.auth_type === 'standard'
+    ? this.standardRequest(method, params)
+    : this.browserRequest(method, params);
+}
+```
+
+Everything above it — every `listConversations`, `postMessage`, `searchMessages`
+— is auth-agnostic and goes through `request()`. **New API calls belong there,
+not in a command file.**
+
+### Where the two genuinely diverge
+
+A handful of methods branch on `authType` because Slack itself offers different
+endpoints. Each divergence is one method, and each is a deliberate trade:
+
+| Method | Browser | Standard |
+|---|---|---|
+| `createDraft` | `drafts.create` | throws — no public API exists |
+| `listSavedItems` | `saved.list` | `stars.list` |
+| `searchModules` | `search.modules` | list + client-side filter (capped at 1000) |
+| `getUnreadCounts` | `client.counts` | `conversations.list` unread fields |
+| `fetchMessage` (`src/lib/message.ts`) | `messages.list` — resolves replies too | `conversations.history` — top-level only |
+
+When you add a feature that only one auth type can support, follow this shape:
+implement the capable path, degrade or fail loudly on the other, and say so in
+the command's `--help` text and in the [user guide](../user-guide/README.md).
+
+## Workspace storage
+
+`src/lib/workspaces.ts` owns `~/.config/slackcli/workspaces.json` (file `0600`
+inside a `0700` directory).
+
+The map key is a **profile key**. Resolution and key derivation are pure
+functions with no I/O — `resolveWorkspace()` and `deriveStorageKey()` — which is
+why they are heavily unit-tested.
+
+- `resolveWorkspace()` tries, in order: exact profile key → explicit `profile`
+  field → workspace ID → workspace name. A selector matching more than one
+  record throws `AmbiguousWorkspaceError` instead of guessing.
+- `deriveStorageKey()` keeps backward compatibility: the first identity for a
+  team is stored under its bare `team_id`, exactly as before profiles existed.
+  Re-authenticating the same identity (team + auth type + `user_id`) refreshes in
+  place; a *different* identity gets `T123-2` rather than overwriting the first.
+
+If you touch either function, assume there are legacy config files in the wild
+that predate the `profile` and `user_id` fields — the tests encode that.
+
+## Authentication flows
+
+`src/lib/auth.ts` orchestrates login and is the only place that decides a token
+is valid.
+
+- `authenticateStandard()` and `authenticateBrowser()` build a temporary config,
+  call `auth.test`, then persist the real `team_id` / `user_id` from the
+  response.
+- `authenticateAuto()` — the `login-auto` flow — deliberately routes
+  verification and persistence back through `authenticateBrowser()`, so a
+  workspace enrolled by the browser is indistinguishable from one added by hand.
+- `getAuthenticatedClient(identifier?)` is what every command calls to get a
+  ready `SlackClient`.
+
+Per-workspace failures in `authenticateAuto()` are collected rather than thrown:
+when several workspaces are captured at once, one stale token must not discard
+the rest.
+
+## Browser token capture (`login-auto`)
+
+Three modules, in order:
+
+1. **`browser-launcher.ts`** — finds a local Chrome/Edge/Chromium/Brave
+   (`SLACKCLI_BROWSER` overrides), launches it against SlackCLI's own profile
+   directory with remote debugging on loopback, and cleans it up.
+2. **`cdp-client.ts`** — a ~200-line Chrome DevTools Protocol client over Bun's
+   WebSocket. Playwright would be the obvious alternative, but SlackCLI ships as
+   a `bun build --compile` binary: bundling Playwright blows the 150 MB CI
+   budget, and an external one cannot be resolved from a downloaded binary at
+   all. The transport edge (`connectCdpSocket`) is kept a few lines long;
+   everything decidable lives in `createCdpSession`, behind a `CdpSocket` seam so
+   it unit-tests without a browser.
+3. **`browser-auth.ts`** — captures the pair. The `xoxc-*` token comes from
+   intercepted API requests (which proves it is live); the `xoxd-*` value comes
+   from the browser's cookie store, because the `d` cookie is `HttpOnly` and page
+   JavaScript cannot read it. It also reads `localConfig_v2` from localStorage to
+   enumerate workspaces the user is signed into but has not opened — that union
+   is why one sign-in enrols every workspace. localStorage is Slack client
+   internals and may change shape without notice, so a failure to read it
+   degrades to whatever interception found rather than failing the run.
+
+Security invariants worth preserving if you work here: only `https://` URLs on a
+`slack.com` host are ever paired with the session cookie, and that check is
+re-done at the point the credential is used rather than being delegated; the
+browser is closed whether or not capture succeeded; and `auth logout` deletes the
+browser profile, because while it exists it can re-mint working tokens with no
+prompt.
+
+## Parsers
+
+Each is dependency-free and pure, so each is directly testable:
+
+| Module | Job |
+|---|---|
+| `curl-parser.ts` | Pull `xoxd`/`xoxc` out of a DevTools cURL command. Handles URL-encoded tokens, `-b` / `--cookie` / `-H 'Cookie:'`, and enterprise Slack URLs. The most thoroughly tested file in the repo — use it as the model for new tests. |
+| `slack-url-parser.ts` | Normalise Slack URLs, permalinks, and timestamps into IDs. Also produces the workspace-mismatch warning. |
+| `mrkdwn.ts` | Slack mrkdwn → `rich_text` blocks, for drafts. |
+| `canvas-parser.ts` | Slack canvas (Quip-based) HTML → Markdown, zero dependencies. |
+
+## Output
+
+`src/lib/formatter.ts` holds every chalk-coloured renderer plus `success()`,
+`error()`, `info()`, `warning()`.
+
+One rule with teeth — read the comment above `writeJson()` before changing
+anything about output:
+
+> **Never call `process.exit()` after `writeJson()`.** `ora` materialises Bun's
+> Node-compat `WriteStream` at import time, which routes stdout through an async
+> path. Exiting immediately drops everything past the 64 KiB pipe buffer, giving
+> you silently truncated JSON *with exit code 0*. Set `process.exitCode` and
+> return instead.
+
+That is [issue #73](https://github.com/shaharia-lab/slackcli/issues/73), and
+[#77](https://github.com/shaharia-lab/slackcli/issues/77) tracks the same hazard
+on the non-JSON paths.
+
+## Adding to the client
+
+To wire up a new Slack API method:
+
+1. Add a method to `SlackClient` that calls `this.request(...)`.
+2. Branch on `this.config.auth_type` **only** if Slack genuinely offers
+   different endpoints — and document the divergence.
+3. Add types to `src/types/index.ts` rather than passing `any` around.
+4. Add a formatter if the output is human-facing, and a `--json` shape if it is
+   script-facing.
+
+Worked example: [adding a command](adding-a-command.md).

--- a/docs/development/build-and-release.md
+++ b/docs/development/build-and-release.md
@@ -1,0 +1,124 @@
+# Build and release
+
+## Building
+
+```bash
+bun run build            # ./dist/slackcli for the current platform
+bun run build:linux      # bun-linux-x64   → dist/slackcli-linux
+bun run build:macos      # bun-darwin-x64  → dist/slackcli-macos
+bun run build:windows    # bun-windows-x64 → dist/slackcli-windows.exe
+bun run build:all        # all three
+```
+
+All of them go through `scripts/build.ts`, a thin wrapper around
+`bun build --compile --minify` whose one real job is injecting the version:
+
+```
+--define __APP_VERSION__=<version from package.json>
+```
+
+A local (untargeted) build also gets `--sourcemap`; cross-compiled targets do
+not.
+
+## Versioning
+
+`src/version.ts` resolves the version in one place:
+
+```ts
+export function getAppVersion(): string {
+  if (typeof __APP_VERSION__ !== 'undefined') return __APP_VERSION__;   // compiled binary
+  return packageJson.version;                                           // running from source
+}
+```
+
+`isRunningUnderBun()` distinguishes a source run from a compiled binary. It is
+what disables the self-updater and the "update available" notice during
+development.
+
+**`package.json` `version` is the single source of truth.** The release workflow
+refuses to build if the pushed tag disagrees with it.
+
+## CI
+
+Two workflows run on every push and PR to `main`.
+
+**`ci.yml`**
+
+1. `workflow-lint` — runs the pinned `actionlint` pre-commit hook over
+   `.github/workflows/`. This exists because an invalid workflow file is a
+   *startup* failure: GitHub cannot parse it, so it never resolves the `on:`
+   triggers, the run carries no logs, and its scheduled runs are never created.
+   `stale.yml` shipped that way and never ran once. CI runs the *same hook id* as
+   `.pre-commit-config.yaml`, so local and CI cannot drift.
+2. `test` — install, `bun run type-check`, `bun run build`, verify the binary
+   answers `--version` and `--help`, and enforce the **150 MB binary size
+   budget**.
+
+**`test.yml`** — `bun test`, plus an integration job that builds the binary and
+smoke-tests it.
+
+Other policy workflows: `pr-linked-issue.yml` (a PR must link an open issue),
+`signed-commits.yml`, and `stale.yml`.
+
+### Why Bun is pinned
+
+CI and the release workflow both pin **Bun 1.3.13**. Bun 1.3.12 produced corrupt
+macOS code signatures ([oven-sh/bun#29120](https://github.com/oven-sh/bun/issues/29120)).
+Bump the pin deliberately, in both files at once, after reading Bun's release
+notes.
+
+### Why the 150 MB budget matters
+
+It is not cosmetic — it is the constraint that shaped `auth login-auto`. A
+bundled Playwright would blow the budget, which is why `cdp-client.ts` exists as
+a hand-rolled DevTools Protocol client instead. Anything that would add tens of
+megabytes needs a different design, not a raised limit.
+
+## Releasing
+
+Releases are triggered by pushing a `v*.*.*` tag, and the repo has a `/release`
+skill that drives the whole sequence. By hand it is:
+
+1. Open the release issue and get it labelled `ready-for-pr` (the constitution
+   applies to releases too).
+2. On a branch: bump `version` in `package.json`, promote the Unreleased section
+   of `CHANGELOG.md`.
+3. Open the PR linking that issue; merge once green.
+4. Push the annotated tag from `main`:
+
+   ```bash
+   git tag -a v0.9.2 -m "v0.9.2" && git push origin v0.9.2
+   ```
+
+`release.yml` then:
+
+1. **`verify-version`** — fails fast if the tag does not match `package.json`,
+   so binaries can never ship with a version baked in that drifts from source.
+2. **`build`** — a matrix of five targets: `linux-x64`, `linux-arm64`,
+   `darwin-x64`, `darwin-arm64`, `windows-x64`.
+3. **`release`** — collects the artefacts, generates `checksums.txt` with
+   `sha256sum`, and publishes a GitHub Release with generated notes.
+4. **`update-homebrew`** — mints a short-lived token from a GitHub App scoped to
+   `shaharia-lab/homebrew-tap` only, and updates the formula there.
+
+Permissions are least-privilege throughout: the workflow default is
+`contents: read`, and only the `release` job opts into `contents: write`.
+
+If a tag was pushed with the wrong version, fix `package.json` on `main`, then
+delete and re-push the tag — the error message from `verify-version` says the
+same.
+
+## The self-updater
+
+`src/lib/updater.ts` backs `slackcli update`. Three behaviours worth knowing
+before you change it:
+
+- It **fails closed** on verification: the release asset's digest must be a
+  `sha256:` digest published by GitHub and must match what was downloaded.
+  A missing or unexpected digest aborts the update rather than installing an
+  unverified binary.
+- It **refuses to act** when installed via Homebrew (detected from the exec path
+  containing `homebrew`, `Cellar`, or `linuxbrew`) or when running under Bun.
+- The background check runs at most every 24 hours, caches to
+  `~/.config/slackcli/update-check.json`, and prints its notice to **stderr** on
+  `beforeExit` — so it never contaminates `--json` on stdout.

--- a/docs/development/project-structure.md
+++ b/docs/development/project-structure.md
@@ -1,0 +1,78 @@
+# Project structure
+
+```
+slackcli/
+├── src/
+│   ├── index.ts                  CLI entry point; registers command groups
+│   ├── version.ts                App version (build-time define, else package.json)
+│   ├── commands/                 One file per command group
+│   │   ├── auth.ts
+│   │   ├── canvas.ts
+│   │   ├── conversations.ts
+│   │   ├── messages.ts
+│   │   ├── saved.ts
+│   │   ├── search.ts
+│   │   └── update.ts
+│   ├── lib/                      All logic; tests live beside each file
+│   └── types/index.ts            Shared interfaces
+├── scripts/build.ts              Compile wrapper that injects __APP_VERSION__
+├── .github/workflows/            CI, tests, release, policy checks
+├── .pre-commit-config.yaml       Local checks mirroring CI
+├── CLAUDE.md                     Repository constitution + architecture notes
+├── CONTRIBUTING.md               Contribution policy
+└── dist/                         Build output (gitignored)
+```
+
+## `src/commands/`
+
+Each file exports a `create<Group>Command(): Command` factory that `src/index.ts`
+registers. They parse flags, call into `src/lib/`, print, and set the exit code.
+They hold no Slack API knowledge.
+
+| File | Subcommands |
+|---|---|
+| `auth.ts` | `login`, `login-browser`, `login-auto`, `list`, `set-default`, `remove`, `logout`, `extract-tokens`, `parse-curl` |
+| `canvas.ts` | `list`, `read` |
+| `conversations.ts` | `list`, `read`, `get`, `unread` |
+| `messages.ts` | `send`, `react`, `edit`, `draft` |
+| `saved.ts` | `list` |
+| `search.ts` | `messages`, `channels`, `people` |
+| `update.ts` | (default action), `check` |
+
+## `src/lib/`
+
+| Module | Responsibility |
+|---|---|
+| `slack-client.ts` | The Slack API abstraction. Dispatches every call to `standardRequest()` or `browserRequest()` by auth type. |
+| `auth.ts` | Login orchestration; returns a configured `SlackClient`. The only place that decides a token is valid. |
+| `workspaces.ts` | Multi-workspace persistence, profile-key derivation and resolution. |
+| `browser-auth.ts` | Captures `xoxd`/`xoxc` from a signed-in browser; pure extractors are exported for tests. |
+| `browser-launcher.ts` | Finds and launches a local Chromium-family browser; owns the profile directory. |
+| `cdp-client.ts` | Minimal Chrome DevTools Protocol client over Bun's WebSocket. |
+| `curl-parser.ts` | Extracts tokens from a DevTools cURL command. |
+| `slack-url-parser.ts` | Slack URL / permalink / timestamp normalisation. |
+| `mrkdwn.ts` | Slack mrkdwn → `rich_text` blocks (drafts). |
+| `canvas-parser.ts` | Slack canvas HTML → Markdown. |
+| `message.ts` | Fetch one message by channel + timestamp, per auth type. |
+| `saved.ts` | Resolves saved-item pointers into messages, channels, and users. |
+| `unread.ts` | Fetches and normalises unread channel data across both auth types. |
+| `formatter.ts` | Chalk-coloured renderers, status helpers, and `writeJson()`. |
+| `clipboard.ts` | Cross-platform clipboard read (`pbpaste` / PowerShell / `xclip` / `xsel`). |
+| `interactive-input.ts` | Multi-line terminal input (double-Enter or Ctrl-D). |
+| `updater.ts` | Self-update via GitHub releases, with SHA-256 verification. |
+
+## `src/types/index.ts`
+
+Every shared interface: `AuthType`, `TokenType`, `StandardAuthConfig`,
+`BrowserAuthConfig`, `WorkspaceConfig`, `WorkspacesData`, `SlackChannel`,
+`SlackUser`, `SlackFile`, `SlackMessage`, `SlackAuthTestResponse`, `SavedItem`,
+`SearchMatch`, `ChannelSearchResult`, `PeopleSearchResult`, `UnreadChannel`,
+`SlackCanvas`, and the per-command option interfaces.
+
+`WorkspaceConfig` is a discriminated union on `auth_type` — narrowing it is what
+makes the dual-auth split type-safe rather than a runtime string check.
+
+## Tests
+
+Tests sit beside the code they cover (`src/lib/curl-parser.test.ts` next to
+`src/lib/curl-parser.ts`). See [testing](testing.md).

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -1,0 +1,95 @@
+# Development setup
+
+## Prerequisites
+
+- [Bun](https://bun.sh) 1.0+ (CI pins **1.3.13** — see
+  [build and release](build-and-release.md#why-bun-is-pinned))
+- TypeScript 5.x (installed as a dev dependency)
+- [pre-commit](https://pre-commit.com) — `brew install pre-commit` or
+  `pip install pre-commit`
+- Optional: Chrome, Edge, Chromium, or Brave, to exercise `auth login-auto`
+
+## First run
+
+```bash
+git clone https://github.com/shaharia-lab/slackcli.git
+cd slackcli
+bun install
+pre-commit install     # do not skip this
+```
+
+`pre-commit install` wires up the same checks CI runs, so you find breakage
+before you push instead of in a red PR.
+
+## Everyday commands
+
+```bash
+bun run dev --help                          # run from source
+bun run dev conversations list --json       # any command, no build step
+
+bun test                                    # whole suite
+bun test src/lib/curl-parser.test.ts        # one file
+bun test --watch                            # while iterating
+
+bun run type-check                          # bunx tsc --noEmit
+
+bun run build                               # ./dist/slackcli for this platform
+bun run build:all                           # linux + macos + windows
+```
+
+There is no watch/rebuild step for normal work — `bun run dev` executes the
+TypeScript directly.
+
+## What the hooks enforce
+
+`.pre-commit-config.yaml` runs on every commit:
+
+| Hook | Why |
+|---|---|
+| `trailing-whitespace`, `end-of-file-fixer` | Keeps diffs clean |
+| `check-yaml`, `check-json`, `check-merge-conflict` | Catches unparseable files |
+| `no-commit-to-branch` (`main`, `master`) | Work happens on a branch |
+| `actionlint` | An invalid workflow file is a *startup* failure — no logs, and scheduled runs are silently never created. CI runs the same pinned hook id, so local and CI cannot drift. |
+| `bun run type-check` | Types must pass |
+| `bun test` | Tests must pass |
+
+Run them all by hand with `pre-commit run --all-files`.
+
+## Signed commits
+
+Commits must be signed — there is a `Signed Commits` workflow that enforces it.
+If you have not set signing up:
+
+```bash
+git config --global commit.gpgsign true
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519.pub
+```
+
+Then add the same public key to GitHub as a **signing key** (separate from an
+authentication key). See [CONTRIBUTING.md](../../CONTRIBUTING.md#signed-commits-required).
+
+## Before you open a pull request
+
+The repository policy is binding, and it is stricter than most:
+
+1. **An issue must exist first**, describing WHAT, WHY, and optionally HOW.
+2. **The issue must carry the `ready-for-pr` label.** A PR opened before the
+   issue is triaged is likely to be rejected even if the code is good.
+3. The PR must link that issue — a `PR must link an open issue` workflow checks
+   this.
+4. Type-check, tests, and hooks must pass; commits must be signed.
+
+Full text: [CONTRIBUTING.md](../../CONTRIBUTING.md) and the constitution in
+[CLAUDE.md](../../CLAUDE.md).
+
+## Local config while developing
+
+Running from source uses the same `~/.config/slackcli/workspaces.json` as an
+installed binary. If you want a throwaway identity for testing, add it under its
+own `--profile` and pass `--workspace=<profile>` rather than changing your
+default.
+
+The self-updater and its "update available" notice are disabled automatically
+when running under Bun, so `bun run dev` will never nag you or try to replace a
+binary that does not exist.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,0 +1,105 @@
+# Testing
+
+Tests use **Bun's native test runner**. There is no Jest, no Vitest, no config
+file to learn.
+
+```bash
+bun test                                  # everything
+bun test src/lib/curl-parser.test.ts      # one file
+bun test --watch                          # while iterating
+bun test -t "enterprise"                  # by test name
+```
+
+`bun test` also runs as a pre-commit hook and in CI, so a failing test blocks the
+commit, not just the PR.
+
+## Layout
+
+Tests live **beside the code they cover**:
+
+```
+src/lib/curl-parser.ts
+src/lib/curl-parser.test.ts
+```
+
+`src/lib/curl-parser.test.ts` is the reference: it is the most thoroughly
+covered file in the repo and shows the house style. Read it before writing a new
+suite.
+
+## What is actually tested
+
+Roughly two thirds of `src/lib` is test code, and the distribution is
+deliberate:
+
+- **Pure functions get exhaustive coverage** — parsers (`curl-parser`,
+  `slack-url-parser`, `canvas-parser`, `mrkdwn`), the workspace key/resolution
+  logic, and formatters. These carry the tricky rules, so they carry the tests.
+- **Impure edges get seams, not mocks of the world.** `cdp-client` is driven
+  through a `CdpSocket` interface so a session can be unit-tested with no
+  browser; only `connectCdpSocket`, the untestable transport edge, is left
+  uncovered — and it is kept a few lines long for exactly that reason.
+- **Command files have thin tests.** They are argument plumbing; anything worth
+  asserting should have been pushed down into `src/lib/`.
+
+## Conventions
+
+**Use `bun:test` imports directly.**
+
+```ts
+import { afterEach, describe, expect, it } from 'bun:test';
+```
+
+**Subclass rather than mock the network.** The established pattern for
+`SlackClient` is a test subclass that overrides `request()` and records calls:
+
+```ts
+class TestSlackClient extends SlackClient {
+  public readonly calls: Array<{ method: string; params: Record<string, unknown> }> = [];
+
+  override async request(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+    this.calls.push({ method, params });
+    return { ok: true, /* canned response */ };
+  }
+}
+```
+
+This asserts on the *exact* method and params sent to Slack — which is what
+regressions actually look like here (a dropped `parse: 'none'`, a wrong endpoint
+for one auth type).
+
+**Never touch the real config.** Anything that writes to disk uses a temp
+directory:
+
+```ts
+const dir = await mkdtemp(join(tmpdir(), 'slackcli-'));
+afterEach(() => rm(dir, { recursive: true, force: true }));
+```
+
+**Restore environment variables.** `browser-launcher.test.ts` snapshots and
+restores `SLACKCLI_BROWSER`, `SLACKCLI_BROWSER_PROFILE`, `PATH`, and
+`LOCALAPPDATA` — a developer with one of those set locally must not see
+different results from CI.
+
+**Test both auth types** whenever you touch a method that branches on
+`auth_type`. That branch is where this codebase's bugs live.
+
+**Name the behaviour, not the function.** Existing tests read like
+`it('honours SLACKCLI_BROWSER over the built-in table')` and
+`it('returns null when SLACKCLI_BROWSER points at nothing, rather than falling
+back')` — the name states the rule, so a failure tells you what broke without
+opening the file.
+
+**No network, no real Slack, no live credentials.** Tests must pass offline on a
+machine that has never authenticated.
+
+## CI
+
+Two workflows exercise tests:
+
+- **Tests** (`test.yml`) — `unit-tests` runs `bun test`; `integration-tests`
+  builds the binary and smoke-tests `--help` and `--version` on the real
+  artefact.
+- **CI** (`ci.yml`) — lints workflow files with `actionlint`, then type-checks,
+  builds, verifies the binary runs, and enforces the 150 MB size budget.
+
+See [build and release](build-and-release.md).

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -1,0 +1,54 @@
+# User guide
+
+## Quick start
+
+```bash
+# 1. Install (macOS / Linux)
+brew tap shaharia-lab/tap && brew install slackcli
+
+# 2. Sign in — a browser opens, you sign in once
+slackcli auth login-auto
+
+# 3. Use it
+slackcli conversations list
+slackcli messages send --recipient-id=C1234567890 --message="Hello from the terminal"
+```
+
+`slackcli --help`, and `slackcli <group> --help`, print the authoritative option
+list for the version you have installed.
+
+## Command groups
+
+| Group | What it does |
+|---|---|
+| `auth` | Sign in, list/select/remove workspaces, extract tokens |
+| `conversations` | List channels and DMs, read history and threads, unreads |
+| `messages` | Send, reply, edit, react, draft, attach files, Block Kit |
+| `search` | Search messages, channels, and people |
+| `saved` | Read your "saved for later" list |
+| `canvas` | List canvases and read them as Markdown |
+| `update` | Check for and install new versions |
+
+## Pages
+
+1. [Installation](installation.md)
+2. [Authentication](authentication.md)
+3. [Workspaces and profiles](workspaces.md)
+4. [Slack links and timestamps](links-and-timestamps.md)
+5. [Conversations](conversations.md)
+6. [Messages](messages.md)
+7. [Search](search.md)
+8. [Saved items](saved.md)
+9. [Canvas](canvas.md)
+10. [Scripting and JSON output](scripting.md)
+11. [Troubleshooting](troubleshooting.md)
+
+## Two things that apply everywhere
+
+**`--workspace <id|name>`** — every command that talks to Slack accepts it, and
+falls back to your default workspace when you omit it. See
+[workspaces and profiles](workspaces.md).
+
+**Paste Slack URLs instead of IDs** — anywhere a channel, user, message, or
+canvas ID is expected. See
+[Slack links and timestamps](links-and-timestamps.md).

--- a/docs/user-guide/authentication.md
+++ b/docs/user-guide/authentication.md
@@ -1,0 +1,157 @@
+# Authentication
+
+SlackCLI supports two kinds of credentials, and four ways to obtain them.
+
+| Auth type | Tokens | Obtained by | Best for |
+|---|---|---|---|
+| **Standard** | `xoxb-*` (bot) or `xoxp-*` (user) | Creating a Slack app | Unattended automation, CI, servers |
+| **Browser** | `xoxd-*` cookie + `xoxc-*` token | Reusing your own signed-in session | Personal use, no admin approval needed |
+
+The auth type is stored per workspace and decides how every later request is
+made — see [architecture](../development/architecture.md#dual-authentication).
+
+## Which should I use?
+
+- You can create (or already have) a Slack app → **standard tokens**. They are
+  stable, scoped, and do not expire with your browser session.
+- You cannot get a Slack app approved, or you want the CLI to act as *you* →
+  **browser tokens**, easiest via `auth login-auto`.
+
+A few features are browser-only, because Slack exposes no public API for them:
+drafts (`messages draft`), fast channel/people search
+(`search channels`, `search people` fall back to client-side filtering on
+standard auth), and fetching an arbitrary thread reply by timestamp alone
+(`conversations get`).
+
+## 1. Standard Slack app tokens
+
+Create an app at [api.slack.com/apps](https://api.slack.com/apps), add the OAuth
+scopes you need, install it to the workspace, and copy the token.
+
+```bash
+slackcli auth login --token=xoxb-YOUR-TOKEN --workspace-name="My Team"
+```
+
+The token is validated with `auth.test` before anything is saved, so a bad token
+fails immediately rather than at first use.
+
+Useful scopes, by what you want to do:
+
+| Task | Scopes |
+|---|---|
+| List channels | `channels:read`, `groups:read`, `im:read`, `mpim:read` |
+| Read history | `channels:history`, `groups:history`, `im:history`, `mpim:history` |
+| Send / edit messages | `chat:write` |
+| React | `reactions:write` |
+| Upload files | `files:write` |
+| Search messages | `search:read` (user tokens only) |
+| Read canvases | `files:read` |
+
+## 2. Automatic browser login (easiest)
+
+```bash
+slackcli auth login-auto
+```
+
+A browser opens on Slack. Sign in as you normally would and SlackCLI captures
+the tokens — it enrols **every workspace you are signed into**, not just the one
+you opened.
+
+| Option | Purpose |
+|---|---|
+| `--workspace-url <url>` | Open a specific workspace instead of the Slack home |
+| `--timeout <seconds>` | How long to wait for sign-in (default `300`) |
+| `--headless` | No visible window; only works once you are already signed in |
+
+| Environment variable | Purpose |
+|---|---|
+| `SLACKCLI_BROWSER` | Path to a browser, if yours is not auto-detected |
+| `SLACKCLI_BROWSER_PROFILE` | Override the profile directory |
+
+**Requirements:** Chrome, Edge, Chromium, or Brave installed. Nothing is
+downloaded and no extra dependency is installed — SlackCLI drives the browser
+you already have, over the Chrome DevTools Protocol.
+
+**Why you sign in again the first time.** SlackCLI runs the browser against its
+own profile in `~/.config/slackcli/browser-profile`, separate from your everyday
+browsing. It has to: since Chrome 136 the browser refuses remote debugging
+against the default profile, so your existing session cannot be reused. The
+profile persists, so **only the first run needs interaction** — afterwards
+`slackcli auth login-auto --headless` refreshes tokens with no window and no
+prompt.
+
+**Security notes.**
+
+- Token values are never printed.
+- **The browser profile is a credential store.** While it exists, `login-auto`
+  can re-mint working tokens with no prompt. `slackcli auth logout` therefore
+  deletes it along with `workspaces.json`; pass `--keep-browser-session` to keep
+  it signed in.
+- Only `https://` URLs on a `slack.com` host are ever paired with your session
+  cookie — a URL read from the browser that points anywhere else is refused.
+- While the browser is open it exposes a DevTools port on loopback that any
+  local process could connect to. SlackCLI closes the browser as soon as capture
+  finishes, and also on `Ctrl-C` or termination.
+- Credentials land in `~/.config/slackcli/workspaces.json` (mode `0600`); the
+  profile directory is `0700` on macOS and Linux (Windows uses ACL defaults).
+
+Partial success is still success: if one captured workspace has a stale token,
+the others are still saved and the failure is reported.
+
+## 3. Parse a cURL command
+
+If you would rather not let SlackCLI drive a browser, copy one Slack API request
+out of DevTools and let it read the tokens from that.
+
+In DevTools → Network, right-click any Slack API request → **Copy** → **Copy as
+cURL**, then:
+
+```bash
+# Interactive: paste, then press Enter twice (or Ctrl-D)
+slackcli auth parse-curl --login
+
+# Straight from the clipboard
+slackcli auth parse-curl --from-clipboard --login
+
+# Piped
+pbpaste | slackcli auth parse-curl --login
+cat curl-command.txt | slackcli auth parse-curl --login
+```
+
+This extracts the workspace URL and name, the `xoxd` token from the cookie
+header, and the `xoxc` token from the request body. Drop `--login` to print what
+was found without saving it.
+
+Clipboard reading uses `pbpaste` on macOS, PowerShell on Windows, and
+`xclip`/`xsel` on Linux — install one of those if the clipboard path fails.
+
+## 4. Browser session tokens by hand
+
+```bash
+slackcli auth extract-tokens     # prints the step-by-step guide
+
+slackcli auth login-browser \
+  --xoxd=xoxd-YOUR-TOKEN \
+  --xoxc=xoxc-YOUR-TOKEN \
+  --workspace-url=https://yourteam.slack.com
+```
+
+Where the values come from: open your workspace in a browser, open DevTools
+(F12), go to Network, refresh or send a message, pick any Slack API request, and
+read `d=xoxd-…` from the `Cookie` header and `"token":"xoxc-…"` from the request
+payload.
+
+## Managing sessions
+
+```bash
+slackcli auth list                        # every stored workspace, default marked
+slackcli auth set-default T1234567        # by profile, workspace ID, or name
+slackcli auth remove T1234567
+slackcli auth logout                      # clear all workspaces + browser profile
+slackcli auth logout --keep-browser-session
+```
+
+Credentials live in `~/.config/slackcli/workspaces.json` (mode `0600`, inside a
+`0700` directory). Nothing is sent anywhere except Slack.
+
+Next: [workspaces and profiles](workspaces.md).

--- a/docs/user-guide/canvas.md
+++ b/docs/user-guide/canvas.md
@@ -1,0 +1,69 @@
+# Canvas
+
+`slackcli canvas` lists Slack canvases and reads them as Markdown, which makes
+them usable in a terminal, a diff, or an AI agent's context.
+
+## `canvas list`
+
+```bash
+slackcli canvas list
+slackcli canvas list --limit=50
+slackcli canvas list --channel=C1234567890     # canvases shared in one channel
+slackcli canvas list --json
+```
+
+| Option | Default | Purpose |
+|---|---|---|
+| `--limit <number>` | `20` | How many to return (1–1000) |
+| `--channel <id>` | — | Channel ID or URL whose shared canvases to list |
+| `--workspace <id\|name>` | — | Workspace to use |
+| `--json` | off | JSON output |
+
+## `canvas read`
+
+```bash
+# By canvas file ID
+slackcli canvas read F1234567890
+
+# From its Slack URL
+slackcli canvas read https://myteam.slack.com/docs/T012AB/F1234567890
+
+# The canvas attached to a channel or DM
+slackcli canvas read --channel=C1234567890
+
+# Raw HTML, no conversion
+slackcli canvas read F1234567890 --raw
+
+# JSON, with the Markdown in a `markdown` field
+slackcli canvas read F1234567890 --json
+```
+
+| Option | Purpose |
+|---|---|
+| `--channel <id>` | Read the canvas attached to this channel or DM |
+| `--raw` | Print the source HTML instead of Markdown |
+| `--workspace <id\|name>` | Workspace to use |
+| `--json` | JSON output including metadata and the Markdown |
+
+Canvas IDs are file IDs: `F` followed by alphanumerics. Either give one or use
+`--channel`; a channel with no canvas is reported as such rather than failing.
+
+### What the conversion handles
+
+Slack canvas exports are Quip-based HTML with custom elements. The converter is
+dependency-free and covers headings, bold/italic/strike/code, links, ordered and
+unordered and nested lists, task lists, blockquotes, fenced code blocks
+(preserved verbatim, so inline tags inside them are not mangled), tables as GFM,
+embedded files and links, and emoji.
+
+`<@U…>` and `<#C…>` mentions are resolved to display names and channel names
+after conversion, so you get `@Rafael` and `#engineering` rather than raw IDs.
+
+### Limits and failure modes
+
+- Downloads are capped at **10 MB**; a larger canvas is refused rather than
+  buffered.
+- If the download comes back as a Slack sign-in page — which is what an expired
+  token produces — SlackCLI detects it and tells you to re-authenticate instead
+  of printing HTML at you.
+- Reading a canvas needs file-read permission: `files:read` for standard tokens.

--- a/docs/user-guide/conversations.md
+++ b/docs/user-guide/conversations.md
@@ -1,0 +1,90 @@
+# Conversations
+
+`slackcli conversations` covers channels, DMs, and group DMs: listing them,
+reading history and threads, fetching one message, and seeing what is unread.
+
+Every subcommand accepts `--workspace <id|name>`.
+
+## `conversations list`
+
+```bash
+slackcli conversations list                          # everything you are in
+slackcli conversations list --types=public_channel
+slackcli conversations list --types=im               # DMs only
+slackcli conversations list --limit=200 --exclude-archived
+```
+
+| Option | Default | Purpose |
+|---|---|---|
+| `--types <types>` | `public_channel,private_channel,mpim,im` | Comma-separated conversation types |
+| `--limit <number>` | `100` | How many to return |
+| `--exclude-archived` | off | Skip archived conversations |
+| `--cursor <cursor>` | — | Fetch the next page |
+
+DM entries are resolved to the other person's name. When more results exist, the
+exact `--cursor` command for the next page is printed.
+
+## `conversations read`
+
+Read channel history, or one thread.
+
+```bash
+# Recent messages in a channel (oldest first)
+slackcli conversations read C1234567890
+
+# One thread
+slackcli conversations read C1234567890 --thread-ts=1234567890.123456
+
+# The thread a message link points at
+slackcli conversations read --permalink="https://myteam.slack.com/archives/C1234567890/p1234567890123456"
+
+# Top-level messages only
+slackcli conversations read C1234567890 --exclude-replies
+
+# A time window
+slackcli conversations read C1234567890 --oldest=1735689600 --latest=1738368000
+
+# Machine-readable
+slackcli conversations read C1234567890 --json
+```
+
+| Option | Default | Purpose |
+|---|---|---|
+| `--thread-ts <ts>` | — | Read a specific thread instead of the channel |
+| `--permalink <url>` | — | Replaces the channel argument and `--thread-ts` |
+| `--exclude-replies` | off | Drop threaded replies from channel history |
+| `--limit <number>` | `100` | How many messages |
+| `--oldest` / `--latest` | — | Time range bounds |
+| `--json` | off | JSON output, including `ts` and `thread_ts` |
+
+Channel history comes back newest-first from Slack and is reversed so you read
+top to bottom. Thread replies are already chronological. `--json` also includes
+reactions, blocks, attachments, file metadata, and a resolved `users` array.
+
+## `conversations get`
+
+Fetch one message by channel and timestamp.
+
+```bash
+slackcli conversations get C1234567890 1234567890.123456
+slackcli conversations get --permalink="https://myteam.slack.com/archives/C1234567890/p1234567890123456"
+slackcli conversations get C1234567890 p1234567890123456 --json
+```
+
+**Auth-type caveat.** With browser auth this resolves both top-level messages and
+thread replies. With a standard token it can only resolve **top-level** messages
+— looking up an arbitrary reply needs its parent's `thread_ts`, and no public
+Slack API returns that from a reply timestamp alone. Read the thread instead:
+`conversations read <channel> --thread-ts=<parent>`.
+
+## `conversations unread`
+
+```bash
+slackcli conversations unread
+slackcli conversations unread --types=dms          # channels, dms, groups
+slackcli conversations unread --json
+```
+
+Conversations with mentions sort first, then alphabetically. On a workspace with
+many unread channels this makes one API call per channel to resolve names and
+may hit Slack rate limits.

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -1,0 +1,97 @@
+# Installation
+
+SlackCLI ships as a single self-contained binary. There is no runtime to install
+— you do not need Bun or Node.js to *run* it.
+
+## Homebrew (macOS and Linux)
+
+```bash
+brew tap shaharia-lab/tap
+brew install slackcli
+```
+
+Upgrade with `brew upgrade slackcli`.
+
+## Pre-built binaries
+
+Download the binary for your platform, make it executable, and put it on your
+`PATH`.
+
+```bash
+# Linux x86_64
+curl -L https://github.com/shaharia-lab/slackcli/releases/latest/download/slackcli-linux -o slackcli
+
+# Linux arm64
+curl -L https://github.com/shaharia-lab/slackcli/releases/latest/download/slackcli-linux-arm64 -o slackcli
+
+# macOS Intel
+curl -L https://github.com/shaharia-lab/slackcli/releases/latest/download/slackcli-macos -o slackcli
+
+# macOS Apple Silicon
+curl -L https://github.com/shaharia-lab/slackcli/releases/latest/download/slackcli-macos-arm64 -o slackcli
+
+chmod +x slackcli
+mkdir -p ~/.local/bin && mv slackcli ~/.local/bin/
+```
+
+On Windows, download `slackcli-windows.exe` from the
+[latest release](https://github.com/shaharia-lab/slackcli/releases/latest) and
+add it to your `PATH`.
+
+Every release publishes a `checksums.txt` alongside the binaries if you want to
+verify a manual download.
+
+## From source
+
+Requires [Bun](https://bun.sh) 1.0 or newer.
+
+```bash
+git clone https://github.com/shaharia-lab/slackcli.git
+cd slackcli
+bun install
+bun run build          # produces ./dist/slackcli
+```
+
+See [development setup](../development/setup.md) for the full contributor
+toolchain.
+
+## Verifying the install
+
+```bash
+slackcli --version
+slackcli --help
+```
+
+## Updating
+
+```bash
+slackcli update check   # report the latest release without changing anything
+slackcli update         # download and replace the running binary in place
+```
+
+`slackcli update` downloads the release asset for your platform, verifies its
+SHA-256 digest against the digest GitHub publishes for that asset, and only then
+replaces the binary. A missing or mismatched digest aborts the update rather
+than installing an unverified file.
+
+Two cases where `slackcli update` deliberately does nothing:
+
+- **Installed via Homebrew.** Use `brew upgrade slackcli`; the self-updater
+  detects a Homebrew path and points you there so it does not fight the package
+  manager.
+- **Running from source** (`bun run dev`). There is no binary to replace — use
+  `git pull`.
+
+SlackCLI also checks for new releases in the background at most once every 24
+hours and prints a one-line notice after your command's output when a newer
+version exists. The result is cached in `~/.config/slackcli/update-check.json`.
+
+## Uninstalling
+
+```bash
+brew uninstall slackcli          # Homebrew
+rm ~/.local/bin/slackcli         # manual install
+
+slackcli auth logout             # remove stored credentials first
+rm -rf ~/.config/slackcli        # or wipe the config directory entirely
+```

--- a/docs/user-guide/links-and-timestamps.md
+++ b/docs/user-guide/links-and-timestamps.md
@@ -1,0 +1,54 @@
+# Slack links and timestamps
+
+Anywhere the CLI takes a channel, user, or canvas ID, you can paste the Slack URL
+instead — the form "Copy link" actually gives you. Bare IDs keep working exactly
+as before.
+
+```bash
+# Equivalent
+slackcli conversations read C1234567890
+slackcli conversations read https://myteam.slack.com/archives/C1234567890
+```
+
+| Pasted value | Understood as |
+|---|---|
+| `https://myteam.slack.com/archives/C1234567890` | channel `C1234567890` |
+| `https://myteam.slack.com/archives/D0987654321` | DM `D0987654321` |
+| `https://myteam.slack.com/team/U9876543210` | user `U9876543210` |
+| `https://myteam.slack.com/docs/T012AB/F1234567890` | canvas `F1234567890` |
+
+Timestamps work the same way — the permalink form is accepted wherever the
+dotted API form is:
+
+| Pasted value | Understood as |
+|---|---|
+| `p1234567890123456` | `1234567890.123456` |
+| `1234567890123456` | `1234567890.123456` |
+| `1234567890.123456` | unchanged |
+
+## `--permalink`
+
+For commands that target one specific message, `--permalink` replaces the
+channel and the timestamp in one go:
+
+```bash
+# Instead of this
+slackcli messages react --channel-id=C1234567890 --timestamp=1234567890.123456 --emoji=heart
+
+# Just paste the link
+slackcli messages react --permalink="https://myteam.slack.com/archives/C1234567890/p1234567890123456" --emoji=heart
+```
+
+Available on `messages send`, `messages react`, `messages edit`,
+`messages draft`, `conversations read`, and `conversations get`.
+
+Rules worth knowing:
+
+- Pass either `--permalink` **or** the explicit inputs, not both.
+- When the link points at a threaded reply, commands that take a `--thread-ts`
+  correctly use the **parent** message, so a reply link makes you reply in the
+  right thread rather than starting a new one.
+- If the pasted link's workspace subdomain does not match the workspace the
+  command will actually call, SlackCLI warns you up front instead of letting
+  Slack answer with a confusing `message_not_found`. (This check only applies to
+  browser-authenticated workspaces, which are the ones that store a URL.)

--- a/docs/user-guide/messages.md
+++ b/docs/user-guide/messages.md
@@ -1,0 +1,140 @@
+# Messages
+
+`slackcli messages` sends, edits, reacts to, and drafts messages.
+
+Every subcommand accepts `--workspace <id|name>`.
+
+## `messages send`
+
+```bash
+# To a channel
+slackcli messages send --recipient-id=C1234567890 --message="Hello team!"
+
+# To a person — the DM is opened for you
+slackcli messages send --recipient-id=U9876543210 --message="Hey there!"
+
+# As a thread reply
+slackcli messages send --recipient-id=C1234567890 --thread-ts=1234567890.123456 --message="Great idea!"
+
+# Reply in the thread a link points at
+slackcli messages send --permalink="https://myteam.slack.com/archives/C1234567890/p1234567890123456" --message="Great idea!"
+
+# With a file attached
+slackcli messages send --recipient-id=C1234567890 --message="Here is the file" --file=./report.pdf
+```
+
+| Option | Purpose |
+|---|---|
+| `--recipient-id <id>` | Channel ID, user ID, or Slack URL |
+| `--message <text>` | **Required.** Message text |
+| `--thread-ts <ts>` | Post as a reply in this thread |
+| `--permalink <url>` | Replaces `--recipient-id` and `--thread-ts` |
+| `--file <path>` | Attach a file; `--message` becomes the comment |
+| `--blocks <json\|@file>` | Block Kit JSON array; cannot be combined with `--file` |
+
+A `--recipient-id` starting with `U` opens a DM first. File uploads need upload
+permission in the workspace — `files:write` for standard tokens. Uploads go
+through Slack's external-upload flow; empty files, directories, and missing
+paths are rejected before anything is sent.
+
+On success the message timestamp is printed — capture it if you want to edit or
+react to the message later.
+
+### Text formatting
+
+Message text is sent with Slack's `parse=none`, so Slack mrkdwn works as you
+write it: `*bold*`, `_italic_`, `~strike~`, `` `code` ``, triple-backtick
+blocks, and links as `<https://example.com|label>`. Slack has no `[text](url)`
+link syntax and no `#` headings in plain message text — use `--blocks` with a
+`markdown` block if you want those.
+
+### Block Kit (`--blocks`)
+
+`--blocks` takes a JSON array of
+[Block Kit blocks](https://docs.slack.dev/reference/block-kit/blocks/), inline or
+loaded from a file with `--blocks=@blocks.json`. It works with both auth types.
+The required `--message` text is still used as the notification and
+accessibility fallback.
+
+Native [`markdown` blocks](https://docs.slack.dev/reference/block-kit/blocks/markdown-block/)
+take *standard* Markdown rather than Slack mrkdwn, which buys you headings, task
+lists, syntax-highlighted code fences, and Markdown tables:
+
+```bash
+slackcli messages send \
+  --recipient-id=C1234567890 \
+  --message="Release notes" \
+  --blocks='[{"type":"markdown","text":"# Release notes\n\n- [x] Build\n- [ ] Deploy\n\nSee the [runbook](https://example.com/runbook)."}]'
+```
+
+Native [`table` blocks](https://docs.slack.dev/reference/block-kit/blocks/table-block/)
+render a real table instead of a code block:
+
+```bash
+slackcli messages send \
+  --recipient-id=C1234567890 \
+  --message="Project status table" \
+  --blocks='[
+    {
+      "type": "table",
+      "column_settings": [{"is_wrapped": true}, {"align": "right"}],
+      "rows": [
+        [
+          {"type": "rich_text", "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": "Project", "style": {"bold": true}}]}]},
+          {"type": "rich_text", "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": "Status", "style": {"bold": true}}]}]}
+        ],
+        [
+          {"type": "rich_text", "elements": [{"type": "rich_text_section", "elements": [{"type": "link", "text": "SlackCLI", "url": "https://github.com/shaharia-lab/slackcli"}]}]},
+          {"type": "raw_text", "text": "Ready"}
+        ]
+      ]
+    }
+  ]'
+```
+
+The JSON is validated before the request: it must be an array, and every element
+must be an object with a non-empty string `type`. Errors name the offending
+index.
+
+## `messages edit`
+
+```bash
+slackcli messages edit --channel-id=C1234567890 --timestamp=1234567890.123456 --message="Corrected message"
+slackcli messages edit --permalink="https://myteam.slack.com/archives/C1234567890/p1234567890123456" --message="Corrected message"
+```
+
+Only messages posted by the authenticated user or app can be edited; ephemeral
+messages cannot. Links survive an edit — SlackCLI sends `parse=none` explicitly,
+because `chat.update` would otherwise default to `client` and escape
+`<url|label>` markup.
+
+## `messages react`
+
+```bash
+slackcli messages react --channel-id=C1234567890 --timestamp=1234567890.123456 --emoji=+1
+slackcli messages react --permalink="https://myteam.slack.com/archives/C1234567890/p1234567890123456" --emoji=heart
+```
+
+`--emoji` takes the name without colons: `+1`/`thumbsup` 👍, `heart` ❤️,
+`fire` 🔥, `eyes` 👀, `tada` 🎉, `rocket` 🚀. Custom workspace emoji work too.
+
+## `messages draft`
+
+```bash
+slackcli messages draft --recipient-id=C1234567890 --message="Hello team!"
+```
+
+Creates an unsent draft in the Slack client — useful when you want a human to
+review and press send.
+
+**Browser auth only.** Slack apps cannot create drafts; there is no public API
+for it. With a standard token the command fails with
+`Draft creation requires browser authentication`.
+
+The text is converted from Slack mrkdwn into `rich_text` blocks so the draft
+opens in the composer already formatted.
+
+## Related
+
+- [Slack links and timestamps](links-and-timestamps.md) — what `--permalink` accepts
+- [Scripting and JSON output](scripting.md) — capturing timestamps in a script

--- a/docs/user-guide/saved.md
+++ b/docs/user-guide/saved.md
@@ -1,0 +1,26 @@
+# Saved items
+
+`slackcli saved list` reads your **Later** / "saved for later" list.
+
+```bash
+slackcli saved list
+slackcli saved list --limit=50
+slackcli saved list --state=to_do
+slackcli saved list --json
+```
+
+| Option | Purpose |
+|---|---|
+| `--limit <number>` | Maximum number of items to return |
+| `--state <state>` | Filter by `saved`, `to_do`, or `completed` |
+| `--workspace <id\|name>` | Workspace to use |
+| `--json` | JSON output |
+
+Raw saved entries are only pointers — a channel ID and a timestamp. SlackCLI
+paginates the whole list, then resolves each pointer into the actual message
+text, the channel name, and the author, so the output is readable without a
+second lookup.
+
+Both auth types work: browser auth uses Slack's `saved.list`, standard auth
+falls back to `stars.list`. The two return different shapes; the enrichment step
+normalises them, so the output and the `--json` schema are the same either way.

--- a/docs/user-guide/scripting.md
+++ b/docs/user-guide/scripting.md
@@ -1,0 +1,116 @@
+# Scripting and JSON output
+
+SlackCLI is built to be driven by scripts, cron jobs, and AI agents as much as by
+hand.
+
+## `--json`
+
+Every read command supports `--json`: `conversations read`, `conversations get`,
+`conversations unread`, `search messages`, `search channels`, `search people`,
+`saved list`, `canvas list`, `canvas read`.
+
+JSON goes to **stdout**. Progress spinners, error messages, and the
+update-available notice go to **stderr**, so a pipe normally carries only data:
+
+```bash
+slackcli conversations read C1234567890 --json | jq '.messages[].text'
+```
+
+One caveat: the workspace-mismatch **warning** is currently written to stdout,
+not stderr. It only fires when you pass a `--permalink` or Slack URL whose
+subdomain does not match the workspace being called, so it cannot appear in a
+pipeline that passes plain IDs or targets the right workspace.
+
+### Shapes
+
+```bash
+# Messages, with a resolved users array so IDs are not opaque
+slackcli conversations read C123 --json | jq '.messages[] | {ts, user, text}'
+slackcli conversations read C123 --json | jq '.users[] | {id, real_name}'
+
+# Just the thread replies to one message
+slackcli conversations read --permalink="$LINK" --json | jq -r '.messages[].text'
+
+# Search hits with their permalinks
+slackcli search messages "deploy failed" --json | jq -r '.matches[] | "\(.channel.name)\t\(.permalink)"'
+
+# Unread channels that have mentions
+slackcli conversations unread --json | jq '.unread_channels[] | select(.mention_count > 0)'
+
+# A canvas as Markdown
+slackcli canvas read F123 --json | jq -r '.markdown' > canvas.md
+```
+
+`--json` output for messages includes `ts`, `thread_ts`, `user`, `text`, `type`,
+`reply_count`, `reactions`, `bot_id`, `blocks`, `attachments`, and file metadata
+when a message has attachments.
+
+## Exit codes
+
+`0` on success, `1` on failure. Failures print a message to stderr — check the
+exit code rather than parsing that text.
+
+```bash
+if ! slackcli messages send --recipient-id="$CHANNEL" --message="$TEXT"; then
+  echo "post failed" >&2
+  exit 1
+fi
+```
+
+An empty result is *not* a failure: a search with no hits, or an unread list with
+nothing in it, exits `0`. Test the data, not the exit code:
+
+```bash
+count=$(slackcli search messages "$Q" --json | jq '.total')
+[ "$count" -gt 0 ] || echo "nothing found"
+```
+
+## Patterns
+
+**Post and keep the timestamp**, so you can edit or react later. The human
+output prints it; `--json` is not offered on `messages send`, so parse the line:
+
+```bash
+ts=$(slackcli messages send --recipient-id=C123 --message="Working…" \
+     | grep -oE '[0-9]{10}\.[0-9]{6}')
+slackcli messages edit --channel-id=C123 --timestamp="$ts" --message="Done ✅"
+```
+
+**Reply into a thread from a link** — no ID juggling:
+
+```bash
+slackcli messages send --permalink="$SLACK_LINK" --message="On it"
+```
+
+**Pick an identity explicitly** in unattended jobs, rather than depending on
+whichever workspace happens to be the default:
+
+```bash
+slackcli messages send --workspace=automation-bot --recipient-id=C123 --message="Nightly build green"
+```
+
+**Paginate a search**:
+
+```bash
+page=1
+while :; do
+  out=$(slackcli search messages "$Q" --page="$page" --limit=100 --json)
+  echo "$out" | jq -r '.matches[].permalink'
+  [ "$page" -lt "$(echo "$out" | jq '.pages')" ] || break
+  page=$((page + 1))
+done
+```
+
+## Notes for unattended use
+
+- **Token freshness.** Browser tokens die with the browser session. Refresh them
+  non-interactively with `slackcli auth login-auto --headless`, which works once
+  the profile has been signed in once.
+- **Rate limits.** Commands that resolve many users or channels
+  (`conversations unread`, `saved list` on a long list) make one API call per
+  entity and can hit Slack's rate limits on a big workspace.
+- **The update notice.** SlackCLI may append a one-line "update available" notice
+  after a command. It goes to stderr and never contaminates `--json` on stdout.
+- **Credentials.** `~/.config/slackcli/workspaces.json` holds live tokens at mode
+  `0600`. Give a CI job its own bot-token profile rather than copying a personal
+  browser session around.

--- a/docs/user-guide/search.md
+++ b/docs/user-guide/search.md
@@ -1,0 +1,60 @@
+# Search
+
+`slackcli search` covers messages, channels, and people. Every subcommand
+accepts `--workspace <id|name>` and `--json`.
+
+## `search messages`
+
+```bash
+slackcli search messages "deployment failed"
+slackcli search messages "release" --in=engineering --from=rafael
+slackcli search messages "incident" --limit=50 --sort=score
+slackcli search messages "after:2026-07-01 has:link" --json
+```
+
+| Option | Default | Purpose |
+|---|---|---|
+| `--in <channel>` | — | Shorthand for the `in:` operator |
+| `--from <user>` | — | Shorthand for the `from:` operator |
+| `--limit <number>` | `20` | Results per page |
+| `--page <number>` | `1` | Which page |
+| `--sort <field>` | `timestamp` | `score` or `timestamp` |
+| `--sort-dir <dir>` | `desc` | `asc` or `desc` |
+
+The query is passed to Slack, so all of its
+[search operators](https://slack.com/help/articles/202528808-Search-in-Slack)
+work: `in:`, `from:`, `before:`, `after:`, `on:`, `during:`, `has:`, `is:`,
+`with:`. `--in` and `--from` are just conveniences appended to the query.
+
+When more pages exist, the next-page command is printed. In `--json` mode the
+`page` and `pages` fields carry the same information.
+
+Standard bot tokens (`xoxb-*`) cannot call `search.messages` at all — Slack
+restricts it to user tokens. Use a `xoxp-*` token or browser auth.
+
+## `search channels`
+
+```bash
+slackcli search channels platform
+slackcli search channels incident --limit=50 --json
+```
+
+Matches on channel name, topic, and purpose.
+
+With **browser auth** this hits Slack's own search backend and is fast. With a
+**standard token** there is no equivalent API, so SlackCLI lists up to 1000
+non-archived channels and filters them locally — correct, but slower on large
+workspaces, and capped at that 1000.
+
+## `search people`
+
+```bash
+slackcli search people rafael
+slackcli search people "@example.com" --limit=50
+```
+
+Matches on username, real name, display name, and email.
+
+The same auth-type split applies: browser auth uses Slack's search backend;
+standard auth lists up to 1000 users and filters locally, skipping deactivated
+accounts and bots.

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -1,0 +1,134 @@
+# Troubleshooting
+
+## `No workspace configured`
+
+Nothing is authenticated yet. Run `slackcli auth login-auto`, or see
+[authentication](authentication.md).
+
+## `Workspace not found: <name>`
+
+The selector matched nothing. `slackcli auth list` shows the profile keys,
+workspace IDs, and names that are valid.
+
+## `"x" matches multiple profiles`
+
+You have more than one identity for that workspace. Pass the profile name
+instead of the bare ID or name — see
+[workspaces and profiles](workspaces.md#how-a-selector-is-resolved).
+
+## Authentication fails
+
+**Standard tokens**
+
+- Check the token has the OAuth scopes the command needs — see the
+  [scope table](authentication.md#1-standard-slack-app-tokens).
+- Re-check the token in your Slack app settings; a reinstall rotates it.
+- `not_allowed_token_type` on search means you are using a bot token. Slack
+  restricts `search.messages` to user (`xoxp-*`) tokens.
+
+**Browser tokens**
+
+- They expire with your browser session. Refresh with
+  `slackcli auth login-auto --headless`, or re-run `parse-curl` / `login-browser`
+  with fresh values.
+- The workspace URL must be `https://yourteam.slack.com`.
+
+## `invalid_auth` or `not_authed`
+
+The stored token is no longer valid. Re-authenticate the same identity — logging
+in again refreshes the tokens in place and keeps your profile key and default.
+
+## Permission errors on channels or messages
+
+- The bot or user must be **a member of the channel** — being able to see it in
+  the web UI is not enough for a bot.
+- Check the OAuth scopes cover the operation (`chat:write` to post,
+  `reactions:write` to react, `files:write` to upload, `files:read` for
+  canvases).
+- For browser tokens: if you cannot open it in the Slack web UI, the CLI cannot
+  either.
+
+## `auth login-auto` cannot find a browser
+
+It needs Chrome, Edge, Chromium, or Brave installed locally. If yours is in a
+non-standard place, point at it:
+
+```bash
+SLACKCLI_BROWSER=/path/to/chrome slackcli auth login-auto
+```
+
+If the browser opens but capture times out, sign in fully (including any SSO
+redirect and 2FA) before the `--timeout` window closes, or raise it with
+`--timeout=600`. Note that `--headless` only works *after* a first interactive
+sign-in has populated the profile.
+
+## `auth parse-curl` cannot read the clipboard
+
+Clipboard access uses `pbpaste` (macOS), PowerShell (Windows), and
+`xclip`/`xsel` (Linux). Install one, or use interactive mode
+(`slackcli auth parse-curl --login`, paste, press Enter twice) or a pipe.
+
+## `Clipboard content does not appear to be a cURL command`
+
+Copy the request from DevTools with **Copy → Copy as cURL** (not "Copy link" or
+"Copy response"). "Copy as cURL (bash)" and "(cmd)" both work.
+
+## Canvas read says authentication expired
+
+The download came back as a Slack sign-in page instead of canvas HTML, which is
+what an expired token produces. Re-authenticate and retry.
+
+## Canvas read says the file is too large
+
+Downloads are capped at 10 MB. Use `--raw` and pipe elsewhere, or read the
+canvas in the Slack UI.
+
+## `conversations get` cannot find a thread reply
+
+With a standard token, only top-level messages can be fetched by timestamp;
+resolving an arbitrary reply needs its parent's `thread_ts`, which no public
+Slack API exposes. Read the thread instead:
+
+```bash
+slackcli conversations read C1234567890 --thread-ts=<parent-ts>
+```
+
+Browser auth does not have this limitation.
+
+## Drafts fail with `requires browser authentication`
+
+Slack apps cannot create drafts. Use a browser-authenticated profile.
+
+## Truncated JSON when piping
+
+If output looks cut off around 64 KiB, you have hit
+[issue #77](https://github.com/shaharia-lab/slackcli/issues/77), which affects
+non-JSON stdout paths (`canvas --raw`, human-readable output). `--json` output is
+not affected. Redirect to a file as a workaround, and add a comment on the issue
+with what you ran.
+
+## `slackcli update` does nothing or fails
+
+- **Installed via Homebrew**: use `brew upgrade slackcli`. The self-updater
+  detects this and refuses so it does not fight the package manager.
+- **Running from source**: there is no binary to replace — `git pull`.
+- **Permission denied**: you lack write access to the binary's location. Install
+  to `~/.local/bin` instead of a system directory.
+- **Checksum mismatch**: the update is aborted deliberately. Do not work around
+  it — download the binary manually and check it against `checksums.txt` from
+  the release.
+
+## Rate limits
+
+`conversations unread` and `saved list` resolve names one entity at a time and
+can hit Slack's rate limits on a large workspace. Narrow the request
+(`--types`, `--limit`) or retry after a pause.
+
+## Still stuck?
+
+- [Open an issue](https://github.com/shaharia-lab/slackcli/issues) with the exact
+  command, the error, and `slackcli --version`.
+- [Discussions](https://github.com/shaharia-lab/slackcli/discussions) for
+  questions.
+- Never paste a token, a cURL command, or your `workspaces.json` into a public
+  issue — all three contain live credentials.

--- a/docs/user-guide/workspaces.md
+++ b/docs/user-guide/workspaces.md
@@ -1,0 +1,103 @@
+# Workspaces and profiles
+
+Every authenticated Slack workspace is stored under a **profile key** in
+`~/.config/slackcli/workspaces.json`. The first workspace you add automatically
+becomes the default; every command uses the default unless you pass
+`--workspace`.
+
+```bash
+slackcli auth list                              # what is stored, and which is default
+slackcli conversations list --workspace=T1234567
+slackcli conversations list --workspace="My Team"
+```
+
+`--workspace` is accepted by every command that talks to Slack.
+
+## Several identities in one workspace
+
+By default each workspace is stored once. To keep **more than one identity for
+the same workspace** — say a browser-authenticated user for search and drafts,
+alongside a bot token for unattended jobs — name each login with `--profile`:
+
+```bash
+# A user identity (browser auth)
+slackcli auth login-browser \
+  --xoxd=xoxd-... --xoxc=xoxc-... \
+  --workspace-url=https://example.slack.com \
+  --profile=rafael
+
+# A bot identity in the same workspace
+slackcli auth login \
+  --token=xoxb-... \
+  --workspace-name=example \
+  --profile=automation-bot
+```
+
+Then select one anywhere `--workspace` is accepted:
+
+```bash
+slackcli search messages "after:2026-07-01" --workspace=rafael --json
+slackcli messages send --recipient-id=C123 --message="Done" --workspace=automation-bot
+```
+
+## How keys are chosen
+
+- **First identity for a team** keeps the historical `team_id` as its key, so
+  existing configs and scripts are unaffected.
+- **Re-authenticating the same identity** (same team, same auth type, same user)
+  refreshes its tokens in place — it keeps its key, its default status, and any
+  name you gave it. This is what makes `auth login-auto --headless` usable as a
+  token refresh.
+- **A second identity without `--profile`** is saved under an auto-generated key
+  such as `T1234567-2` rather than overwriting the first. The key that was used
+  is printed after login.
+- **`--profile` naming an existing key that belongs to a different team** is
+  refused, so you cannot clobber an unrelated record by reusing a name.
+
+## How a selector is resolved
+
+`--workspace`, `auth set-default`, and `auth remove` all accept the same kinds of
+value, tried in this order:
+
+1. An exact profile key
+2. An explicit `--profile` name
+3. A workspace ID (`T…`)
+4. A workspace name
+
+If a bare ID or name matches more than one stored profile, SlackCLI stops and
+asks you to disambiguate with a profile name instead of silently picking one.
+
+```
+"example" matches multiple profiles: T1234567, rafael.
+Re-run with --workspace=<profile> (see "slackcli auth list").
+```
+
+## Config file
+
+`~/.config/slackcli/workspaces.json`, mode `0600`:
+
+```json
+{
+  "default_workspace": "T1234567",
+  "workspaces": {
+    "T1234567": {
+      "workspace_id": "T1234567",
+      "workspace_name": "example",
+      "auth_type": "browser",
+      "workspace_url": "https://example.slack.com",
+      "xoxd_token": "xoxd-...",
+      "xoxc_token": "xoxc-..."
+    },
+    "automation-bot": {
+      "workspace_id": "T1234567",
+      "workspace_name": "example",
+      "profile": "automation-bot",
+      "auth_type": "standard",
+      "token": "xoxb-...",
+      "token_type": "bot"
+    }
+  }
+}
+```
+
+It holds live credentials. Do not commit it, sync it, or hand it around.


### PR DESCRIPTION
Closes #127

## What

Adds a `docs/` directory — the repo had none — split into the two categories the issue asked for.

**`docs/user-guide/`** (11 pages) — installation, authentication, workspaces & profiles, Slack links & timestamps, one page per command group (conversations, messages, search, saved, canvas), scripting & JSON output, troubleshooting.

**`docs/development/`** (6 pages) — setup, architecture, project structure, testing, build & release, and a worked example of adding a command.

`docs/README.md` is the index; each category has its own index too.

## Why

Everything lived in a single ~20 KB `README.md` covering install, four auth methods, every command, configuration, development and troubleshooting in one scroll. A user could not find the one command they needed, and a contributor got nothing about how the codebase is actually put together.

## Notable content

The developer pages write down what was previously only visible in source comments:

- the dual-auth dispatch in `SlackClient.request()`, and a table of the five places the two auth types genuinely diverge (`createDraft`, `listSavedItems`, `searchModules`, `getUnreadCounts`, `fetchMessage`) with the reason for each;
- the profile-key derivation and resolution rules in `workspaces.ts`, including the backward-compatibility constraints on legacy config files;
- the CDP-based `login-auto` capture, why it is hand-rolled rather than Playwright, and the security invariants worth preserving;
- the `writeJson()` / `process.exit()` hazard behind #73, called out in both the architecture page and the new-command checklist;
- why Bun is pinned to 1.3.13 and why the 150 MB binary budget is a design constraint rather than a nicety.

## README

Trimmed to an overview that links into `docs/`: header, demo, features, installation, a short authentication summary, a quick tour, configuration, development, contributing, and pointers for the rest.

One correctness fix while there: the README's Contributing section described a plain fork-and-PR flow, which contradicts the issue-first / `ready-for-pr` policy in `CONTRIBUTING.md` and `CLAUDE.md`. It now matches.

## Verification

- Documentation only — no source or behaviour changes.
- Every relative link in `README.md` and `docs/` checked to resolve.
- `bun run type-check` clean; `bun test` 422 pass / 0 fail; `pre-commit run --all-files` passes.