### PR TITLE
feat: add read-only team and usergroups commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ bun run build:all          # All platforms
 
 ### Entry Point & Command Structure
 
-`src/index.ts` registers the Commander.js command groups `auth`, `canvas`, `conversations`, `messages`, `saved`, `search`, and `update`. Each group is implemented in `src/commands/` and delegates to `src/lib/` modules.
+`src/index.ts` registers the Commander.js command groups `auth`, `canvas`, `conversations`, `messages`, `saved`, `search`, `team`, `usergroups`, and `update`. Each group is implemented in `src/commands/` and delegates to `src/lib/` modules.
 
 ### Dual Authentication
 
@@ -151,6 +151,7 @@ Browser tokens can be captured two ways: pasting a cURL command from DevTools (`
 | `src/lib/interactive-input.ts` | Multi-line terminal input (double-Enter or Ctrl+D to submit) |
 | `src/lib/saved.ts` | Enriches saved-for-later items (resolves messages & channels) |
 | `src/lib/unread.ts` | Fetches and resolves unread channel data |
+| `src/lib/usergroups.ts` | Normalizes user groups and resolves members to names |
 | `src/lib/updater.ts` | Self-update via GitHub releases |
 | `src/lib/canvas-parser.ts` | Slack Canvas HTML to Markdown converter (zero deps, Quip-based HTML) |
 

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -25,6 +25,8 @@ list for the version you have installed.
 | `conversations` | List channels and DMs, read history and threads, unreads |
 | `messages` | Send, reply, edit, react, draft, attach files, Block Kit |
 | `search` | Search messages, channels, and people |
+| `team` | Read the workspace's own name, domain, and ID |
+| `usergroups` | List, read, and manage user groups ("subteams") |
 | `saved` | Read your "saved for later" list |
 | `canvas` | List canvases and read them as Markdown |
 | `update` | Check for and install new versions |
@@ -38,10 +40,12 @@ list for the version you have installed.
 5. [Conversations](conversations.md)
 6. [Messages](messages.md)
 7. [Search](search.md)
-8. [Saved items](saved.md)
-9. [Canvas](canvas.md)
-10. [Scripting and JSON output](scripting.md)
-11. [Troubleshooting](troubleshooting.md)
+8. [Team](team.md)
+9. [User groups](usergroups.md)
+10. [Saved items](saved.md)
+11. [Canvas](canvas.md)
+12. [Scripting and JSON output](scripting.md)
+13. [Troubleshooting](troubleshooting.md)
 
 ## Two things that apply everywhere
 

--- a/docs/user-guide/team.md
+++ b/docs/user-guide/team.md
@@ -1,0 +1,27 @@
+# Team
+
+`slackcli team` reads information about the **workspace (team) itself** — its
+name, domain, and ID.
+
+```bash
+slackcli team info
+slackcli team info --json
+```
+
+## `team info`
+
+Shows the workspace name, ID, domain, and (when present) email domain and
+verification status. Backed by Slack's `team.info`, which works for both
+standard (`xoxb`/`xoxp`) and browser (`xoxd`/`xoxc`) tokens.
+
+| Option | Purpose |
+|---|---|
+| `--team <workspace-id>` | Target workspace T-id (enterprise org scoping) |
+| `--workspace <id\|name>` | Workspace to use |
+| `--json` | JSON output |
+
+On a Slack **Enterprise Grid**, `--team <T-id>` scopes the lookup to a specific
+member workspace; without it Slack returns the token's own workspace.
+
+For **groups of users** within the workspace — what Slack calls User Groups or
+"subteams" — see [User groups](usergroups.md).

--- a/docs/user-guide/usergroups.md
+++ b/docs/user-guide/usergroups.md
@@ -1,0 +1,59 @@
+# User groups
+
+`slackcli usergroups` lists and reads **user groups** — Slack's own name for a
+named, mentionable group of people (also called a "subteam", e.g.
+`@platform-team`).
+
+```bash
+slackcli usergroups list
+slackcli usergroups list --include-disabled --json
+slackcli usergroups read @platform-team
+```
+
+> This PR adds the **read-only** surface (`list`, `read`). The write verbs
+> (`create`, `update`, `add`, `remove`, `enable`, `disable`) land in a
+> follow-up PR so the read side can be reviewed and merged on its own.
+
+## Referring to a group
+
+`read` takes a `<group>` argument that accepts any of:
+
+- the group **ID** (`S03E2T070G7`),
+- the **@handle** (`@platform` or `platform`), or
+- the exact **name** (`"Platform Team"`, case-insensitive).
+
+## `usergroups list`
+
+Lists the workspace's user groups, sorted by name, with each group's handle,
+member count, and enabled/disabled state.
+
+| Option | Purpose |
+|---|---|
+| `--include-disabled` | Include disabled (archived) groups |
+| `--team <workspace-id>` | Scope to one workspace (enterprise org) |
+| `--workspace <id\|name>` | Workspace to use |
+| `--json` | JSON output |
+
+## `usergroups read <group>`
+
+Shows one group and its members, resolving member IDs to names.
+
+| Option | Purpose |
+|---|---|
+| `--team <workspace-id>` | Scope to one workspace (enterprise org) |
+| `--workspace <id\|name>` | Workspace to use |
+| `--json` | JSON output |
+
+## Enterprise orgs and `--team`
+
+On a Slack **Enterprise Grid** a user group belongs to a specific member
+workspace. A group scoped to a member workspace may not appear in the
+org-level `usergroups list`; refer to it by its `S…` ID, and pass
+`--team <workspace-id>` (a `T…` ID) to scope the listing. On a single-workspace
+install `--team` is unnecessary.
+
+## Auth types
+
+Both commands go through Slack's read `usergroups.list` / `usergroups.users.list`
+methods, which work for standard (`xoxb`/`xoxp`) and browser (`xoxd`/`xoxc`)
+tokens alike.

--- a/src/commands/team.ts
+++ b/src/commands/team.ts
@@ -1,0 +1,51 @@
+import { Command } from 'commander';
+import ora from 'ora';
+import { getAuthenticatedClient } from '../lib/auth.ts';
+import { error, formatTeamInfo, writeJson } from '../lib/formatter.ts';
+import type { SlackTeam } from '../types/index.ts';
+
+export function createTeamCommand(): Command {
+  const team = new Command('team')
+    .description('View the workspace (team) itself');
+
+  team
+    .command('info')
+    .description('Show workspace name, domain, and ID')
+    .option('--workspace <id|name>', 'Workspace to use')
+    .option('--team <workspace-id>', 'Target workspace T-id (enterprise org scoping)')
+    .option('--json', 'Output in JSON format', false)
+    .action(async (options) => {
+      const spinner = ora('Fetching workspace info...').start();
+
+      try {
+        const client = await getAuthenticatedClient(options.workspace);
+        const response = await client.getTeamInfo({ team: options.team });
+        const t = response.team ?? {};
+
+        const info: SlackTeam = {
+          id: t.id,
+          name: t.name,
+          domain: t.domain,
+          email_domain: t.email_domain,
+          url: t.url,
+          is_verified: t.is_verified,
+          icon: t.icon,
+        };
+
+        spinner.succeed(`Workspace: ${info.name}`);
+
+        if (options.json) {
+          writeJson(info);
+          return;
+        }
+
+        console.log('\n' + formatTeamInfo(info));
+      } catch (err: any) {
+        spinner.fail('Failed to fetch workspace info');
+        error(err.message);
+        process.exit(1);
+      }
+    });
+
+  return team;
+}

--- a/src/commands/usergroups.ts
+++ b/src/commands/usergroups.ts
@@ -1,0 +1,106 @@
+import { Command } from 'commander';
+import ora from 'ora';
+import { getAuthenticatedClient } from '../lib/auth.ts';
+import {
+  error,
+  formatUsergroup,
+  formatUsergroupList,
+  writeJson,
+} from '../lib/formatter.ts';
+import {
+  fetchUsergroupMembers,
+  fetchUsergroups,
+  resolveUsergroup,
+} from '../lib/usergroups.ts';
+import type { SlackUsergroup } from '../types/index.ts';
+
+// Resolve a <group> argument (id / @handle / name) to a group, or fail the
+// spinner and exit. Shared by every subcommand that takes a group reference.
+async function requireGroup(
+  client: any,
+  ref: string,
+  spinner: ReturnType<typeof ora>,
+  teamId?: string,
+): Promise<SlackUsergroup> {
+  spinner.text = 'Resolving user group...';
+  const group = await resolveUsergroup(client, ref, {
+    teamId,
+    onProgress: (msg) => { spinner.text = msg; },
+  });
+  if (!group) {
+    spinner.fail(`No user group matching "${ref}" (try an ID, @handle, or exact name)`);
+    process.exit(1);
+  }
+  return group;
+}
+
+export function createUsergroupsCommand(): Command {
+  const usergroups = new Command('usergroups')
+    .description('List and read user groups (Slack "subteams")');
+
+  // ─── list ────────────────────────────────────────────────────────────────
+  usergroups
+    .command('list')
+    .description('List the workspace\'s user groups')
+    .option('--include-disabled', 'Include disabled (archived) groups', false)
+    .option('--workspace <id|name>', 'Workspace to use')
+    .option('--team <workspace-id>', 'Target workspace T-id (enterprise org scoping)')
+    .option('--json', 'Output in JSON format', false)
+    .action(async (options) => {
+      const spinner = ora('Fetching user groups...').start();
+      try {
+        const client = await getAuthenticatedClient(options.workspace);
+        const groups = await fetchUsergroups(client, {
+          includeDisabled: options.includeDisabled,
+          teamId: options.team,
+          onProgress: (msg) => { spinner.text = msg; },
+        });
+
+        spinner.succeed(`Found ${groups.length} user group${groups.length === 1 ? '' : 's'}`);
+
+        if (options.json) {
+          writeJson({ usergroup_count: groups.length, usergroups: groups });
+          return;
+        }
+        console.log('\n' + formatUsergroupList(groups));
+      } catch (err: any) {
+        spinner.fail('Failed to fetch user groups');
+        error(err.message);
+        process.exit(1);
+      }
+    });
+
+  // ─── read ────────────────────────────────────────────────────────────────
+  usergroups
+    .command('read')
+    .description('Show a user group and its members')
+    .argument('<group>', 'Group ID, @handle, or exact name')
+    .option('--workspace <id|name>', 'Workspace to use')
+    .option('--team <workspace-id>', 'Target workspace T-id (enterprise org scoping)')
+    .option('--json', 'Output in JSON format', false)
+    .action(async (ref, options) => {
+      const spinner = ora('Fetching user group...').start();
+      try {
+        const client = await getAuthenticatedClient(options.workspace);
+        const group = await requireGroup(client, ref, spinner, options.team);
+        const { ids, members } = await fetchUsergroupMembers(client, group.id, {
+          teamId: options.team,
+          onProgress: (msg) => { spinner.text = msg; },
+        });
+
+        spinner.succeed(`${group.name} — ${members.length} member${members.length === 1 ? '' : 's'}`);
+
+        if (options.json) {
+          writeJson({ ...group, member_ids: ids, members });
+          return;
+        }
+        console.log('\n' + formatUsergroup(group, members));
+      } catch (err: any) {
+        spinner.fail('Failed to read user group');
+        error(err.message);
+        process.exit(1);
+      }
+    });
+
+  return usergroups;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ import { createCanvasCommand } from './commands/canvas.ts';
 import { createUpdateCommand } from './commands/update.ts';
 import { createSavedCommand } from './commands/saved.ts';
 import { createSearchCommand } from './commands/search.ts';
+import { createTeamCommand } from './commands/team.ts';
+import { createUsergroupsCommand } from './commands/usergroups.ts';
 import { notifyIfUpdateAvailable } from './lib/updater.ts';
 import { getAppVersion } from './version.ts';
 
@@ -25,6 +27,8 @@ program.addCommand(createConversationsCommand());
 program.addCommand(createMessagesCommand());
 program.addCommand(createSavedCommand());
 program.addCommand(createSearchCommand());
+program.addCommand(createTeamCommand());
+program.addCommand(createUsergroupsCommand());
 program.addCommand(createUpdateCommand());
 
 // Show update notification after command output if a newer version is cached

--- a/src/lib/formatter.ts
+++ b/src/lib/formatter.ts
@@ -2,7 +2,9 @@ import chalk from 'chalk';
 import type {
   SlackCanvas, SlackChannel, SlackFile, SlackMessage, SlackUser, WorkspaceConfig,
   SavedItem, SearchMatch, ChannelSearchResult, PeopleSearchResult, UnreadChannel,
+  SlackTeam, SlackUsergroup, UsergroupMember,
 } from '../types/index.ts';
+import { isUsergroupEnabled } from './usergroups.ts';
 
 // Serialise a value as JSON and write it to stdout.
 //
@@ -407,4 +409,63 @@ function truncateText(text: string | undefined, maxLen: number): string {
   if (!text) return '[no text]';
   if (text.length <= maxLen) return text;
   return text.substring(0, maxLen) + '...';
+}
+
+// ─── Team (workspace) & user groups ───────────────────────────────────────
+
+// Format team (workspace) info
+export function formatTeamInfo(team: SlackTeam): string {
+  let output = chalk.bold(`🏢 ${team.name}\n\n`);
+  output += `  ${chalk.dim('ID:')}     ${team.id}\n`;
+  if (team.domain) output += `  ${chalk.dim('Domain:')} ${team.domain}.slack.com\n`;
+  if (team.email_domain) output += `  ${chalk.dim('Email:')}  @${team.email_domain}\n`;
+  if (team.url) output += `  ${chalk.dim('URL:')}    ${team.url}\n`;
+  if (team.is_verified) output += `  ${chalk.green('✓ Verified')}\n`;
+  return output;
+}
+
+// Format a list of user groups
+export function formatUsergroupList(groups: SlackUsergroup[]): string {
+  if (groups.length === 0) {
+    return chalk.dim('No user groups found.\n');
+  }
+
+  let output = chalk.bold(`👥 User Groups (${groups.length})\n\n`);
+
+  groups.forEach((g, idx) => {
+    const handle = g.handle ? chalk.cyan(`@${g.handle}`) : chalk.dim('(no handle)');
+    const count = typeof g.user_count === 'number' ? chalk.dim(`${g.user_count} members`) : '';
+    const disabled = isUsergroupEnabled(g) ? '' : chalk.yellow(' [disabled]');
+    output += `  ${chalk.dim(`${idx + 1}.`)} ${chalk.bold(g.name)} ${handle} ${chalk.dim(`(${g.id})`)} ${count}${disabled}\n`;
+    if (g.description) {
+      output += `     ${chalk.dim(g.description)}\n`;
+    }
+    output += '\n';
+  });
+
+  return output;
+}
+
+// Format a single user group with its resolved members
+export function formatUsergroup(group: SlackUsergroup, members: UsergroupMember[]): string {
+  const handle = group.handle ? chalk.cyan(`@${group.handle}`) : chalk.dim('(no handle)');
+  const disabled = isUsergroupEnabled(group) ? chalk.green(' [enabled]') : chalk.yellow(' [disabled]');
+
+  let output = chalk.bold(`👥 ${group.name}`) + ` ${handle}${disabled}\n\n`;
+  output += `  ${chalk.dim('ID:')}      ${group.id}\n`;
+  if (group.description) output += `  ${chalk.dim('About:')}   ${group.description}\n`;
+  output += `  ${chalk.dim('Members:')} ${members.length}\n`;
+
+  if (members.length > 0) {
+    output += '\n';
+    members.forEach((m, idx) => {
+      const display = m.display_name || m.name || m.id;
+      const real = m.real_name && m.real_name !== display ? ` (${m.real_name})` : '';
+      const bot = m.is_bot ? chalk.dim(' [bot]') : '';
+      const gone = m.deleted ? chalk.dim(' [deactivated]') : '';
+      output += `  ${chalk.dim(`${idx + 1}.`)} ${chalk.bold(`@${display}`)}${chalk.dim(real)} ${chalk.dim(`(${m.id})`)}${bot}${gone}\n`;
+    });
+  }
+
+  return output;
 }

--- a/src/lib/slack-client.ts
+++ b/src/lib/slack-client.ts
@@ -368,6 +368,39 @@ export class SlackClient {
     return this.request('conversations.info', { channel });
   }
 
+  // Get team (workspace) info. team.info works for both auth types. On an
+  // enterprise org, an optional team (T-id) scopes the lookup to one workspace;
+  // omitted, Slack returns the token's own workspace.
+  async getTeamInfo(options: { team?: string } = {}): Promise<any> {
+    const params: Record<string, any> = {};
+    if (options.team) params.team = options.team;
+    return this.request('team.info', params);
+  }
+
+  // List user groups ("subteams"). include_count returns user_count;
+  // include_disabled returns groups whose date_delete is non-zero. On an
+  // enterprise org, team_id scopes the listing to one workspace.
+  async listUsergroups(options: {
+    include_disabled?: boolean;
+    team_id?: string;
+  } = {}): Promise<any> {
+    const params: Record<string, any> = { include_count: true };
+    if (options.include_disabled) params.include_disabled = true;
+    if (options.team_id) params.team_id = options.team_id;
+    return this.request('usergroups.list', params);
+  }
+
+  // List the member user IDs of a user group.
+  async listUsergroupUsers(usergroup: string, options: {
+    include_disabled?: boolean;
+    team_id?: string;
+  } = {}): Promise<any> {
+    const params: Record<string, any> = { usergroup };
+    if (options.include_disabled) params.include_disabled = true;
+    if (options.team_id) params.team_id = options.team_id;
+    return this.request('usergroups.users.list', params);
+  }
+
   // Get unread counts (browser: client.counts, standard: conversations.list with unread data)
   async getUnreadCounts(): Promise<any> {
     if (this.config.auth_type === 'browser') {

--- a/src/lib/usergroups.test.ts
+++ b/src/lib/usergroups.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  fetchUsergroupMembers,
+  isUsergroupEnabled,
+  normalizeUsergroups,
+  resolveUsergroup,
+} from './usergroups.ts';
+import type { SlackClient } from './slack-client.ts';
+
+// Minimal fake client: records every request and returns canned responses
+// keyed by method. Mirrors the SlackClient surface the read helpers call.
+function fakeClient(overrides: Partial<Record<string, (params: any) => any>> = {}): {
+  client: SlackClient;
+  calls: Array<{ method: string; params: any }>;
+} {
+  const calls: Array<{ method: string; params: any }> = [];
+  const client: any = {
+    listUsergroups: (params: any) => {
+      calls.push({ method: 'usergroups.list', params });
+      return overrides['usergroups.list']?.(params) ?? { ok: true, usergroups: [] };
+    },
+    listUsergroupUsers: (usergroup: string) => {
+      calls.push({ method: 'usergroups.users.list', params: { usergroup } });
+      return overrides['usergroups.users.list']?.({ usergroup }) ?? { ok: true, users: [] };
+    },
+    getUsersInfo: (ids: string[]) => {
+      calls.push({ method: 'users.info', params: { ids } });
+      return overrides['users.info']?.({ ids }) ?? { ok: true, users: [] };
+    },
+  };
+  return { client: client as SlackClient, calls };
+}
+
+describe('isUsergroupEnabled', () => {
+  test('date_delete 0 or missing is enabled', () => {
+    expect(isUsergroupEnabled({ date_delete: 0 })).toBe(true);
+    expect(isUsergroupEnabled({})).toBe(true);
+  });
+  test('non-zero date_delete is disabled', () => {
+    expect(isUsergroupEnabled({ date_delete: 1700000000 })).toBe(false);
+  });
+});
+
+describe('normalizeUsergroups', () => {
+  test('maps fields and sorts by name', () => {
+    const out = normalizeUsergroups([
+      { id: 'S2', name: 'Zebra', handle: 'z', user_count: 3 },
+      { id: 'S1', name: 'Apple', handle: 'a', user_count: 1 },
+    ]);
+    expect(out.map((g) => g.name)).toEqual(['Apple', 'Zebra']);
+    expect(out[0].id).toBe('S1');
+    expect(out[0].user_count).toBe(1);
+  });
+  test('tolerates empty/undefined input', () => {
+    expect(normalizeUsergroups(undefined as any)).toEqual([]);
+    expect(normalizeUsergroups([])).toEqual([]);
+  });
+});
+
+describe('resolveUsergroup', () => {
+  const groups = [
+    { id: 'S03E2T070G7', name: 'Platform Team', handle: 'platform', date_delete: 0 },
+    { id: 'S03E2T1SWEB', name: 'Security', handle: 'sec', date_delete: 0 },
+  ];
+  const list = () => ({ client } = fakeClient({ 'usergroups.list': () => ({ ok: true, usergroups: groups }) }));
+  let client: SlackClient;
+
+  test('resolves by id', async () => {
+    list();
+    const g = await resolveUsergroup(client, 'S03E2T1SWEB');
+    expect(g?.name).toBe('Security');
+  });
+  test('resolves by @handle case-insensitively', async () => {
+    list();
+    const g = await resolveUsergroup(client, '@PLATFORM');
+    expect(g?.id).toBe('S03E2T070G7');
+  });
+  test('resolves by exact name', async () => {
+    list();
+    const g = await resolveUsergroup(client, 'security');
+    expect(g?.id).toBe('S03E2T1SWEB');
+  });
+  test('returns undefined on no handle/name match', async () => {
+    list();
+    expect(await resolveUsergroup(client, 'nope')).toBeUndefined();
+  });
+  test('honours a raw S-id even when absent from the list (enterprise grid)', async () => {
+    const { client } = fakeClient({ 'usergroups.list': () => ({ ok: true, usergroups: [] }) });
+    const g = await resolveUsergroup(client, 'S0BT63G1N2E');
+    expect(g?.id).toBe('S0BT63G1N2E'); // stub, not undefined
+  });
+});
+
+describe('fetchUsergroupMembers', () => {
+  test('resolves ids to names, preserving order', async () => {
+    const { client } = fakeClient({
+      'usergroups.users.list': () => ({ ok: true, users: ['U1', 'U2'] }),
+      'users.info': () => ({
+        ok: true,
+        users: [
+          { id: 'U2', name: 'bob', real_name: 'Bob', profile: { display_name: 'bobby' } },
+          { id: 'U1', name: 'alice', real_name: 'Alice', profile: { display_name: 'al' } },
+        ],
+      }),
+    });
+    const { ids, members } = await fetchUsergroupMembers(client, 'S1');
+    expect(ids).toEqual(['U1', 'U2']);
+    expect(members.map((m) => m.id)).toEqual(['U1', 'U2']); // order preserved
+    expect(members[0].display_name).toBe('al');
+  });
+  test('empty group short-circuits without a users.info call', async () => {
+    const { client, calls } = fakeClient({
+      'usergroups.users.list': () => ({ ok: true, users: [] }),
+    });
+    const { members } = await fetchUsergroupMembers(client, 'S1');
+    expect(members).toEqual([]);
+    expect(calls.some((c) => c.method === 'users.info')).toBe(false);
+  });
+});

--- a/src/lib/usergroups.ts
+++ b/src/lib/usergroups.ts
@@ -1,0 +1,117 @@
+import type { SlackClient } from './slack-client.ts';
+import type { SlackUsergroup, UsergroupMember } from '../types/index.ts';
+
+type ProgressOptions = { onProgress?: (message: string) => void };
+type ScopeOptions = { teamId?: string };
+type LibOptions = ProgressOptions & ScopeOptions;
+
+// A user group is "enabled" when Slack has not soft-deleted it. Slack encodes
+// that as date_delete === 0 (a disabled group carries the unix time it was
+// disabled). The formatter imports this so the render layer and the lib share
+// one definition of the rule.
+export function isUsergroupEnabled(group: Pick<SlackUsergroup, 'date_delete'>): boolean {
+  return !group.date_delete || group.date_delete === 0;
+}
+
+// Normalise the usergroups.list array into our typed, name-sorted shape. The
+// raw response carries ~25 fields per group; we keep the ones worth surfacing.
+export function normalizeUsergroups(raw: any[]): SlackUsergroup[] {
+  const groups: SlackUsergroup[] = (raw || []).map((g) => ({
+    id: g.id,
+    team_id: g.team_id,
+    name: g.name,
+    handle: g.handle,
+    description: g.description,
+    is_external: g.is_external,
+    is_usergroup: g.is_usergroup,
+    is_subteam: g.is_subteam,
+    date_create: g.date_create,
+    date_update: g.date_update,
+    date_delete: g.date_delete,
+    created_by: g.created_by,
+    user_count: g.user_count,
+    channel_count: g.channel_count,
+    users: g.users,
+  }));
+  groups.sort((a, b) => a.name.localeCompare(b.name));
+  return groups;
+}
+
+// Fetch the workspace's user groups as a normalised, sorted list.
+export async function fetchUsergroups(
+  client: SlackClient,
+  options: { includeDisabled?: boolean } & LibOptions = {},
+): Promise<SlackUsergroup[]> {
+  options.onProgress?.('Fetching user groups...');
+  const response = await client.listUsergroups({
+    include_disabled: options.includeDisabled,
+    team_id: options.teamId,
+  });
+  return normalizeUsergroups(response?.usergroups ?? []);
+}
+
+// Resolve a user group by its id (S...), @handle, or exact name (case-insensitive
+// on handle/name). Returns undefined when nothing matches.
+//
+// A raw usergroup id (S...) is honoured DIRECTLY without a usergroups.list
+// round-trip: on an enterprise grid, a group scoped to a member workspace does
+// not always appear in the org-context list, so requiring a list hit would make
+// a just-created group unresolvable. For an id we return a stub the caller
+// enriches (read/create/update responses carry the full object anyway); only
+// @handle / name refs need the list to map to an id.
+const USERGROUP_ID = /^S[A-Z0-9]{6,}$/;
+
+export async function resolveUsergroup(
+  client: SlackClient,
+  ref: string,
+  options: LibOptions = {},
+): Promise<SlackUsergroup | undefined> {
+  if (USERGROUP_ID.test(ref)) {
+    // Trust the id. Enrich from the list when the group is visible there, but
+    // never fail resolution just because an org-level list omits a grid group.
+    const groups = await fetchUsergroups(client, { includeDisabled: true, ...options });
+    return groups.find((g) => g.id === ref) ?? { id: ref, name: ref };
+  }
+
+  const needle = ref.replace(/^@/, '');
+  const groups = await fetchUsergroups(client, { includeDisabled: true, ...options });
+
+  const lower = needle.toLowerCase();
+  return groups.find(
+    (g) => (g.handle && g.handle.toLowerCase() === lower) || g.name.toLowerCase() === lower,
+  );
+}
+
+// Resolve a group's member IDs to typed members with best-effort name data.
+// Returns { ids, members } — ids is always the raw membership; members carries
+// resolved names when the users.info lookups succeed.
+export async function fetchUsergroupMembers(
+  client: SlackClient,
+  usergroupId: string,
+  options: LibOptions = {},
+): Promise<{ ids: string[]; members: UsergroupMember[] }> {
+  options.onProgress?.('Fetching group members...');
+  const response = await client.listUsergroupUsers(usergroupId, { team_id: options.teamId });
+  const ids: string[] = response?.users ?? [];
+
+  if (ids.length === 0) return { ids, members: [] };
+
+  options.onProgress?.('Resolving member names...');
+  const usersResponse = await client.getUsersInfo(ids);
+  const byId = new Map<string, any>();
+  for (const u of usersResponse?.users ?? []) byId.set(u.id, u);
+
+  const members: UsergroupMember[] = ids.map((id) => {
+    const u = byId.get(id);
+    return {
+      id,
+      name: u?.name,
+      real_name: u?.real_name ?? u?.profile?.real_name,
+      display_name: u?.profile?.display_name,
+      is_bot: u?.is_bot,
+      deleted: u?.deleted,
+    };
+  });
+
+  return { ids, members };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -252,3 +252,62 @@ export interface CanvasReadOptions {
   raw?: boolean;
   workspace?: string;
 }
+
+// Team (workspace) info — from team.info. Only the fields worth surfacing at
+// the CLI; the raw response carries many more.
+export interface SlackTeam {
+  id: string;
+  name: string;
+  domain?: string;
+  email_domain?: string;
+  url?: string;
+  is_verified?: boolean;
+  icon?: Record<string, unknown>;
+}
+
+export interface TeamInfoOptions {
+  workspace?: string;
+}
+
+// User Group ("subteam") — Slack's own name for a named group of users.
+// Modeled on the usergroups.list shape (include_count + include_disabled).
+export interface SlackUsergroup {
+  id: string;
+  team_id?: string;
+  name: string;
+  handle?: string;
+  description?: string;
+  is_external?: boolean;
+  is_usergroup?: boolean;
+  is_subteam?: boolean;
+  // Unix seconds; date_delete === 0 means the group is enabled/active.
+  date_create?: number;
+  date_update?: number;
+  date_delete?: number;
+  created_by?: string;
+  user_count?: number;
+  channel_count?: number;
+  // Present when the group's membership is returned inline (include_users).
+  users?: string[];
+}
+
+// A resolved member of a user group: the id plus best-effort name resolution.
+export interface UsergroupMember {
+  id: string;
+  name?: string;
+  real_name?: string;
+  display_name?: string;
+  is_bot?: boolean;
+  deleted?: boolean;
+}
+
+export interface UsergroupListOptions {
+  includeDisabled?: boolean;
+  team?: string;
+  workspace?: string;
+}
+
+export interface UsergroupReadOptions {
+  team?: string;
+  workspace?: string;
+}


### PR DESCRIPTION
## Linked issue

Part of #139

<!-- This is the read-only half of #139. It intentionally does NOT close the
issue — the follow-up write PR carries `Closes #139`, so #139 stays open until
both halves land. -->

## Summary

Adds the **read-only** surface of two new command groups, mirroring Slack's own API naming:

- `slackcli team info` — workspace (team) metadata (name, domain, ID, verification) via `team.info`.
- `slackcli usergroups list` — the workspace's User Groups ("subteams"), sorted, with handle / member count / enabled state (`--include-disabled`).
- `slackcli usergroups read <group>` — one group and its members, resolving member IDs to names. `<group>` is an id, `@handle`, or exact name.

Every command takes `--workspace`, `--json`, and `--team <workspace-id>` for Enterprise Grid scoping. All calls route through the read methods `team.info` / `usergroups.list` / `usergroups.users.list`, which work under both auth types (standard `xoxb`/`xoxp` and browser `xoxc`/`xoxd`), so no new auth surface is introduced.

**Read/write split (per the discussion on #139):** this is the first of two PRs — read-only here, and a follow-up PR for the write verbs (`create`/`update`/`add`/`remove`/`enable`/`disable`, with a `--yes` confirmation gate) once this merges. Keeping the read side separate makes it low-risk and independently reviewable.

One design note: `resolveUsergroup` honours a raw `S…` id directly rather than requiring a `usergroups.list` hit — on an Enterprise Grid a group scoped to a member workspace does not always appear in the org-context list, so an id-only lookup would otherwise fail.

**Tests:** `src/lib/usergroups.test.ts` — 11 cases covering `normalizeUsergroups` (field mapping + sort + empty input), `resolveUsergroup` (by id / @handle / exact name / no-match / raw-S-id-absent-from-list), `isUsergroupEnabled`, and `fetchUsergroupMembers` (id→name resolution preserving order, empty-group short-circuit). Full suite: 433 pass. Verified live against a real workspace: `team info` and `usergroups list`/`read` work, and `usergroups --help` shows only `list` and `read` (no write verbs).

## Checklist

- [x] The linked issue is open and carries the `ready-for-pr` label (constitution §1–2)
- [x] Change is focused on the linked issue — no unrelated edits
- [x] Tests added/updated, including edge cases (constitution §4)
- [x] `bun run type-check` and `bun test` pass locally
- [x] Pre-commit hooks are installed and passing — no `--no-verify`, no `SKIP=` (constitution §5)
- [x] All commits are signed (constitution §5 — unsigned commits make the PR unmergeable)
- [x] Documentation in `docs/` updated, added, or deleted as needed (constitution §7)
- [x] No tokens, credentials, or user data handled insecurely
