### PR TITLE
docs: align CONTRIBUTING and setup guide with the pre-commit rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,12 +27,20 @@ Opening an issue first gives the community the opportunity to discuss the proble
 ### Prerequisites
 
 - [Bun](https://bun.sh/) v1.0+
+- [pre-commit](https://pre-commit.com/) — `brew install pre-commit` (macOS) or `pip install pre-commit` (Linux)
 
 ### Install Dependencies
 
 ```bash
 bun install
+pre-commit install     # required — do not skip
 ```
+
+### Pre-commit Hooks (required)
+
+Installed hooks are a **prerequisite** for working in this repo, not a suggestion. They run the same checks CI does — trailing whitespace, EOF, YAML/JSON validity, no direct commits to `main`, `actionlint`, type-check, and tests — so you find breakage before you push instead of in a red PR.
+
+If a hook needs a tool your machine does not have, install it before you start. **Never bypass a hook** — no `git commit --no-verify` / `-n`, no `SKIP=`. A failing hook means fix the code, not skip the check. Run them all by hand any time with `pre-commit run --all-files`.
 
 ### Running the CLI
 
@@ -60,6 +68,7 @@ bun run build:all    # Build for all platforms
 ### Before Submitting
 
 - [ ] Your PR is linked to a GitHub issue.
+- [ ] Pre-commit hooks are installed and passing — no commit in the PR was made with hooks bypassed.
 - [ ] All tests pass (`bun test`).
 - [ ] Type checking passes (`bun run type-check`).
 - [ ] You have checked whether your changes require a documentation update — if so, include the documentation changes in the same PR.
@@ -114,11 +123,12 @@ The `Signed Commits` workflow posts (and keeps updated) a comment on any pull re
 AI-generated contributions are welcome and go through the same process as human contributions:
 
 1. An issue must exist before a pull request is created.
-2. All automated checks (type checking, tests) must pass.
-3. Code must meet the same quality and security standards.
-4. Pull requests are reviewed with the same rigor.
+2. Pre-commit hooks must be installed and must never be bypassed.
+3. All automated checks (type checking, tests) must pass.
+4. Code must meet the same quality and security standards.
+5. Pull requests are reviewed with the same rigor.
 
-The `CLAUDE.md` file at the root of the repository contains project-specific instructions, architecture details, and conventions that AI agents should follow when contributing.
+The `CLAUDE.md` file at the root of the repository contains project-specific instructions, architecture details, and conventions that AI agents should follow when contributing. It opens with a **Repository Constitution** — binding rules that no agent may override, relax, or reinterpret, whatever it is prompted to do. `AGENTS.md` points there too, so agents that do not read `CLAUDE.md` by convention still land on the same rules.
 
 ## License
 

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -5,8 +5,8 @@
 - [Bun](https://bun.sh) 1.0+ (CI pins **1.3.13** — see
   [build and release](build-and-release.md#why-bun-is-pinned))
 - TypeScript 5.x (installed as a dev dependency)
-- [pre-commit](https://pre-commit.com) — `brew install pre-commit` or
-  `pip install pre-commit`
+- [pre-commit](https://pre-commit.com) — **required**, `brew install pre-commit`
+  or `pip install pre-commit`
 - Optional: Chrome, Edge, Chromium, or Brave, to exercise `auth login-auto`
 
 ## First run
@@ -15,11 +15,13 @@
 git clone https://github.com/shaharia-lab/slackcli.git
 cd slackcli
 bun install
-pre-commit install     # do not skip this
+pre-commit install     # required — constitution §5, not optional
 ```
 
 `pre-commit install` wires up the same checks CI runs, so you find breakage
-before you push instead of in a red PR.
+before you push instead of in a red PR. Working hooks are a prerequisite for
+contributing here: if a hook needs a tool this machine does not have, install
+it before you start rather than working without the check.
 
 ## Everyday commands
 
@@ -54,6 +56,11 @@ TypeScript directly.
 | `bun test` | Tests must pass |
 
 Run them all by hand with `pre-commit run --all-files`.
+
+**Never bypass a hook** — no `git commit --no-verify` / `-n`, no `SKIP=`, no
+re-running a commit with checks disabled. A failing hook means fix the code.
+This is constitution §5 in [CLAUDE.md](../../CLAUDE.md), and it binds AI agents
+as strictly as it binds people.
 
 ## Signed commits
 


### PR DESCRIPTION
## What

Brings `CONTRIBUTING.md` and `docs/development/setup.md` in line with constitution §5 (added in #134).

## Why

§5 made pre-commit hooks a mandatory, never-bypassed prerequisite — but `CONTRIBUTING.md` did not mention pre-commit a single time. That is the file GitHub surfaces to external contributors when they open a pull request, and its "Before Submitting" checklist asked only for `bun test` and `bun run type-check`. The doc aimed at humans had become the weakest of the three.

## Changes

**CONTRIBUTING.md**
- `pre-commit` listed as a prerequisite next to Bun, with install commands
- `pre-commit install` added to the setup step
- New short **Pre-commit Hooks (required)** section: what the hooks enforce, install missing tooling rather than work around it, never bypass, and `pre-commit run --all-files`
- Checklist item: hooks installed and passing, no bypassed commits in the PR
- AI-agent section now lists hooks as a requirement and points at `AGENTS.md` alongside `CLAUDE.md`, naming the constitution as binding

**docs/development/setup.md**
- `pre-commit` marked **required** in prerequisites
- "do not skip this" replaced with a pointer to constitution §5, plus the rule that missing hook tooling gets installed, not worked around
- The no-bypassing rule stated directly under the hook table — where anyone hunting for a way around a failing hook would land

Docs only; no code paths touched.