### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-08-29
+
 ### Added
-- **Native Block Kit messages**: `messages send --blocks <json|@file>` passes a JSON array of structured blocks to `chat.postMessage`, including Slack's native `table` blocks with rich-text cells and `markdown` blocks with standard Markdown. Works with standard and browser-session authentication.
+- **Native Block Kit messages**: `messages send --blocks <json|@file>` passes a JSON array of structured blocks to `chat.postMessage`, including Slack's native `table` blocks with rich-text cells and `markdown` blocks with standard Markdown. Works with standard and browser-session authentication (#121)
 
 ## [0.9.1] - 2026-08-21
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slackcli",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "A fast, developer-friendly CLI tool for interacting with Slack workspaces",
   "main": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary

Cut release **v0.10.0** — bump `package.json` from `0.9.1` to `0.10.0` and promote the `[Unreleased]` CHANGELOG section under a `## [0.10.0] - 2026-08-29` heading.

The bump has to be on `main` *before* the tag is pushed: `release.yml`'s `verify-version` step fails when the tag disagrees with `package.json` (#82).

## Why a minor bump

`0.x` SemVer as this repo uses it: a new capability is a minor, fixes only are a patch. #124 adds a new flag, so `0.9.1` → `0.10.0`.

## Included since v0.9.1

**Added**
- Native Block Kit messages — `messages send --blocks <json|@file>` passes a JSON array of structured blocks to `chat.postMessage`, including Slack's native `table` blocks with rich-text cells and `markdown` blocks. Works with standard and browser-session auth (#121, #124)

Everything else merged since `v0.9.1` is documentation only (#126, #128, #131, #133, #134, #135, #136) — no shipped behaviour, so nothing else in the changelog.

## Changes in this PR

- `package.json`: `0.9.1` → `0.10.0`
- `CHANGELOG.md`: new `[0.10.0]` heading; `[Unreleased]` left in place and empty

## Checks

- `bun run type-check` — clean
- `bun test` — 422 passed, 0 failed
- pre-commit hooks — passed

## After merge

Push the annotated tag `v0.10.0` at the merged bump commit, which triggers `release.yml` to build the binaries and update the Homebrew tap.

This PR is labelled `no-issue-needed`: a release proposes nothing new — everything in it was already authorized when it merged.
