### PR TITLE
docs: sync contributor docs with the new issue and PR templates

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -37,9 +37,12 @@ bun run dev --help
 This repository's contribution policy is stricter than most and is binding on
 human and AI contributors alike:
 
-1. **An issue must exist first**, stating WHAT, WHY, and optionally HOW.
+1. **An issue must exist first**, filed with one of the issue templates (bug
+   report, feature request, improvement) and stating WHAT, WHY, and optionally
+   HOW. Blank issues are disabled.
 2. **The issue must carry the `ready-for-pr` label** before a PR is opened.
-3. The PR must link that issue — a workflow enforces it.
+3. The PR must link that issue and follow the PR template, checklist included —
+   a workflow enforces the link.
 4. Type-check, tests, and pre-commit hooks pass; commits are signed.
 
 Full text: [CONTRIBUTING.md](../../CONTRIBUTING.md), and the constitution at the

--- a/docs/development/adding-a-command.md
+++ b/docs/development/adding-a-command.md
@@ -2,9 +2,9 @@
 
 A worked example: adding `slackcli conversations members <channel-id>`.
 
-Before writing anything, satisfy the policy: open an issue describing WHAT, WHY
-and optionally HOW, and wait for the **`ready-for-pr`** label. See
-[CONTRIBUTING.md](../../CONTRIBUTING.md).
+Before writing anything, satisfy the policy: open an issue with the feature
+request template describing WHAT, WHY and optionally HOW, and wait for the
+**`ready-for-pr`** label. See [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
 ## 1. Types first
 
@@ -137,4 +137,4 @@ review:
 - [ ] Errors: `spinner.fail(...)`, `error(message)`, `process.exit(1)`.
 - [ ] Never print a token value.
 - [ ] `bun run type-check` and `bun test` pass; commits are signed.
-- [ ] The PR links a `ready-for-pr` issue.
+- [ ] The PR links a `ready-for-pr` issue and follows the PR template.

--- a/docs/development/project-structure.md
+++ b/docs/development/project-structure.md
@@ -17,6 +17,8 @@ slackcli/
 │   └── types/index.ts            Shared interfaces
 ├── scripts/build.ts              Compile wrapper that injects __APP_VERSION__
 ├── .github/workflows/            CI, tests, release, policy checks
+├── .github/ISSUE_TEMPLATE/       Issue forms; blank issues are disabled
+├── .github/PULL_REQUEST_TEMPLATE.md  Linked-issue reference + checklist
 ├── .pre-commit-config.yaml       Local checks mirroring CI
 ├── CLAUDE.md                     Repository constitution + architecture notes
 ├── CONTRIBUTING.md               Contribution policy


### PR DESCRIPTION
## Linked issue

None — this is the nightly documentation sync. Labelled `no-issue-needed`; the decisions being documented were already triaged in the PRs below.

## Merged PRs covered

- **#144** — _docs: refresh CLAUDE.md (fix drift, add hard rules) and add issue/PR templates_. Added `.github/ISSUE_TEMPLATE/` (bug report, feature request, improvement; `blank_issues_enabled: false`) and `.github/PULL_REQUEST_TEMPLATE.md`, and turned "use the templates" into constitution §3. The developer docs still described the older, template-less policy.
- **#142** — _chore: release v0.10.0_. No documentation surface: the diff is `package.json` `version` plus a promoted `CHANGELOG.md` heading. `docs/` states no version number and the build scripts read the version from `package.json`, so nothing went stale.

## What changed in `docs/`

- `docs/development/README.md` — the "Before opening a pull request" list now says an issue must be filed with one of the issue templates (blank issues are disabled), and that the PR must follow the PR template and its checklist.
- `docs/development/adding-a-command.md` — same correction in the opening policy paragraph and in the final checklist item.
- `docs/development/project-structure.md` — the repository tree now lists `.github/ISSUE_TEMPLATE/` and `.github/PULL_REQUEST_TEMPLATE.md`.

Nothing was added or deleted — no page became obsolete.

## Deliberately not documented

- The rest of #144's CLAUDE.md refresh (new constitution rules §6–§8, corrected CI/release descriptions, module table). That file is the constitution itself and `docs/` already links to it; restating it would duplicate a source of truth. The CI/release facts it corrected already matched `docs/development/build-and-release.md`, which was the accurate one.
- #142 in full, per above.

## Checklist

- [x] Documentation-only change, entirely under `docs/`
- [x] Relative links in the touched files verified to resolve
- [x] Pre-commit hooks pass; commit is signed