### PR TITLE
docs: redesign the README as a landing page, with a star/share call to action

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,9 @@ No Slack app to build, no admin approval to wait for.
 
 <br>
 
-### ⭐ Like the idea? Star the repo.
+### ⭐ Like the idea? [Star the repo.](https://github.com/shaharia-lab/slackcli)
 
 It takes two seconds, and it is how the next person finds SlackCLI.
-
-[![Star SlackCLI](https://img.shields.io/badge/⭐_Star_SlackCLI-181717?style=for-the-badge&logo=github)](https://github.com/shaharia-lab/slackcli)
-[![Share it](https://img.shields.io/badge/📣_Share_it-3fa045?style=for-the-badge)](#-spread-the-word)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 # SlackCLI
 
-### Your Slack workspace, from the terminal.
+### Work with one — or many — Slack workspaces, straight from your terminal.
 
-Read channels, send messages, search history, and pipe it all into `jq` —
-without building a Slack app first.
+Read channels, send messages, search history, and catch up on what you missed.
+Built to be **AI-agent friendly**, so your scripts and assistants can use Slack too.
+No Slack app to build, no admin approval to wait for.
 
 [![Release](https://img.shields.io/github/v/release/shaharia-lab/slackcli?style=flat-square&color=3fa045)](https://github.com/shaharia-lab/slackcli/releases/latest)
 [![CI](https://img.shields.io/github/actions/workflow/status/shaharia-lab/slackcli/ci.yml?branch=main&style=flat-square&label=CI&logo=github)](https://github.com/shaharia-lab/slackcli/actions/workflows/ci.yml)
@@ -15,6 +16,16 @@ without building a Slack app first.
 [![Last commit](https://img.shields.io/github/last-commit/shaharia-lab/slackcli?style=flat-square)](https://github.com/shaharia-lab/slackcli/commits/main)
 
 **[Quickstart](#-quickstart) · [What it does](#-what-do-you-want-to-do) · [Commands](#-command-reference) · [Docs](docs/README.md) · [Contributing](#-contributing)**
+
+<br>
+
+### ⭐ Like the idea? Star the repo.
+
+SlackCLI is an independent open-source project with no company behind it.
+A star takes two seconds and is how the next person finds it.
+
+[![Star this repo](https://img.shields.io/badge/⭐_Star_SlackCLI-181717?style=for-the-badge&logo=github)](https://github.com/shaharia-lab/slackcli)
+[![Share on X](https://img.shields.io/badge/Tell_someone-000000?style=for-the-badge&logo=x&logoColor=white)](https://twitter.com/intent/tweet?text=SlackCLI%20%E2%80%94%20work%20with%20one%20or%20many%20Slack%20workspaces%20straight%20from%20your%20terminal%2C%20and%20let%20AI%20agents%20do%20it%20too.&url=https%3A%2F%2Fgithub.com%2Fshaharia-lab%2Fslackcli)
 
 </div>
 
@@ -339,23 +350,20 @@ slackcli update                              # install it
 
 ---
 
-## ⭐ Star it, share it
+## ⭐ Spread the word
 
-SlackCLI is a small independent project with no company behind it. Stars are the
-entire growth engine — they are how the next person finds this instead of writing
-the same glue script for the fifth time.
+Made it this far? Then SlackCLI is probably useful to you — and the fastest way to
+keep it alive is to make it easier for the next person to find.
 
 <div align="center">
 
-**If SlackCLI saved you an afternoon, [give it a star](https://github.com/shaharia-lab/slackcli) — it takes two seconds.**
-
-[![Star this repo](https://img.shields.io/badge/⭐_Star_this_repo-181717?style=for-the-badge&logo=github)](https://github.com/shaharia-lab/slackcli)
-[![Share on X](https://img.shields.io/badge/Share_on_X-000000?style=for-the-badge&logo=x&logoColor=white)](https://twitter.com/intent/tweet?text=SlackCLI%20%E2%80%94%20drive%20your%20Slack%20workspace%20from%20the%20terminal%2C%20with%20JSON%20output%20for%20scripts%20and%20AI%20agents.&url=https%3A%2F%2Fgithub.com%2Fshaharia-lab%2Fslackcli)
-[![Discuss](https://img.shields.io/badge/Join_the_discussion-5865F2?style=for-the-badge&logo=github)](https://github.com/shaharia-lab/slackcli/discussions)
+**[⭐ Star SlackCLI](https://github.com/shaharia-lab/slackcli)** ·
+**[💬 Say hello in Discussions](https://github.com/shaharia-lab/slackcli/discussions)** ·
+**[📣 Tell someone](https://twitter.com/intent/tweet?text=SlackCLI%20%E2%80%94%20work%20with%20one%20or%20many%20Slack%20workspaces%20straight%20from%20your%20terminal%2C%20and%20let%20AI%20agents%20do%20it%20too.&url=https%3A%2F%2Fgithub.com%2Fshaharia-lab%2Fslackcli)**
 
 </div>
 
-Other things that genuinely help, in rough order of usefulness:
+In rough order of usefulness:
 
 - ⭐ **Star the repo** — the single highest-leverage thing.
 - 🐛 **Open an issue** when something breaks or a command feels wrong.

--- a/README.md
+++ b/README.md
@@ -1,176 +1,229 @@
+<div align="center">
+
 # SlackCLI
 
-![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/shaharia-lab/slackcli/total)
-[![Release](https://img.shields.io/github/v/release/shaharia-lab/slackcli)](https://github.com/shaharia-lab/slackcli/releases)
-[![Stars](https://img.shields.io/github/stars/shaharia-lab/slackcli)](https://github.com/shaharia-lab/slackcli/stargazers)
-[![License](https://img.shields.io/github/license/shaharia-lab/slackcli)](https://github.com/shaharia-lab/slackcli/blob/main/LICENSE)
-[![Last Commit](https://img.shields.io/github/last-commit/shaharia-lab/slackcli)](https://github.com/shaharia-lab/slackcli/commits/main)
+### Your Slack workspace, from the terminal.
 
-> **Disclaimer:** This is an unofficial, open-source CLI tool for interacting with Slack. It is not affiliated with, endorsed by, or supported by Slack Technologies. Slack has an official CLI — see the [Slack CLI documentation](https://docs.slack.dev/tools/slack-cli/) for the officially supported tooling.
+Read channels, send messages, search history, and pipe it all into `jq` —
+without building a Slack app first.
 
-A fast, developer-friendly command-line interface tool for interacting with Slack workspaces. Built with TypeScript and Bun, it enables AI agents, automation tools, and developers to access Slack functionality directly from the terminal.
+[![Release](https://img.shields.io/github/v/release/shaharia-lab/slackcli?style=flat-square&color=3fa045)](https://github.com/shaharia-lab/slackcli/releases/latest)
+[![CI](https://img.shields.io/github/actions/workflow/status/shaharia-lab/slackcli/ci.yml?branch=main&style=flat-square&label=CI&logo=github)](https://github.com/shaharia-lab/slackcli/actions/workflows/ci.yml)
+[![Downloads](https://img.shields.io/github/downloads/shaharia-lab/slackcli/total?style=flat-square&color=blue)](https://github.com/shaharia-lab/slackcli/releases)
+[![Stars](https://img.shields.io/github/stars/shaharia-lab/slackcli?style=flat-square&color=f5c518)](https://github.com/shaharia-lab/slackcli/stargazers)
+[![License](https://img.shields.io/github/license/shaharia-lab/slackcli?style=flat-square)](LICENSE)
+[![Last commit](https://img.shields.io/github/last-commit/shaharia-lab/slackcli?style=flat-square)](https://github.com/shaharia-lab/slackcli/commits/main)
 
-## Demo
+**[Quickstart](#-quickstart) · [What it does](#-what-do-you-want-to-do) · [Commands](#-command-reference) · [Docs](docs/README.md) · [Contributing](#-contributing)**
 
-Sign in, browse conversations, search the workspace, read a thread from a permalink, reply, react, read a canvas as Markdown, and pipe `--json` into `jq` — all from the terminal.
+</div>
+
+---
+
+## 🎬 See it in action
+
+Sign in, browse conversations, search the workspace, read a thread from a permalink,
+reply, react, read a canvas as Markdown, and pipe `--json` into `jq` — all from the terminal.
 
 https://github.com/user-attachments/assets/90cf1c89-2859-4b84-a731-b0ff3e1172f3
 
-## Features
+> [!IMPORTANT]
+> **Unofficial project.** SlackCLI is not affiliated with, endorsed by, or supported by
+> Slack Technologies. Slack ships an [official CLI](https://docs.slack.dev/tools/slack-cli/)
+> for building Slack apps — this is a different tool, for driving a workspace you already
+> belong to.
 
-- 🔐 **Dual Authentication Support**: Standard Slack tokens (xoxb/xoxp) or browser tokens (xoxd/xoxc)
-- 🪄 **Automatic Browser Login**: sign into Slack in a browser and the tokens are captured for you
-- 🎯 **Easy Token Extraction**: Automatically parse tokens from browser cURL commands
-- 🏢 **Multi-Workspace Management**: Manage multiple Slack workspaces with ease
-- 💬 **Conversation Management**: List channels, read messages, send messages
-- 🎉 **Message Reactions**: Add emoji reactions to messages programmatically
-- 📄 **Canvas Support**: List and read Slack canvas documents as markdown
-- 🚀 **Fast & Lightweight**: Built with Bun for blazing fast performance
-- 🔄 **Auto-Update**: Built-in self-update mechanism
-- 🎨 **Beautiful Output**: Colorful, user-friendly terminal output
+---
 
-## Installation
+## ⚡ Quickstart
 
-### Homebrew (macOS and Linux)
+Three steps, about a minute.
+
+<details open>
+<summary><b>1. Install</b> — pick your platform</summary>
+
+<br>
+
+**Homebrew** (macOS & Linux) — recommended
 
 ```bash
 brew tap shaharia-lab/tap
 brew install slackcli
 ```
 
-To upgrade to the latest version:
+<details>
+<summary>Linux — direct binary</summary>
 
 ```bash
-brew upgrade slackcli
-```
-
-### Pre-built Binaries
-
-#### Linux (x86_64)
-```bash
+# x86_64
 curl -L https://github.com/shaharia-lab/slackcli/releases/latest/download/slackcli-linux -o slackcli
-chmod +x slackcli
-mkdir -p ~/.local/bin && mv slackcli ~/.local/bin/
-```
 
-#### Linux (arm64)
-```bash
+# arm64
 curl -L https://github.com/shaharia-lab/slackcli/releases/latest/download/slackcli-linux-arm64 -o slackcli
-chmod +x slackcli
-mkdir -p ~/.local/bin && mv slackcli ~/.local/bin/
+
+chmod +x slackcli && mkdir -p ~/.local/bin && mv slackcli ~/.local/bin/
 ```
 
-#### macOS (Intel)
+</details>
+
+<details>
+<summary>macOS — direct binary</summary>
+
 ```bash
+# Intel
 curl -L https://github.com/shaharia-lab/slackcli/releases/latest/download/slackcli-macos -o slackcli
-chmod +x slackcli
-mkdir -p ~/.local/bin && mv slackcli ~/.local/bin/
-```
 
-#### macOS (Apple Silicon)
-```bash
+# Apple Silicon
 curl -L https://github.com/shaharia-lab/slackcli/releases/latest/download/slackcli-macos-arm64 -o slackcli
-chmod +x slackcli
-mkdir -p ~/.local/bin && mv slackcli ~/.local/bin/
+
+chmod +x slackcli && mkdir -p ~/.local/bin && mv slackcli ~/.local/bin/
 ```
 
-#### Windows
-Download `slackcli-windows.exe` from the [latest release](https://github.com/shaharia-lab/slackcli/releases/latest) and add it to your PATH.
+</details>
 
-### From Source
+<details>
+<summary>Windows</summary>
+
+Download `slackcli-windows.exe` from the [latest release](https://github.com/shaharia-lab/slackcli/releases/latest)
+and put it somewhere on your `PATH`.
+
+</details>
+
+<details>
+<summary>From source (Bun)</summary>
 
 ```bash
-# Clone the repository
 git clone https://github.com/shaharia-lab/slackcli.git
 cd slackcli
-
-# Install dependencies
 bun install
-
-# Build binary
-bun run build
+bun run build        # -> ./dist/slackcli
 ```
 
+</details>
 
-## Documentation
+Every release ships `checksums.txt` — verify your download if you care to, and you should.
+Full details in the [installation guide](docs/user-guide/installation.md).
 
-Full documentation lives in [`docs/`](docs/README.md).
+</details>
 
-**User guide** — [installation](docs/user-guide/installation.md) ·
-[authentication](docs/user-guide/authentication.md) ·
-[workspaces & profiles](docs/user-guide/workspaces.md) ·
-[Slack links & timestamps](docs/user-guide/links-and-timestamps.md) ·
-[conversations](docs/user-guide/conversations.md) ·
-[messages](docs/user-guide/messages.md) ·
-[search](docs/user-guide/search.md) ·
-[saved items](docs/user-guide/saved.md) ·
-[canvas](docs/user-guide/canvas.md) ·
-[scripting & JSON](docs/user-guide/scripting.md) ·
-[troubleshooting](docs/user-guide/troubleshooting.md)
+<details open>
+<summary><b>2. Sign in</b> — one command, no Slack app required</summary>
 
-**Developer docs** — [setup](docs/development/setup.md) ·
-[architecture](docs/development/architecture.md) ·
-[project structure](docs/development/project-structure.md) ·
-[testing](docs/development/testing.md) ·
-[build & release](docs/development/build-and-release.md) ·
-[adding a command](docs/development/adding-a-command.md)
-
-## Authentication
-
-SlackCLI works with two kinds of credentials: **standard** Slack app tokens
-(`xoxb-*` / `xoxp-*`) and **browser** session tokens (`xoxd-*` + `xoxc-*`). There
-are four ways to get signed in:
+<br>
 
 ```bash
-# 1. Automatic browser login (easiest) — sign in once, every workspace enrolled
 slackcli auth login-auto
-
-# 2. Standard Slack app token
-slackcli auth login --token=xoxb-YOUR-TOKEN --workspace-name="My Team"
-
-# 3. Parse a cURL command copied from browser DevTools
-slackcli auth parse-curl --login
-
-# 4. Browser session tokens by hand
-slackcli auth extract-tokens          # prints the guide
-slackcli auth login-browser --xoxd=xoxd-... --xoxc=xoxc-... --workspace-url=https://yourteam.slack.com
 ```
 
-Which to pick, what `login-auto` does with your browser profile, the security
-model, and the OAuth scopes each command needs are all in the
-[authentication guide](docs/user-guide/authentication.md).
+A browser opens, you sign into Slack as you normally would, and SlackCLI captures the
+session tokens for **every workspace on that account**. Nothing leaves your machine.
 
-## Quick tour
+Prefer a real Slack app token, or need a service account? There are three other ways —
+see [authentication](#-authentication-two-kinds-of-credentials) below.
+
+</details>
+
+<details open>
+<summary><b>3. Do something useful</b></summary>
+
+<br>
 
 ```bash
-# Conversations
-slackcli conversations list --types=public_channel
-slackcli conversations read C1234567890 --limit=50
-slackcli conversations unread
-
-# Messages — paste a Slack link instead of juggling IDs
-slackcli messages send --recipient-id=C1234567890 --message="Hello team!"
-slackcli messages send --permalink="https://myteam.slack.com/archives/C123/p1234567890123456" --message="On it"
-slackcli messages react --permalink="$LINK" --emoji=+1
-slackcli messages edit --channel-id=C123 --timestamp=1234567890.123456 --message="Corrected"
-
-# Search, saved items, canvases
+slackcli conversations unread                       # what did I miss?
 slackcli search messages "deploy failed" --in=engineering
-slackcli saved list --state=to_do
-slackcli canvas read F1234567890
-
-# Anything that returns data speaks JSON
-slackcli conversations read C1234567890 --json | jq '.messages[].text'
-
-# Several workspaces, or several identities in one workspace
-slackcli conversations list --workspace=automation-bot
+slackcli messages send --permalink="$LINK" --message="On it 👀"
 ```
 
-`slackcli <group> --help` prints the authoritative options for your version. For
-everything else — Block Kit tables and Markdown blocks, file uploads, drafts,
-pagination, profiles — see the [user guide](docs/user-guide/README.md).
+</details>
 
-## Configuration
+> [!TIP]
+> Anywhere SlackCLI wants a channel ID or a timestamp, you can paste a **Slack link**
+> instead. Copy a permalink out of the Slack app and hand it straight to the CLI —
+> see [links & timestamps](docs/user-guide/links-and-timestamps.md).
+
+---
+
+## 🧭 What do you want to do?
+
+| I want to… | Try this | Learn more |
+|---|---|---|
+| See what I missed | `slackcli conversations unread` | [conversations](docs/user-guide/conversations.md) |
+| Read a channel or a thread | `slackcli conversations read C123 --limit=50` | [conversations](docs/user-guide/conversations.md) |
+| Send, reply, edit, or react | `slackcli messages send --permalink="$LINK" --message="…"` | [messages](docs/user-guide/messages.md) |
+| Search the workspace | `slackcli search messages "release notes"` | [search](docs/user-guide/search.md) |
+| Find a channel or a person | `slackcli search people "ada"` | [search](docs/user-guide/search.md) |
+| Work through "saved for later" | `slackcli saved list --state=to_do` | [saved items](docs/user-guide/saved.md) |
+| Read a Canvas as Markdown | `slackcli canvas read F123` | [canvas](docs/user-guide/canvas.md) |
+| Upload a file with a message | `slackcli messages send --file=./report.pdf …` | [messages](docs/user-guide/messages.md) |
+| Post rich Block Kit content | `slackcli messages send --blocks=@blocks.json …` | [messages](docs/user-guide/messages.md) |
+| Script it / feed an AI agent | `… --json \| jq` | [scripting & JSON](docs/user-guide/scripting.md) |
+| Juggle several workspaces | `slackcli conversations list --workspace=automation-bot` | [workspaces](docs/user-guide/workspaces.md) |
+| Fix something that broke | `slackcli auth list` | [troubleshooting](docs/user-guide/troubleshooting.md) |
+
+---
+
+## 🤖 Built to be scripted
+
+Every command that returns data speaks `--json`, so SlackCLI drops straight into shell
+pipelines, cron jobs, CI steps, and AI agent toolchains.
+
+```bash
+# Who is talking about the outage, and when?
+slackcli search messages "outage" --in=incidents --json \
+  | jq -r '.matches[] | "\(.username)\t\(.text)"'
+
+# Turn today's unreads into a digest
+slackcli conversations unread --json | jq '[.unread_channels[] | {name, unread_count}]'
+
+# Read a thread, summarise it elsewhere, reply with the result
+slackcli conversations read --permalink="$LINK" --json | jq '.messages[].text'
+```
+
+No Slack app, no OAuth dance, no webhook server — just a binary and a token.
+Patterns, exit codes, and pagination are in [scripting & JSON output](docs/user-guide/scripting.md).
+
+---
+
+## 🔐 Authentication: two kinds of credentials
+
+SlackCLI talks to Slack either as a **Slack app** (`xoxb-*` / `xoxp-*`) or as a
+**signed-in browser session** (`xoxd-*` + `xoxc-*`). One `SlackClient` abstracts both.
+
+```mermaid
+flowchart LR
+    A["Any slackcli command"] --> B{"Workspace<br/>auth type"}
+    B -->|standard| C["@slack/web-api<br/>xoxb / xoxp"]
+    B -->|browser| D["fetch + session headers<br/>xoxd + xoxc"]
+    C --> E(("Slack API"))
+    D --> E
+```
+
+<details>
+<summary><b>Four ways to sign in</b> — and which one to pick</summary>
+
+<br>
+
+| Method | Command | Best for |
+|---|---|---|
+| **Automatic browser login** | `slackcli auth login-auto` | Almost everyone. Sign in once, all workspaces enrolled. |
+| **Slack app token** | `slackcli auth login --token=xoxb-… --workspace-name="My Team"` | Bots, CI, service accounts, long-lived automation. |
+| **Parse a DevTools cURL** | `slackcli auth parse-curl --login` | Locked-down browsers, or when you already copied the request. |
+| **Browser tokens by hand** | `slackcli auth login-browser --xoxd=… --xoxc=… --workspace-url=…` | Full control, or scripted provisioning. |
+
+Browser session tokens can create **drafts**, which a Slack app simply cannot do, and
+they back `saved list` and `conversations unread` with Slack's own native endpoints
+rather than approximations. Slack app tokens are more stable and survive a browser logout.
+
+`slackcli auth extract-tokens` prints the manual walkthrough.
+The security model, the OAuth scopes each command needs, and what `login-auto` does with
+your browser profile are all in the [authentication guide](docs/user-guide/authentication.md).
+
+</details>
+
+<details>
+<summary><b>Where credentials live</b></summary>
+
+<br>
 
 Configuration lives in `~/.config/slackcli/` (directory mode `0700`):
 
@@ -180,70 +233,254 @@ Configuration lives in `~/.config/slackcli/` (directory mode `0700`):
 | `update-check.json` | Cached update check, refreshed at most daily |
 | `browser-profile/` | The browser profile used by `auth login-auto` |
 
-`workspaces.json` and `browser-profile/` both hold live credentials — do not
-commit, sync, or share them. `slackcli auth logout` clears both.
+`workspaces.json` and `browser-profile/` both hold **live credentials** — do not commit,
+sync, or share them. `slackcli auth logout` clears both.
 
-## Development
-
-```bash
-bun install
-pre-commit install          # enforces the same checks CI runs
-bun run dev --help          # run from source
-bun test                    # tests
-bun run type-check          # bunx tsc --noEmit
-bun run build               # ./dist/slackcli
-```
-
-See the [developer docs](docs/development/README.md) for the architecture, the
-project layout, testing conventions, and the release process.
-
-## Contributing
-
-Contributions are welcome, and the process is a little stricter than most repos:
-
-1. **Open an issue first**, describing WHAT the change is, WHY it is needed, and
-   optionally HOW.
-2. **Wait for the `ready-for-pr` label.** This is how the maintainer decides
-   which features belong in the CLI, and it locks the feature to your PR.
-3. Fork, branch, and open a pull request that **links the issue**. A workflow
-   enforces the link.
-4. Make sure type-check, tests, and pre-commit hooks pass, and that your commits
-   are signed.
-
-The full policy is in [CONTRIBUTING.md](CONTRIBUTING.md) and
-[CLAUDE.md](CLAUDE.md). Security issues go through [SECURITY.md](SECURITY.md),
-never a public issue.
-
-## Troubleshooting
-
-Common problems — expired tokens, missing OAuth scopes, permission errors,
-`login-auto` not finding a browser, update failures — are covered in the
-[troubleshooting guide](docs/user-guide/troubleshooting.md).
-
-## License
-
-MIT License - see [LICENSE](LICENSE) file for details
-
-## Support
-
-- 🐛 [Report Issues](https://github.com/shaharia-lab/slackcli/issues)
-- 💬 [Discussions](https://github.com/shaharia-lab/slackcli/discussions)
-- 📧 Email: support@shaharia.com
-
-## 🤝 Contributors
-
-A huge thanks to the amazing people who have contributed to SlackCLI!
-
-<a href="https://github.com/shaharia-lab/slackcli/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=shaharia-lab/slackcli" />
-</a>
-
-## Acknowledgments
-
-- Built with [Bun](https://bun.sh)
-- Powered by [@slack/web-api](https://slack.dev/node-slack-sdk/)
-- Inspired by [gscli](https://github.com/shaharia-lab/gscli)
+</details>
 
 ---
 
-**Made with ❤️ by Shaharia Lab**
+## 📖 Command reference
+
+Seven command groups. `slackcli <group> --help` always prints the authoritative options
+for the version you have installed.
+
+<details>
+<summary><code>auth</code> — sign in, manage workspaces</summary>
+
+<br>
+
+| Command | Does |
+|---|---|
+| `auth login-auto` | Sign in through a browser; captures tokens automatically |
+| `auth login` | Sign in with a standard Slack app token (`xoxb-*` / `xoxp-*`) |
+| `auth login-browser` | Sign in with browser session tokens (`xoxd-*` + `xoxc-*`) |
+| `auth parse-curl` | Extract tokens from a cURL command copied out of DevTools |
+| `auth extract-tokens` | Print the manual token-extraction guide |
+| `auth list` | List authenticated workspaces |
+| `auth set-default <workspace>` | Choose the default workspace |
+| `auth remove <workspace>` | Remove one workspace |
+| `auth logout` | Remove all workspaces and the stored browser profile |
+
+📄 [authentication](docs/user-guide/authentication.md) · [workspaces & profiles](docs/user-guide/workspaces.md)
+
+</details>
+
+<details>
+<summary><code>conversations</code> — channels, DMs, threads, unreads</summary>
+
+<br>
+
+```bash
+slackcli conversations list --types=public_channel
+slackcli conversations read C1234567890 --limit=50
+slackcli conversations read --permalink="$LINK"          # reads that message's thread
+slackcli conversations get C1234567890 1234567890.123456
+slackcli conversations unread
+```
+
+📄 [conversations](docs/user-guide/conversations.md)
+
+</details>
+
+<details>
+<summary><code>messages</code> — send, reply, edit, react, draft</summary>
+
+<br>
+
+```bash
+slackcli messages send --recipient-id=C1234567890 --message="Hello team!"
+slackcli messages send --permalink="$LINK" --message="On it"      # replies in-thread
+slackcli messages send --recipient-id=C123 --file=./report.pdf --message="Latest numbers"
+slackcli messages send --recipient-id=C123 --blocks=@blocks.json
+slackcli messages react --permalink="$LINK" --emoji=+1
+slackcli messages edit --channel-id=C123 --timestamp=1234567890.123456 --message="Corrected"
+slackcli messages draft --recipient-id=C123 --message="Draft for later"
+```
+
+> [!NOTE]
+> `messages draft` requires browser session tokens — Slack apps cannot create drafts.
+
+📄 [messages](docs/user-guide/messages.md)
+
+</details>
+
+<details>
+<summary><code>search</code> — messages, channels, people</summary>
+
+<br>
+
+```bash
+slackcli search messages "deploy failed" --in=engineering --from=ada --limit=50
+slackcli search channels "incident"
+slackcli search people "ada@example.com"
+```
+
+📄 [search](docs/user-guide/search.md)
+
+</details>
+
+<details>
+<summary><code>saved</code> · <code>canvas</code> · <code>update</code></summary>
+
+<br>
+
+```bash
+slackcli saved list --state=to_do            # saved | to_do | completed
+slackcli canvas list --channel=C1234567890
+slackcli canvas read F1234567890             # Canvas -> Markdown
+slackcli update check                        # is there a newer version?
+slackcli update                              # install it
+```
+
+📄 [saved items](docs/user-guide/saved.md) · [canvas](docs/user-guide/canvas.md)
+
+</details>
+
+---
+
+## ⭐ Star it, share it
+
+SlackCLI is a small independent project with no company behind it. Stars are the
+entire growth engine — they are how the next person finds this instead of writing
+the same glue script for the fifth time.
+
+<div align="center">
+
+**If SlackCLI saved you an afternoon, [give it a star](https://github.com/shaharia-lab/slackcli) — it takes two seconds.**
+
+[![Star this repo](https://img.shields.io/badge/⭐_Star_this_repo-181717?style=for-the-badge&logo=github)](https://github.com/shaharia-lab/slackcli)
+[![Share on X](https://img.shields.io/badge/Share_on_X-000000?style=for-the-badge&logo=x&logoColor=white)](https://twitter.com/intent/tweet?text=SlackCLI%20%E2%80%94%20drive%20your%20Slack%20workspace%20from%20the%20terminal%2C%20with%20JSON%20output%20for%20scripts%20and%20AI%20agents.&url=https%3A%2F%2Fgithub.com%2Fshaharia-lab%2Fslackcli)
+[![Discuss](https://img.shields.io/badge/Join_the_discussion-5865F2?style=for-the-badge&logo=github)](https://github.com/shaharia-lab/slackcli/discussions)
+
+</div>
+
+Other things that genuinely help, in rough order of usefulness:
+
+- ⭐ **Star the repo** — the single highest-leverage thing.
+- 🐛 **Open an issue** when something breaks or a command feels wrong.
+- 💬 **Tell one person** who lives in Slack and in a terminal.
+- ✍️ **Write about it** — a blog post, a work Slack message, a comment on HN or Reddit.
+- 🛠️ **Send a PR** — see [Contributing](#-contributing) below.
+
+<details>
+<summary>Star history</summary>
+
+<br>
+
+<a href="https://star-history.com/#shaharia-lab/slackcli&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=shaharia-lab/slackcli&type=Date&theme=dark" />
+    <img alt="Star history chart for shaharia-lab/slackcli" src="https://api.star-history.com/svg?repos=shaharia-lab/slackcli&type=Date" />
+  </picture>
+</a>
+
+</details>
+
+---
+
+## 📚 Documentation
+
+Everything lives in [`docs/`](docs/README.md).
+
+<table>
+<tr>
+<td valign="top" width="50%">
+
+**User guide** — how to *use* it
+
+- [Installation](docs/user-guide/installation.md)
+- [Authentication](docs/user-guide/authentication.md)
+- [Workspaces & profiles](docs/user-guide/workspaces.md)
+- [Slack links & timestamps](docs/user-guide/links-and-timestamps.md)
+- [Conversations](docs/user-guide/conversations.md)
+- [Messages](docs/user-guide/messages.md)
+- [Search](docs/user-guide/search.md)
+- [Saved items](docs/user-guide/saved.md)
+- [Canvas](docs/user-guide/canvas.md)
+- [Scripting & JSON output](docs/user-guide/scripting.md)
+- [Troubleshooting](docs/user-guide/troubleshooting.md)
+
+</td>
+<td valign="top" width="50%">
+
+**Developer docs** — how to *work on* it
+
+- [Development setup](docs/development/setup.md)
+- [Architecture](docs/development/architecture.md)
+- [Project structure](docs/development/project-structure.md)
+- [Testing](docs/development/testing.md)
+- [Build & release](docs/development/build-and-release.md)
+- [Adding a command](docs/development/adding-a-command.md)
+
+<br>
+
+```bash
+bun install
+pre-commit install     # same checks CI runs
+bun run dev --help     # run from source
+bun test               # 400+ tests
+bun run type-check
+bun run build          # -> ./dist/slackcli
+```
+
+</td>
+</tr>
+</table>
+
+---
+
+## 🤝 Contributing
+
+Contributions are very welcome — and the process here is a little stricter than most
+repos, on purpose.
+
+> [!IMPORTANT]
+> **Open an issue first, and wait for the `ready-for-pr` label.** That label is how the
+> maintainer decides which features belong in the CLI, and it locks the feature to your
+> PR so nobody duplicates your work. A workflow enforces the issue link.
+
+1. **[Open an issue](https://github.com/shaharia-lab/slackcli/issues/new)** describing
+   **WHAT** the change is, **WHY** it is needed, and optionally **HOW**.
+2. Wait for triage and the **`ready-for-pr`** label.
+3. Fork, branch, and open a PR that **links the issue** (`Closes #123`).
+4. Make sure type-check, tests, and pre-commit hooks pass, and that your commits are
+   **signed**.
+
+Looking for a place to start? Try
+[`good first issue`](https://github.com/shaharia-lab/slackcli/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+or [`help wanted`](https://github.com/shaharia-lab/slackcli/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
+
+The full policy is in [CONTRIBUTING.md](CONTRIBUTING.md) and [CLAUDE.md](CLAUDE.md).
+Security issues go through [SECURITY.md](SECURITY.md) — never a public issue.
+
+### Contributors
+
+<a href="https://github.com/shaharia-lab/slackcli/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=shaharia-lab/slackcli" alt="Contributors" />
+</a>
+
+---
+
+## 💬 Support
+
+- 🐛 [Report a bug or request a feature](https://github.com/shaharia-lab/slackcli/issues)
+- 💬 [Discussions](https://github.com/shaharia-lab/slackcli/discussions)
+- 🔒 [Security policy](SECURITY.md)
+- 📧 support@shaharia.com
+
+## 📄 License
+
+[MIT](LICENSE) — do what you like, no warranty.
+
+Built with [Bun](https://bun.sh) · powered by [@slack/web-api](https://slack.dev/node-slack-sdk/) ·
+inspired by [gscli](https://github.com/shaharia-lab/gscli)
+
+<div align="center">
+<br>
+
+**Made with ❤️ by [Shaharia Lab](https://github.com/shaharia-lab)**
+
+⭐ [Star SlackCLI](https://github.com/shaharia-lab/slackcli) if it made your day a little shorter.
+
+</div>

--- a/README.md
+++ b/README.md
@@ -21,11 +21,10 @@ No Slack app to build, no admin approval to wait for.
 
 ### ⭐ Like the idea? Star the repo.
 
-SlackCLI is an independent open-source project with no company behind it.
-A star takes two seconds and is how the next person finds it.
+It takes two seconds, and it is how the next person finds SlackCLI.
 
-[![Star this repo](https://img.shields.io/badge/⭐_Star_SlackCLI-181717?style=for-the-badge&logo=github)](https://github.com/shaharia-lab/slackcli)
-[![Share on X](https://img.shields.io/badge/Tell_someone-000000?style=for-the-badge&logo=x&logoColor=white)](https://twitter.com/intent/tweet?text=SlackCLI%20%E2%80%94%20work%20with%20one%20or%20many%20Slack%20workspaces%20straight%20from%20your%20terminal%2C%20and%20let%20AI%20agents%20do%20it%20too.&url=https%3A%2F%2Fgithub.com%2Fshaharia-lab%2Fslackcli)
+[![Star SlackCLI](https://img.shields.io/badge/⭐_Star_SlackCLI-181717?style=for-the-badge&logo=github)](https://github.com/shaharia-lab/slackcli)
+[![Share it](https://img.shields.io/badge/📣_Share_it-3fa045?style=for-the-badge)](#-spread-the-word)
 
 </div>
 
@@ -359,7 +358,17 @@ keep it alive is to make it easier for the next person to find.
 
 **[⭐ Star SlackCLI](https://github.com/shaharia-lab/slackcli)** ·
 **[💬 Say hello in Discussions](https://github.com/shaharia-lab/slackcli/discussions)** ·
-**[📣 Tell someone](https://twitter.com/intent/tweet?text=SlackCLI%20%E2%80%94%20work%20with%20one%20or%20many%20Slack%20workspaces%20straight%20from%20your%20terminal%2C%20and%20let%20AI%20agents%20do%20it%20too.&url=https%3A%2F%2Fgithub.com%2Fshaharia-lab%2Fslackcli)**
+**[🐛 Report something broken](https://github.com/shaharia-lab/slackcli/issues)**
+
+<br>
+
+**Share it with one person who lives in Slack and in a terminal**
+
+[![X](https://img.shields.io/badge/X-000000?style=for-the-badge&logo=x&logoColor=white)](https://twitter.com/intent/tweet?text=SlackCLI%20%E2%80%94%20work%20with%20one%20or%20many%20Slack%20workspaces%20straight%20from%20your%20terminal%2C%20and%20let%20AI%20agents%20do%20it%20too.&url=https%3A%2F%2Fgithub.com%2Fshaharia-lab%2Fslackcli)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fgithub.com%2Fshaharia-lab%2Fslackcli)
+[![Bluesky](https://img.shields.io/badge/Bluesky-0285FF?style=for-the-badge&logo=bluesky&logoColor=white)](https://bsky.app/intent/compose?text=SlackCLI%20%E2%80%94%20work%20with%20one%20or%20many%20Slack%20workspaces%20straight%20from%20your%20terminal%2C%20and%20let%20AI%20agents%20do%20it%20too.%20https%3A%2F%2Fgithub.com%2Fshaharia-lab%2Fslackcli)
+[![Reddit](https://img.shields.io/badge/Reddit-FF4500?style=for-the-badge&logo=reddit&logoColor=white)](https://www.reddit.com/submit?url=https%3A%2F%2Fgithub.com%2Fshaharia-lab%2Fslackcli&title=SlackCLI%20%E2%80%94%20work%20with%20one%20or%20many%20Slack%20workspaces%20straight%20from%20your%20terminal)
+[![Hacker News](https://img.shields.io/badge/Hacker_News-FF6600?style=for-the-badge&logo=ycombinator&logoColor=white)](https://news.ycombinator.com/submitlink?u=https%3A%2F%2Fgithub.com%2Fshaharia-lab%2Fslackcli&t=SlackCLI%20%E2%80%94%20work%20with%20one%20or%20many%20Slack%20workspaces%20straight%20from%20your%20terminal)
 
 </div>
 


### PR DESCRIPTION
Closes #130

## What

`README.md` rewritten from scratch as a **landing page**. Now that `docs/` exists
(#128), the README no longer has to be the manual — it has to make the first
15 seconds count and then get out of the way.

Documentation only. No source changes, no behaviour changes.

## The shape of the new page

| Section | Purpose |
|---|---|
| Hero + badges + nav | A plain-language subtitle (works across one or many workspaces, AI-agent friendly), badges answering the "is this maintained?" question above the fold, and a short **star ask** directly under the nav |
| Demo video | Kept, moved up, with a one-line description of what it shows |
| Unofficial-tool disclaimer | Now a GitHub `[!IMPORTANT]` alert instead of a plain quote |
| **Quickstart** | Three `<details open>` steps — install, sign in, do something useful. Per-platform installs nest one level deeper, so the page is short but nothing is more than a click away |
| **What do you want to do?** | A 12-row task table: intent → command → docs page. This is the routing layer into `docs/` |
| **Built to be scripted** | Three real `jq` pipelines; the AI-agent / automation pitch that the repo description already makes but the README never did |
| **Authentication** | A Mermaid diagram of the dual-auth dispatch, with the four sign-in methods and the credential-storage table collapsed underneath |
| **Command reference** | One `<details>` per command group, all seven covered |
| **Spread the word** | The fuller ask once the reader has seen what the tool does, plus a collapsed star-history chart |
| **Documentation** | Two-column table: user guide vs developer docs, with the dev command block |
| **Contributing** | Leads with the issue-first / `ready-for-pr` policy as an `[!IMPORTANT]` alert, then `good first issue` / `help wanted` entry points |

## Interactivity

Everything is GitHub-native rendering — no committed assets, no external JS:
15 `<details>` blocks (2 levels deep in the install section), alert blockquotes,
a Mermaid fence, `<picture>` with `prefers-color-scheme` for the star-history
chart so it works in both themes, and anchor nav in the hero.

## The star / share ask

Previously absent from the page entirely. Now asked twice, at the two moments
someone is actually willing to act:

1. **In the hero**, right under the nav — a one-line ask in plain text, with
   the heading itself linking to the repo. No buttons; the status badges are
   directly above it and a second button row read as redundant.
2. **Lower down** as "Spread the word", once the reader has seen what the tool
   does — star / discussions / issues links, a row of share buttons, a ranked
   list of other ways to help, and a collapsed star-history chart.

Plus a closing line in the footer. Deliberately not sprinkled anywhere else.

## Revision after first review

Two changes on top of the original push:

- The subtitle led with *"pipe it all into `jq`"*, which reads as complexity to
  anyone who is not already a shell user. It now leads with working across one
  or many workspaces and names the **AI-agent friendly** angle instead of a
  specific tool. `jq` still appears, but down in the scripting section where
  the audience is self-selected.
- The only star ask sat three quarters of the way down the page. There is now
  one in the hero, and the lower section was retitled and trimmed so the two
  complement rather than repeat each other.

## Revision after second review

- Dropped the "no company behind it" framing from the star ask. It now just
  says what a star does.
- Sharing was X-only for no better reason than reflex. The share row now covers
  **X, LinkedIn, Bluesky, Reddit and Hacker News**. All carry a pre-written line
  except LinkedIn, which dropped support for pre-filled share text — its link
  passes the URL only and LinkedIn renders the repository's own Open Graph
  title and description.
- One cosmetic caveat: shields.io no longer serves a LinkedIn icon (simple-icons
  removed it over trademark policy), so that badge is text-on-LinkedIn-blue
  while the other four have their icons.
- The hero's own star/share buttons were dropped — plain text there instead.
  The share row in "Spread the word" is unchanged.

## Accuracy pass

Everything on the page was checked against the current source rather than
copied forward:

- Every command and flag verified against `--help` for each of the seven groups.
- `conversations unread --json` emits `{ unread_channels: [...] }`, not
  `.channels` — the `jq` example uses the real key.
- `search messages --json` match fields (`username`, `text`) checked against
  `SearchMatch` in `src/types/index.ts`.
- Corrected a claim I had initially written: only **drafts** are genuinely
  browser-token-only. `saved list` and `conversations unread` work under both
  auth types — browser auth just backs them with Slack's native `saved.list` /
  `client.counts` instead of `stars.list` / a `conversations.list` scan
  (`src/lib/slack-client.ts:289,372`).
- `update` installs, `update check` checks — both listed correctly.
- "400+ tests" — `bun test` reports 422.

## Verification

- All 22 relative links resolve from the repo root.
- All heading anchors used in the hero nav match their headings.
- HTML tag balance checked (`<details>` 15/15, `<div>` 3/3, table tags 4/4).
- `pre-commit run --files README.md` passes.
- `bun test` — 422 pass / 0 fail (unchanged; nothing in `src/` was touched).

Worth eyeballing the rendered page on the PR's **Files changed → rich diff**
before merging — the `<details>`/Mermaid/star-history bits only really show
there.
