### PR TITLE
feat(emoji): add read-only emoji list and emoji get commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ bun run build:all          # All platforms
 
 ### Entry Point & Command Structure
 
-`src/index.ts` registers the Commander.js command groups `auth`, `canvas`, `conversations`, `messages`, `saved`, `search`, and `update`. Each group is implemented in `src/commands/` and delegates to `src/lib/` modules.
+`src/index.ts` registers eight Commander.js command groups: `auth`, `canvas`, `conversations`, `emoji`, `messages`, `saved`, `search`, `update`. Each group is implemented in `src/commands/` and delegates to `src/lib/` modules.
 
 ### Dual Authentication
 
@@ -151,12 +151,13 @@ Browser tokens can be captured two ways: pasting a cURL command from DevTools (`
 | `src/lib/interactive-input.ts` | Multi-line terminal input (double-Enter or Ctrl+D to submit) |
 | `src/lib/saved.ts` | Enriches saved-for-later items (resolves messages & channels) |
 | `src/lib/unread.ts` | Fetches and resolves unread channel data |
+| `src/lib/emoji.ts` | Normalizes the custom-emoji map (originals vs. aliases) |
 | `src/lib/updater.ts` | Self-update via GitHub releases |
 | `src/lib/canvas-parser.ts` | Slack Canvas HTML to Markdown converter (zero deps, Quip-based HTML) |
 
 ### Type Definitions
 
-All shared TypeScript interfaces live in `src/types/index.ts` (e.g., `AuthType`, `SlackMessage`, `SlackChannel`). Add new shared types there rather than defining them inline in a module.
+All shared TypeScript interfaces are in `src/types/index.ts`, including `AuthType`, `StandardAuthConfig`, `BrowserAuthConfig`, `SlackChannel`, `SlackUser`, `SlackMessage`, `SavedItem`, `SearchMatch`, `ChannelSearchResult`, `PeopleSearchResult`, `UnreadChannel`, `SlackCanvas`, `CanvasListOptions`, `CanvasReadOptions`, and `CustomEmoji`.
 
 ## Testing
 

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -27,6 +27,7 @@ list for the version you have installed.
 | `search` | Search messages, channels, and people |
 | `saved` | Read your "saved for later" list |
 | `canvas` | List canvases and read them as Markdown |
+| `emoji` | List a workspace's custom emoji and inspect one |
 | `update` | Check for and install new versions |
 
 ## Pages
@@ -40,8 +41,9 @@ list for the version you have installed.
 7. [Search](search.md)
 8. [Saved items](saved.md)
 9. [Canvas](canvas.md)
-10. [Scripting and JSON output](scripting.md)
-11. [Troubleshooting](troubleshooting.md)
+10. [Emoji](emoji.md)
+11. [Scripting and JSON output](scripting.md)
+12. [Troubleshooting](troubleshooting.md)
 
 ## Two things that apply everywhere
 

--- a/docs/user-guide/emoji.md
+++ b/docs/user-guide/emoji.md
@@ -1,0 +1,46 @@
+# Emoji
+
+`slackcli emoji` reads a workspace's **custom emoji** — the ones an admin or
+member uploaded, not the built-in Unicode set.
+
+```bash
+slackcli emoji list
+slackcli emoji list --limit=50
+slackcli emoji list --no-aliases
+slackcli emoji list --json
+slackcli emoji get party-parrot
+slackcli emoji get :party-parrot: --json
+```
+
+## `emoji list`
+
+Lists every custom emoji in the workspace, sorted by name.
+
+| Option | Purpose |
+|---|---|
+| `--limit <number>` | Maximum number of emoji to return |
+| `--no-aliases` | Exclude alias emoji, showing only originals |
+| `--workspace <id\|name>` | Workspace to use |
+| `--json` | JSON output |
+
+## `emoji get <name>`
+
+Shows one emoji's details — whether it is an original (with its image URL) or an
+alias (with the emoji it points at). The name matches with or without the
+surrounding colons, so both `party-parrot` and `:party-parrot:` work.
+
+| Option | Purpose |
+|---|---|
+| `--workspace <id\|name>` | Workspace to use |
+| `--json` | JSON output |
+
+## Aliases
+
+Slack's `emoji.list` returns two kinds of value per name: an image URL for an
+original custom emoji, or the string `alias:<target>` for an alias that reuses
+another emoji's image. SlackCLI normalises both into a typed entry — `is_alias`
+distinguishes them, and `alias_for` names the target — so the terminal output
+and the `--json` schema stay the same regardless of which kind it is.
+
+Both auth types work: `emoji.list` is available to standard (`xoxb`/`xoxp`) and
+browser (`xoxd`/`xoxc`) tokens alike.

--- a/src/commands/emoji.test.ts
+++ b/src/commands/emoji.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'bun:test';
+import { createEmojiCommand } from './emoji.ts';
+
+function subcommand(name: string) {
+  return createEmojiCommand().commands.find((command) => command.name() === name);
+}
+
+function longOptions(name: string): string[] {
+  return (subcommand(name)?.options ?? []).map((option) => option.long ?? '');
+}
+
+function argumentNames(name: string): Array<{ name: string; required: boolean }> {
+  return (subcommand(name)?.registeredArguments ?? []).map((argument) => ({
+    name: argument.name(),
+    required: argument.required,
+  }));
+}
+
+describe('emoji command', () => {
+  it('exposes the list and get subcommands', () => {
+    const names = createEmojiCommand().commands.map((command) => command.name());
+    expect(names).toContain('list');
+    expect(names).toContain('get');
+  });
+
+  it('gives list the --limit, --no-aliases, --workspace and --json options', () => {
+    const opts = longOptions('list');
+    expect(opts).toContain('--limit');
+    expect(opts).toContain('--no-aliases');
+    expect(opts).toContain('--workspace');
+    expect(opts).toContain('--json');
+  });
+
+  it('makes get take a required name positional plus --workspace and --json', () => {
+    expect(argumentNames('get')).toEqual([{ name: 'name', required: true }]);
+    const opts = longOptions('get');
+    expect(opts).toContain('--workspace');
+    expect(opts).toContain('--json');
+  });
+});

--- a/src/commands/emoji.ts
+++ b/src/commands/emoji.ts
@@ -1,0 +1,100 @@
+import { Command } from 'commander';
+import ora from 'ora';
+import { getAuthenticatedClient } from '../lib/auth.ts';
+import { error, formatEmoji, formatEmojiList, writeJson } from '../lib/formatter.ts';
+import { fetchCustomEmoji, getCustomEmoji, parseEmojiLimit } from '../lib/emoji.ts';
+
+export function createEmojiCommand(): Command {
+  const emoji = new Command('emoji')
+    .description('View a workspace\'s custom emoji');
+
+  emoji
+    .command('list')
+    .description('List the workspace\'s custom emoji')
+    .option('--limit <number>', 'Maximum number of emoji to return')
+    .option('--no-aliases', 'Exclude alias emoji, showing only originals')
+    .option('--workspace <id|name>', 'Workspace to use')
+    .option('--json', 'Output in JSON format', false)
+    .action(async (options) => {
+      const spinner = ora('Fetching custom emoji...').start();
+
+      try {
+        const client = await getAuthenticatedClient(options.workspace);
+
+        let emojiList = await fetchCustomEmoji(client, {
+          onProgress: (msg) => { spinner.text = msg; },
+        });
+
+        // `--no-aliases` sets options.aliases to false (Commander convention).
+        if (options.aliases === false) {
+          emojiList = emojiList.filter(e => !e.is_alias);
+        }
+
+        if (options.limit !== undefined) {
+          const { limit, error: limitError } = parseEmojiLimit(options.limit);
+          if (limitError !== undefined) {
+            spinner.fail('Invalid limit');
+            error(limitError);
+            process.exit(1);
+          }
+          emojiList = emojiList.slice(0, limit);
+        }
+
+        if (emojiList.length === 0) {
+          spinner.succeed('No custom emoji found');
+          return;
+        }
+
+        spinner.succeed(`Found ${emojiList.length} custom emoji`);
+
+        if (options.json) {
+          writeJson({ emoji_count: emojiList.length, emoji: emojiList });
+          return;
+        }
+
+        console.log('\n' + formatEmojiList(emojiList));
+      } catch (err: any) {
+        spinner.fail('Failed to fetch custom emoji');
+        error(err.message);
+        process.exit(1);
+      }
+    });
+
+  emoji
+    .command('get')
+    .description('Show details for a single custom emoji')
+    .argument('<name>', 'Emoji name, with or without surrounding colons')
+    .option('--workspace <id|name>', 'Workspace to use')
+    .option('--json', 'Output in JSON format', false)
+    .action(async (name, options) => {
+      const spinner = ora('Fetching custom emoji...').start();
+
+      try {
+        const client = await getAuthenticatedClient(options.workspace);
+
+        const found = await getCustomEmoji(client, name, {
+          onProgress: (msg) => { spinner.text = msg; },
+        });
+
+        if (!found) {
+          spinner.fail(`No custom emoji named :${name.replace(/^:|:$/g, '')}:`);
+          process.exit(1);
+        }
+
+        spinner.succeed(`Found :${found.name}:`);
+
+        if (options.json) {
+          writeJson(found);
+          return;
+        }
+
+        console.log('\n' + formatEmoji(found));
+      } catch (err: any) {
+        spinner.fail('Failed to fetch custom emoji');
+        error(err.message);
+        process.exit(1);
+      }
+    });
+
+  return emoji;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { createAuthCommand } from './commands/auth.ts';
 import { createConversationsCommand } from './commands/conversations.ts';
 import { createMessagesCommand } from './commands/messages.ts';
 import { createCanvasCommand } from './commands/canvas.ts';
+import { createEmojiCommand } from './commands/emoji.ts';
 import { createUpdateCommand } from './commands/update.ts';
 import { createSavedCommand } from './commands/saved.ts';
 import { createSearchCommand } from './commands/search.ts';
@@ -22,6 +23,7 @@ program
 program.addCommand(createAuthCommand());
 program.addCommand(createCanvasCommand());
 program.addCommand(createConversationsCommand());
+program.addCommand(createEmojiCommand());
 program.addCommand(createMessagesCommand());
 program.addCommand(createSavedCommand());
 program.addCommand(createSearchCommand());

--- a/src/lib/emoji.test.ts
+++ b/src/lib/emoji.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'bun:test';
+import { fetchCustomEmoji, getCustomEmoji, normalizeEmojiMap, parseEmojiLimit } from './emoji.ts';
+import type { SlackClient } from './slack-client.ts';
+
+function createMockClient(
+  overrides: { listEmoji?: () => Promise<any> } = {},
+): SlackClient {
+  return {
+    listEmoji: overrides.listEmoji ?? (() => Promise.resolve({ ok: true, emoji: {} })),
+  } as unknown as SlackClient;
+}
+
+describe('normalizeEmojiMap', () => {
+  it('maps a URL value to an original (non-alias) emoji', () => {
+    const result = normalizeEmojiMap({ parrot: 'https://emoji.example/parrot.gif' });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      name: 'parrot',
+      is_alias: false,
+      url: 'https://emoji.example/parrot.gif',
+    });
+  });
+
+  it('maps an "alias:" value to an alias emoji with its target', () => {
+    const result = normalizeEmojiMap({ shipit: 'alias:squirrel' });
+    expect(result[0]).toEqual({ name: 'shipit', is_alias: true, alias_for: 'squirrel' });
+  });
+
+  it('sorts emoji by name', () => {
+    const result = normalizeEmojiMap({
+      zebra: 'https://emoji.example/z.png',
+      apple: 'https://emoji.example/a.png',
+      mango: 'alias:apple',
+    });
+    expect(result.map(e => e.name)).toEqual(['apple', 'mango', 'zebra']);
+  });
+
+  it('returns an empty list for an empty map', () => {
+    expect(normalizeEmojiMap({})).toEqual([]);
+  });
+});
+
+describe('fetchCustomEmoji', () => {
+  it('normalizes the emoji.list response', async () => {
+    const client = createMockClient({
+      listEmoji: () => Promise.resolve({
+        ok: true,
+        emoji: {
+          beta: 'https://emoji.example/beta.png',
+          alpha: 'alias:beta',
+        },
+      }),
+    });
+
+    const result = await fetchCustomEmoji(client);
+    expect(result.map(e => e.name)).toEqual(['alpha', 'beta']);
+    expect(result[0].is_alias).toBe(true);
+    expect(result[1].is_alias).toBe(false);
+  });
+
+  it('tolerates a response with no emoji field', async () => {
+    const client = createMockClient({ listEmoji: () => Promise.resolve({ ok: true }) });
+    expect(await fetchCustomEmoji(client)).toEqual([]);
+  });
+
+  it('reports progress through the onProgress callback', async () => {
+    const messages: string[] = [];
+    const client = createMockClient();
+    await fetchCustomEmoji(client, { onProgress: (m) => messages.push(m) });
+    expect(messages.length).toBeGreaterThan(0);
+  });
+});
+
+describe('getCustomEmoji', () => {
+  const client = createMockClient({
+    listEmoji: () => Promise.resolve({
+      ok: true,
+      emoji: { 'party-parrot': 'https://emoji.example/pp.gif' },
+    }),
+  });
+
+  it('finds an emoji by bare name', async () => {
+    const found = await getCustomEmoji(client, 'party-parrot');
+    expect(found?.name).toBe('party-parrot');
+  });
+
+  it('finds an emoji when the name is wrapped in colons', async () => {
+    const found = await getCustomEmoji(client, ':party-parrot:');
+    expect(found?.name).toBe('party-parrot');
+  });
+
+  it('returns undefined for an unknown emoji', async () => {
+    expect(await getCustomEmoji(client, 'does-not-exist')).toBeUndefined();
+  });
+});
+
+describe('parseEmojiLimit', () => {
+  it('accepts a positive integer', () => {
+    expect(parseEmojiLimit('5')).toEqual({ limit: 5 });
+  });
+
+  it('parses the leading integer of a numeric string', () => {
+    expect(parseEmojiLimit('10')).toEqual({ limit: 10 });
+  });
+
+  it('rejects a non-numeric value instead of yielding NaN', () => {
+    // Regression: parseInt('abc') is NaN and slice(0, NaN) returns [], which
+    // made `--limit abc` look like an empty workspace rather than an error.
+    expect(parseEmojiLimit('abc')).toEqual({ error: 'Limit must be a positive integer' });
+  });
+
+  it('rejects a negative value instead of dropping from the tail', () => {
+    // Regression: slice(0, -2) silently drops the last two entries.
+    expect(parseEmojiLimit('-2')).toEqual({ error: 'Limit must be a positive integer' });
+  });
+
+  it('rejects zero', () => {
+    expect(parseEmojiLimit('0')).toEqual({ error: 'Limit must be a positive integer' });
+  });
+});

--- a/src/lib/emoji.ts
+++ b/src/lib/emoji.ts
@@ -1,0 +1,57 @@
+import type { SlackClient } from './slack-client.ts';
+import type { CustomEmoji } from '../types/index.ts';
+
+// Validate and parse the `emoji list --limit` option value. The command slices
+// its already-fetched list locally rather than handing the value to Slack, so a
+// non-numeric or non-positive value must be rejected here — otherwise
+// `parseInt('abc')` yields NaN and `slice(0, NaN)` returns an empty list,
+// making a bad flag look like an empty workspace. Returns the parsed limit, or
+// an `error` message when the value is not a positive integer.
+export function parseEmojiLimit(value: string): { limit?: number; error?: string } {
+  const limit = parseInt(value, 10);
+  if (isNaN(limit) || limit < 1) {
+    return { error: 'Limit must be a positive integer' };
+  }
+  return { limit };
+}
+
+// Slack's emoji.list returns a flat map of name -> value, where the value is
+// either an image URL for a real custom emoji or the string "alias:<target>"
+// pointing at another emoji (custom or built-in). This normalises that map into
+// a typed, name-sorted list so the command and formatter never touch the raw
+// shape.
+export function normalizeEmojiMap(map: Record<string, string>): CustomEmoji[] {
+  const emoji: CustomEmoji[] = Object.entries(map).map(([name, value]) => {
+    if (typeof value === 'string' && value.startsWith('alias:')) {
+      return { name, is_alias: true, alias_for: value.slice('alias:'.length) };
+    }
+    return { name, is_alias: false, url: value };
+  });
+
+  emoji.sort((a, b) => a.name.localeCompare(b.name));
+  return emoji;
+}
+
+// Fetch the workspace's custom emoji as a normalised, sorted list.
+export async function fetchCustomEmoji(
+  client: SlackClient,
+  options: { onProgress?: (message: string) => void } = {},
+): Promise<CustomEmoji[]> {
+  options.onProgress?.('Fetching custom emoji...');
+  const response = await client.listEmoji();
+  const map: Record<string, string> = response?.emoji ?? {};
+  return normalizeEmojiMap(map);
+}
+
+// Look up a single custom emoji by name. The name is matched with any
+// surrounding colons stripped, so both `party-parrot` and `:party-parrot:`
+// resolve. Returns undefined when the workspace has no such custom emoji.
+export async function getCustomEmoji(
+  client: SlackClient,
+  name: string,
+  options: { onProgress?: (message: string) => void } = {},
+): Promise<CustomEmoji | undefined> {
+  const target = name.replace(/^:|:$/g, '');
+  const emoji = await fetchCustomEmoji(client, options);
+  return emoji.find((e) => e.name === target);
+}

--- a/src/lib/formatter.ts
+++ b/src/lib/formatter.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import type {
   SlackCanvas, SlackChannel, SlackFile, SlackMessage, SlackUser, WorkspaceConfig,
   SavedItem, SearchMatch, ChannelSearchResult, PeopleSearchResult, UnreadChannel,
+  CustomEmoji,
 } from '../types/index.ts';
 
 // Serialise a value as JSON and write it to stdout.
@@ -407,4 +408,39 @@ function truncateText(text: string | undefined, maxLen: number): string {
   if (!text) return '[no text]';
   if (text.length <= maxLen) return text;
   return text.substring(0, maxLen) + '...';
+}
+
+// Format a custom-emoji list for the terminal.
+export function formatEmojiList(emoji: CustomEmoji[]): string {
+  const aliasCount = emoji.filter(e => e.is_alias).length;
+  const realCount = emoji.length - aliasCount;
+
+  let output = chalk.bold(
+    `😀 Custom emoji (${emoji.length} — ${realCount} original, ${aliasCount} alias)\n\n`,
+  );
+
+  emoji.forEach((e) => {
+    if (e.is_alias) {
+      output += `  ${chalk.cyan(`:${e.name}:`)} ${chalk.dim(`→ :${e.alias_for}:`)}\n`;
+    } else {
+      output += `  ${chalk.cyan(`:${e.name}:`)}${e.url ? ` ${chalk.dim(e.url)}` : ''}\n`;
+    }
+  });
+
+  return output;
+}
+
+// Format a single custom emoji's details.
+export function formatEmoji(emoji: CustomEmoji): string {
+  let output = chalk.bold(`😀 :${emoji.name}:\n`);
+  if (emoji.is_alias) {
+    output += `  ${chalk.dim('Type:')} alias\n`;
+    output += `  ${chalk.dim('Alias for:')} :${emoji.alias_for}:\n`;
+  } else {
+    output += `  ${chalk.dim('Type:')} original\n`;
+    if (emoji.url) {
+      output += `  ${chalk.dim('URL:')} ${emoji.url}\n`;
+    }
+  }
+  return output;
 }

--- a/src/lib/slack-client.ts
+++ b/src/lib/slack-client.ts
@@ -368,6 +368,12 @@ export class SlackClient {
     return this.request('conversations.info', { channel });
   }
 
+  // List the workspace's custom emoji (emoji.list works for both auth types).
+  // Returns { ok, emoji: { <name>: <image-url|"alias:<other>"> } }.
+  async listEmoji(): Promise<any> {
+    return this.request('emoji.list', {});
+  }
+
   // Get unread counts (browser: client.counts, standard: conversations.list with unread data)
   async getUnreadCounts(): Promise<any> {
     if (this.config.auth_type === 'browser') {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -252,3 +252,24 @@ export interface CanvasReadOptions {
   raw?: boolean;
   workspace?: string;
 }
+
+// Custom (workspace) emoji
+export interface CustomEmoji {
+  // Emoji short name without the surrounding colons (e.g. `party-parrot`).
+  name: string;
+  // A real emoji points at an image URL; an alias points at another emoji's
+  // name. `is_alias` disambiguates, and `alias_for` names the target when true.
+  url?: string;
+  is_alias: boolean;
+  alias_for?: string;
+}
+
+export interface EmojiListOptions {
+  limit?: number;
+  aliases?: boolean;
+  workspace?: string;
+}
+
+export interface EmojiGetOptions {
+  workspace?: string;
+}


### PR DESCRIPTION
## What

Adds a read-only `emoji` command group for viewing a workspace's custom emoji, working under both standard (`xoxb`/`xoxp`) and browser (`xoxc`/`xoxd`) auth via `emoji.list`.

- `emoji list` — name-sorted list, with `--limit`, `--no-aliases`, `--workspace`, and `--json`
- `emoji get <name>` — details for a single emoji, accepting the name with or without surrounding colons

## Why

Custom emoji are a gap in the read commands (as noted in #140). This fills it with a read-only surface that mirrors the existing `--json` / `--workspace` conventions and the `slack-client` auth abstraction, so it works the same across both auth types.

## How

- `src/lib/emoji.ts` — `normalizeEmojiMap` turns the flat `emoji.list` map into a typed, name-sorted list, distinguishing originals (`url`) from aliases (`is_alias` + `alias_for`); `fetchCustomEmoji` / `getCustomEmoji` wrap the fetch and single-lookup.
- `src/lib/slack-client.ts` — `listEmoji()` routes through the shared `request()` path so both auth types work.
- `src/commands/emoji.ts` — the `emoji list` / `emoji get` group, following the `saved.ts` / `docs/development/adding-a-command.md` pattern.
- `src/lib/formatter.ts` — `formatEmojiList` / `formatEmoji` in the existing chalk style.
- `src/types/index.ts` — `CustomEmoji`, `EmojiListOptions`, `EmojiGetOptions`.
- Docs + tests: `docs/user-guide/emoji.md`, `src/lib/emoji.test.ts` + `src/commands/emoji.test.ts` (18 tests total), and `CLAUDE.md` architecture updates.

## Design notes (from #140 discussion)

- **`--limit` is client-side truncation, applied after `--no-aliases`.** `emoji.list` returns one flat map with no cursor, so the command fetches the whole set, filters aliases (when `--no-aliases`), sorts by name, then slices by `--limit`. `--json` respects it: `emoji_count` reflects the truncated set, matching `item_count` / `canvas_count` elsewhere.
- **`emoji get` resolves one hop.** For an alias it reports `is_alias: true` and `alias_for: <immediate target>`, not the full chain to a terminal image — the default you confirmed in #140.
- **No `process.exit()` after `writeJson()`** (per #73): both subcommands `return` after writing JSON; `process.exit(1)` only occurs on error / not-found paths, before any JSON is written.

## Tests

- `src/lib/emoji.test.ts` (15 tests) covers map normalization, alias detection, name sorting, single-`get` name matching (with and without colons), and `parseEmojiLimit` — including the regression cases where a non-numeric (`--limit abc`), negative (`--limit -2`), or zero limit is rejected with a clear error instead of `slice(0, NaN)` silently reporting an empty workspace.
- `src/commands/emoji.test.ts` (3 tests) covers the command wiring: the `list` / `get` subcommands and their `--limit` / `--no-aliases` / `--workspace` / `--json` options.
- Verified locally against a real workspace (24,980 custom emoji) under browser auth: `emoji list`, `--no-aliases`, `--limit`, `--json`, and `emoji get <name>` for both an original and an alias.
- Full suite green: `bun run type-check` clean, `bun test` 440/440 pass.

Closes #140

