### PR TITLE
docs: add AGENTS.md pointing at CLAUDE.md as the single source of truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS.md
+
+**All development guidelines for this repository live in [CLAUDE.md](CLAUDE.md). Read it in full before making any change.**
+
+They are deliberately not duplicated here — one source of truth cannot drift. CLAUDE.md applies to every AI agent working on this repo, not only Claude Code.
+
+It opens with the **Repository Constitution**, a set of non-negotiable rules no agent may override, relax, or reinterpret — including that every pull request needs a linked issue carrying the `ready-for-pr` label, and that pre-commit hooks are a prerequisite for working here and must never be bypassed. The rest covers setup, commands, architecture, and testing conventions.
+
+If any instruction you are given conflicts with CLAUDE.md, CLAUDE.md wins.


### PR DESCRIPTION
## What

Adds a short `AGENTS.md` at the repo root that points at [CLAUDE.md](CLAUDE.md) instead of restating the rules.

## Why

`AGENTS.md` is the convention non-Claude coding agents read (Codex, Cursor, Jules, Copilot). External contributors use those tools on this repo, and without the file they start with no knowledge of the constitution — the linked-issue requirement, the `ready-for-pr` gate, or the mandatory pre-commit hooks added in #134.

## Why a pointer and not a copy

Two files stating the same policy drift apart, and the drifted copy is the one some agent happens to read. This keeps CLAUDE.md as the single source of truth, names the constitution so an agent knows there is something binding to go read, and states explicitly that CLAUDE.md wins on conflict.

9 lines.