### PR TITLE
fix: throttle Slack API calls through a shared rate limiter (#147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Slack API calls are throttled**: every request now goes through a process-wide rate limiter — at most 2 in flight, with at least 200ms between calls — for both standard and browser-session authentication (#147)
+  - Unthrottled bursts (one `users.info` per user, one `conversations.info` per channel) could trip Slack's `unexpected_api_call_volume` anomaly detection, which on Enterprise Grid signs the browser session out
+  - Commands that resolve many names (`saved list`, `conversations unread`) are correspondingly slower on large workspaces; the spinner keeps running while they are paced
+
 ## [0.10.0] - 2026-08-29
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ Browser tokens can be captured two ways: pasting a cURL command from DevTools (`
 | Module | Purpose |
 |---|---|
 | `src/lib/auth.ts` | Orchestrates login flows and returns configured `SlackClient` |
-| `src/lib/slack-client.ts` | Slack API abstraction (standard via SDK, browser via fetch) |
+| `src/lib/slack-client.ts` | Slack API abstraction (standard via SDK, browser via fetch); every call is paced by the shared rate limiter |
 | `src/lib/browser-auth.ts` | Captures `xoxc`/`xoxd` tokens from a live browser session (powers `auth login-auto`) |
 | `src/lib/browser-launcher.ts` | Locates/launches a Chromium-family browser with CDP enabled, using a dedicated slackcli profile |
 | `src/lib/cdp-client.ts` | Minimal zero-dependency Chrome DevTools Protocol client over Bun's WebSocket |
@@ -155,6 +155,7 @@ Browser tokens can be captured two ways: pasting a cURL command from DevTools (`
 | `src/lib/usergroups.ts` | Normalizes user groups and resolves members to names |
 | `src/lib/updater.ts` | Self-update via GitHub releases |
 | `src/lib/canvas-parser.ts` | Slack Canvas HTML to Markdown converter (zero deps, Quip-based HTML) |
+| `src/lib/rate-limiter.ts` | Process-wide concurrency cap + minimum interval applied to every Slack API call |
 
 ### Type Definitions
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -38,15 +38,43 @@ important thing to understand about this codebase.
 
 ```ts
 async request(method: string, params = {}) {
-  return this.config.auth_type === 'standard'
-    ? this.standardRequest(method, params)
-    : this.browserRequest(method, params);
+  return this.rateLimiter.run(() =>
+    this.config.auth_type === 'standard'
+      ? this.standardRequest(method, params)
+      : this.browserRequest(method, params));
 }
 ```
 
 Everything above it — every `listConversations`, `postMessage`, `searchMessages`
 — is auth-agnostic and goes through `request()`. **New API calls belong there,
 not in a command file.**
+
+### Throttling
+
+Because `request()` is a complete funnel, it is also where outgoing traffic is
+paced. `src/lib/rate-limiter.ts` holds a hand-rolled `RateLimiter` — a
+concurrency cap plus a minimum delay between call *starts* — and
+`slackRateLimiter`, the process-wide instance every `SlackClient` shares by
+default (`SLACK_MAX_CONCURRENT_REQUESTS`, `SLACK_MIN_REQUEST_INTERVAL_MS`).
+
+It exists because Slack's Enterprise Grid anomaly detection raises
+[`unexpected_api_call_volume`](https://docs.slack.dev/reference/audit-logs-api/anomalous-events-reference/)
+when a client outpaces what a browser would do, and it can log the session out.
+Several paths fan out one call per entity — `getUsersInfo()`,
+`enrichSavedItems()` in `saved.ts`, and the unread resolver in `unread.ts` — so
+the gate sits in `request()` and those modules need no throttling of their own.
+
+Two consequences worth knowing:
+
+- The pacing applies to **both** auth types. The anomaly is about volume, not
+  about which transport produced it.
+- Commands that resolve many names (`saved list`, `conversations unread`) are
+  measurably slower on large workspaces. That is the trade; keep the spinner
+  running so it does not look hung.
+
+Retry/backoff on HTTP 429 is deliberately *not* here — it is a separate concern
+from pacing, and the raw `fetch()` calls used for file upload/download are
+single-shot per invocation, so they bypass the limiter.
 
 ### Where the two genuinely diverge
 

--- a/docs/development/project-structure.md
+++ b/docs/development/project-structure.md
@@ -45,7 +45,7 @@ They hold no Slack API knowledge.
 
 | Module | Responsibility |
 |---|---|
-| `slack-client.ts` | The Slack API abstraction. Dispatches every call to `standardRequest()` or `browserRequest()` by auth type. |
+| `slack-client.ts` | The Slack API abstraction. Dispatches every call to `standardRequest()` or `browserRequest()` by auth type, through the shared rate limiter. |
 | `auth.ts` | Login orchestration; returns a configured `SlackClient`. The only place that decides a token is valid. |
 | `workspaces.ts` | Multi-workspace persistence, profile-key derivation and resolution. |
 | `browser-auth.ts` | Captures `xoxd`/`xoxc` from a signed-in browser; pure extractors are exported for tests. |
@@ -55,6 +55,7 @@ They hold no Slack API knowledge.
 | `slack-url-parser.ts` | Slack URL / permalink / timestamp normalisation. |
 | `mrkdwn.ts` | Slack mrkdwn → `rich_text` blocks (drafts). |
 | `canvas-parser.ts` | Slack canvas HTML → Markdown. |
+| `rate-limiter.ts` | Concurrency cap and minimum interval shared by every Slack API call. |
 | `message.ts` | Fetch one message by channel + timestamp, per auth type. |
 | `saved.ts` | Resolves saved-item pointers into messages, channels, and users. |
 | `unread.ts` | Fetches and normalises unread channel data across both auth types. |

--- a/docs/user-guide/scripting.md
+++ b/docs/user-guide/scripting.md
@@ -106,9 +106,12 @@ done
 - **Token freshness.** Browser tokens die with the browser session. Refresh them
   non-interactively with `slackcli auth login-auto --headless`, which works once
   the profile has been signed in once.
-- **Rate limits.** Commands that resolve many users or channels
-  (`conversations unread`, `saved list` on a long list) make one API call per
-  entity and can hit Slack's rate limits on a big workspace.
+- **Throttling.** slackcli keeps at most 2 Slack API calls in flight and leaves
+  at least 200ms between them, so it does not trip Slack's
+  `unexpected_api_call_volume` anomaly detection. Commands that resolve many
+  users or channels (`conversations unread`, `saved list` on a long list) make
+  one API call per entity, so budget wall-clock time for them and set generous
+  timeouts in a scheduled job.
 - **The update notice.** SlackCLI may append a one-line "update available" notice
   after a command. It goes to stderr and never contaminates `--json` on stdout.
 - **Credentials.** `~/.config/slackcli/workspaces.json` holds live tokens at mode

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -118,11 +118,19 @@ with what you ran.
   it — download the binary manually and check it against `checksums.txt` from
   the release.
 
-## Rate limits
+## Rate limits and slow commands
 
-`conversations unread` and `saved list` resolve names one entity at a time and
-can hit Slack's rate limits on a large workspace. Narrow the request
-(`--types`, `--limit`) or retry after a pause.
+slackcli paces its own traffic: it keeps at most 2 Slack API calls in flight and
+leaves at least 200ms between calls, for both app tokens and browser sessions.
+Bursting past that is what trips Slack's `unexpected_api_call_volume` anomaly
+detection, which on Enterprise Grid can sign the session out.
+
+The visible cost is that commands resolving many names one entity at a time —
+`conversations unread`, `saved list` — take noticeably longer on a large
+workspace. The spinner keeps running; it is throttling, not hanging. Narrow the
+request (`--types`, `--limit`) to make it finish sooner.
+
+If Slack itself rate-limits you anyway, retry after a pause.
 
 ## Still stuck?
 

--- a/src/lib/rate-limiter.test.ts
+++ b/src/lib/rate-limiter.test.ts
@@ -72,16 +72,16 @@ describe('RateLimiter', () => {
   });
 
   it('paces tasks queued after an idle period without an extra delay', async () => {
-    const limiter = new RateLimiter({ maxConcurrent: 2, minIntervalMs: 25 });
+    const limiter = new RateLimiter({ maxConcurrent: 2, minIntervalMs: 60 });
 
     await limiter.run(async () => undefined);
-    await sleep(40);
+    await sleep(80);
 
     const before = Date.now();
     await limiter.run(async () => undefined);
 
     // The interval already elapsed while idle, so the next call must not wait again.
-    expect(Date.now() - before).toBeLessThan(25);
+    expect(Date.now() - before).toBeLessThan(60);
   });
 
   it('does not delay anything when minIntervalMs is 0', async () => {

--- a/src/lib/rate-limiter.test.ts
+++ b/src/lib/rate-limiter.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  RateLimiter,
+  SLACK_MAX_CONCURRENT_REQUESTS,
+  SLACK_MIN_REQUEST_INTERVAL_MS,
+  slackRateLimiter,
+} from './rate-limiter.ts';
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Timers may fire a hair early depending on the platform clock, so spacing
+// assertions allow a small tolerance rather than demanding the exact interval.
+const TIMER_TOLERANCE_MS = 5;
+
+/** Runs `count` tasks through `limiter`, recording start times and peak concurrency. */
+async function drive(
+  limiter: RateLimiter,
+  count: number,
+  taskDurationMs = 0,
+): Promise<{ starts: number[]; peakConcurrent: number }> {
+  const starts: number[] = [];
+  let inFlight = 0;
+  let peakConcurrent = 0;
+
+  await Promise.all(
+    Array.from({ length: count }, () =>
+      limiter.run(async () => {
+        starts.push(Date.now());
+        inFlight += 1;
+        peakConcurrent = Math.max(peakConcurrent, inFlight);
+        if (taskDurationMs > 0) await sleep(taskDurationMs);
+        inFlight -= 1;
+      }),
+    ),
+  );
+
+  return { starts, peakConcurrent };
+}
+
+describe('RateLimiter', () => {
+  it('runs a task and resolves with its value', async () => {
+    const limiter = new RateLimiter({ maxConcurrent: 2, minIntervalMs: 0 });
+
+    await expect(limiter.run(async () => 'done')).resolves.toBe('done');
+  });
+
+  it('never runs more tasks concurrently than maxConcurrent', async () => {
+    const limiter = new RateLimiter({ maxConcurrent: 2, minIntervalMs: 0 });
+
+    const { peakConcurrent } = await drive(limiter, 8, 10);
+
+    expect(peakConcurrent).toBe(2);
+  });
+
+  it('serializes fully when maxConcurrent is 1', async () => {
+    const limiter = new RateLimiter({ maxConcurrent: 1, minIntervalMs: 0 });
+
+    const { peakConcurrent } = await drive(limiter, 5, 5);
+
+    expect(peakConcurrent).toBe(1);
+  });
+
+  it('leaves at least minIntervalMs between task starts', async () => {
+    const limiter = new RateLimiter({ maxConcurrent: 2, minIntervalMs: 25 });
+
+    const { starts } = await drive(limiter, 4);
+
+    expect(starts).toHaveLength(4);
+    for (let i = 1; i < starts.length; i += 1) {
+      expect(starts[i]! - starts[i - 1]!).toBeGreaterThanOrEqual(25 - TIMER_TOLERANCE_MS);
+    }
+  });
+
+  it('paces tasks queued after an idle period without an extra delay', async () => {
+    const limiter = new RateLimiter({ maxConcurrent: 2, minIntervalMs: 25 });
+
+    await limiter.run(async () => undefined);
+    await sleep(40);
+
+    const before = Date.now();
+    await limiter.run(async () => undefined);
+
+    // The interval already elapsed while idle, so the next call must not wait again.
+    expect(Date.now() - before).toBeLessThan(25);
+  });
+
+  it('does not delay anything when minIntervalMs is 0', async () => {
+    const limiter = new RateLimiter({ maxConcurrent: 4, minIntervalMs: 0 });
+
+    const before = Date.now();
+    const { starts } = await drive(limiter, 6);
+
+    expect(starts).toHaveLength(6);
+    expect(Date.now() - before).toBeLessThan(200);
+  });
+
+  it('propagates a rejection and still releases the slot', async () => {
+    const limiter = new RateLimiter({ maxConcurrent: 1, minIntervalMs: 0 });
+
+    await expect(limiter.run(async () => {
+      throw new Error('boom');
+    })).rejects.toThrow('boom');
+
+    // A leaked slot would leave this pending forever.
+    await expect(limiter.run(async () => 'still works')).resolves.toBe('still works');
+  });
+
+  it('keeps running queued tasks after one of them rejects', async () => {
+    const limiter = new RateLimiter({ maxConcurrent: 1, minIntervalMs: 0 });
+    const completed: string[] = [];
+
+    const results = await Promise.allSettled([
+      limiter.run(async () => {
+        completed.push('first');
+      }),
+      limiter.run(async () => {
+        throw new Error('middle failed');
+      }),
+      limiter.run(async () => {
+        completed.push('third');
+      }),
+    ]);
+
+    expect(results.map((result) => result.status)).toEqual(['fulfilled', 'rejected', 'fulfilled']);
+    expect(completed).toEqual(['first', 'third']);
+  });
+
+  it('starts tasks in the order they were submitted', async () => {
+    const limiter = new RateLimiter({ maxConcurrent: 1, minIntervalMs: 0 });
+    const order: number[] = [];
+
+    await Promise.all(
+      [0, 1, 2, 3, 4].map((index) =>
+        limiter.run(async () => {
+          order.push(index);
+        }),
+      ),
+    );
+
+    expect(order).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('rejects invalid options', () => {
+    expect(() => new RateLimiter({ maxConcurrent: 0, minIntervalMs: 0 })).toThrow(/maxConcurrent/);
+    expect(() => new RateLimiter({ maxConcurrent: -1, minIntervalMs: 0 })).toThrow(/maxConcurrent/);
+    expect(() => new RateLimiter({ maxConcurrent: Number.NaN, minIntervalMs: 0 })).toThrow(/maxConcurrent/);
+    expect(() => new RateLimiter({ maxConcurrent: 1, minIntervalMs: -1 })).toThrow(/minIntervalMs/);
+    expect(() => new RateLimiter({ maxConcurrent: 1, minIntervalMs: Number.POSITIVE_INFINITY }))
+      .toThrow(/minIntervalMs/);
+  });
+});
+
+describe('slackRateLimiter defaults', () => {
+  it('is a RateLimiter configured from the exported Slack constants', () => {
+    expect(slackRateLimiter).toBeInstanceOf(RateLimiter);
+    expect(SLACK_MAX_CONCURRENT_REQUESTS).toBeGreaterThanOrEqual(1);
+    expect(SLACK_MIN_REQUEST_INTERVAL_MS).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/rate-limiter.ts
+++ b/src/lib/rate-limiter.ts
@@ -53,6 +53,11 @@ export class RateLimiter {
    * hold its slot while queueing behind itself and deadlock at `maxConcurrent`.
    * `SlackClient` satisfies this — no method awaits one `request()` inside
    * another — so keep composite calls sequential rather than nested.
+   *
+   * A `task` that never settles holds its slot forever and stalls everything
+   * behind it. `browserRequest()` uses a bare `fetch` with no timeout, so if a
+   * caller ever needs to survive a hung request, the timeout belongs on the
+   * request itself (an `AbortSignal`), not here.
    */
   async run<T>(task: () => Promise<T>): Promise<T> {
     await this.acquire();

--- a/src/lib/rate-limiter.ts
+++ b/src/lib/rate-limiter.ts
@@ -48,6 +48,11 @@ export class RateLimiter {
   /**
    * Runs `task` once a slot is free and the minimum interval has elapsed.
    * Rejections propagate unchanged, and the slot is always released.
+   *
+   * `task` must not itself wait on another `run()` of the same limiter: it would
+   * hold its slot while queueing behind itself and deadlock at `maxConcurrent`.
+   * `SlackClient` satisfies this — no method awaits one `request()` inside
+   * another — so keep composite calls sequential rather than nested.
    */
   async run<T>(task: () => Promise<T>): Promise<T> {
     await this.acquire();

--- a/src/lib/rate-limiter.ts
+++ b/src/lib/rate-limiter.ts
@@ -1,0 +1,106 @@
+// Paces outgoing Slack API calls so a burst of them does not look like scraping.
+//
+// Slack's Enterprise Grid anomaly detection raises `unexpected_api_call_volume`
+// when a client produces more API traffic than a browser or the official app
+// would, and it can log the session out. Several slackcli paths fan out one call
+// per user or per channel with no delay, so every request is funnelled through
+// this limiter before it leaves the process.
+//
+// Hand-rolled rather than pulled from npm (`p-limit`, `bottleneck`, …): the CLI
+// ships as a `bun build --compile` binary under a 150MB CI budget, and this is
+// ~60 lines with no other consumer.
+
+export interface RateLimiterOptions {
+  /** Maximum number of tasks allowed to run at the same time. Must be >= 1. */
+  maxConcurrent: number;
+  /** Minimum delay between two task *starts*, in milliseconds. Must be >= 0. */
+  minIntervalMs: number;
+}
+
+/** Concurrency cap applied to every Slack API call. */
+export const SLACK_MAX_CONCURRENT_REQUESTS = 2;
+
+/** Minimum delay between two Slack API calls, in milliseconds. */
+export const SLACK_MIN_REQUEST_INTERVAL_MS = 200;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+export class RateLimiter {
+  private readonly maxConcurrent: number;
+  private readonly minIntervalMs: number;
+  private inFlight = 0;
+  private lastStartedAt = 0;
+  private waiters: Array<() => void> = [];
+  private pumping = false;
+
+  constructor(options: RateLimiterOptions) {
+    if (!Number.isFinite(options.maxConcurrent) || options.maxConcurrent < 1) {
+      throw new Error('RateLimiter: maxConcurrent must be a finite number >= 1');
+    }
+    if (!Number.isFinite(options.minIntervalMs) || options.minIntervalMs < 0) {
+      throw new Error('RateLimiter: minIntervalMs must be a finite number >= 0');
+    }
+
+    this.maxConcurrent = options.maxConcurrent;
+    this.minIntervalMs = options.minIntervalMs;
+  }
+
+  /**
+   * Runs `task` once a slot is free and the minimum interval has elapsed.
+   * Rejections propagate unchanged, and the slot is always released.
+   */
+  async run<T>(task: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await task();
+    } finally {
+      this.release();
+    }
+  }
+
+  private acquire(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.waiters.push(resolve);
+      void this.pump();
+    });
+  }
+
+  private release(): void {
+    this.inFlight -= 1;
+    void this.pump();
+  }
+
+  // Single-threaded drain of the waiter queue. The `pumping` guard keeps exactly
+  // one drain alive, so `inFlight` and `lastStartedAt` can only be advanced here
+  // and never race across the `await sleep(...)` below.
+  private async pump(): Promise<void> {
+    if (this.pumping) return;
+    this.pumping = true;
+
+    try {
+      while (this.waiters.length > 0 && this.inFlight < this.maxConcurrent) {
+        const wait = this.minIntervalMs - (Date.now() - this.lastStartedAt);
+        if (wait > 0) await sleep(wait);
+
+        const next = this.waiters.shift();
+        if (!next) break;
+
+        this.inFlight += 1;
+        this.lastStartedAt = Date.now();
+        next();
+      }
+    } finally {
+      this.pumping = false;
+    }
+  }
+}
+
+/**
+ * The limiter every `SlackClient` shares by default. Slack counts API volume per
+ * session, not per client object, so the pacing has to be process-wide — a
+ * per-instance limiter would let two clients double the rate.
+ */
+export const slackRateLimiter = new RateLimiter({
+  maxConcurrent: SLACK_MAX_CONCURRENT_REQUESTS,
+  minIntervalMs: SLACK_MIN_REQUEST_INTERVAL_MS,
+});

--- a/src/lib/rate-limiter.ts
+++ b/src/lib/rate-limiter.ts
@@ -55,9 +55,12 @@ export class RateLimiter {
    * another — so keep composite calls sequential rather than nested.
    *
    * A `task` that never settles holds its slot forever and stalls everything
-   * behind it. `browserRequest()` uses a bare `fetch` with no timeout, so if a
-   * caller ever needs to survive a hung request, the timeout belongs on the
-   * request itself (an `AbortSignal`), not here.
+   * behind it, and neither Slack path is bounded today: `browserRequest()` uses
+   * a bare `fetch` with no timeout, and the `WebClient` is constructed with the
+   * SDK defaults (`timeout: 0`, `tenRetriesInAboutThirtyMinutes`), so a retrying
+   * standard call can hold a slot for ~30 minutes. The bound belongs on the
+   * request — an `AbortSignal`, or `timeout`/`retryConfig` on the `WebClient` —
+   * not here.
    */
   async run<T>(task: () => Promise<T>): Promise<T> {
     await this.acquire();

--- a/src/lib/slack-client.test.ts
+++ b/src/lib/slack-client.test.ts
@@ -302,9 +302,9 @@ describe('SlackClient request throttling', () => {
 
   // Slack counts API volume per session, not per client object, so two clients
   // must not be able to double the rate by each holding their own limiter.
-  // This is the one test that leans on the process-wide `slackRateLimiter`; it
-  // asserts a gap between its own two calls, so earlier tests advancing the
-  // singleton's clock cannot affect it.
+  // This leans on the process-wide `slackRateLimiter`, which other tests in this
+  // file also touch. Safe because it asserts the gap between its own two calls:
+  // whatever advanced the singleton's clock earlier cannot shrink that gap.
   it('shares one limiter across clients when none is injected', async () => {
     const starts: number[] = [];
     globalThis.fetch = (async (_input, _init) => {

--- a/src/lib/slack-client.test.ts
+++ b/src/lib/slack-client.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { SlackClient } from './slack-client.ts';
+import { RateLimiter } from './rate-limiter.ts';
 
 class TestSlackClient extends SlackClient {
   public readonly calls: Array<{ method: string; params: Record<string, unknown> }> = [];
@@ -229,5 +230,92 @@ describe('SlackClient.postMessage', () => {
     expect(body?.get('channel')).toBe('C123');
     expect(body?.get('text')).toBe('Status table');
     expect(body?.get('blocks')).toBe(JSON.stringify(blocks));
+  });
+});
+
+describe('SlackClient request throttling', () => {
+  // A fast stand-in for the process-wide limiter: same shape, test-sized numbers.
+  const testLimiter = () => new RateLimiter({ maxConcurrent: 2, minIntervalMs: 25 });
+
+  it('paces browser-session requests and caps their concurrency', async () => {
+    const starts: number[] = [];
+    let inFlight = 0;
+    let peakConcurrent = 0;
+
+    globalThis.fetch = (async (_input, _init) => {
+      starts.push(Date.now());
+      inFlight += 1;
+      peakConcurrent = Math.max(peakConcurrent, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      inFlight -= 1;
+      return Response.json({ ok: true, user: { id: 'U1' } });
+    }) as typeof fetch;
+
+    const client = new SlackClient({
+      workspace_id: 'T123',
+      workspace_name: 'Test Workspace',
+      auth_type: 'browser',
+      xoxd_token: 'xoxd-test',
+      xoxc_token: 'xoxc-test',
+      workspace_url: 'https://example.slack.com',
+    }, { rateLimiter: testLimiter() });
+
+    await Promise.all(['U1', 'U2', 'U3', 'U4'].map((id) => client.getUserInfo(id)));
+
+    expect(starts).toHaveLength(4);
+    expect(peakConcurrent).toBeLessThanOrEqual(2);
+    for (let i = 1; i < starts.length; i += 1) {
+      // 5ms of slack for platform timer jitter.
+      expect(starts[i]! - starts[i - 1]!).toBeGreaterThanOrEqual(20);
+    }
+  });
+
+  it('paces standard-token requests too', async () => {
+    const starts: number[] = [];
+
+    const client = new SlackClient({
+      workspace_id: 'T123',
+      workspace_name: 'Test Workspace',
+      auth_type: 'standard',
+      token: 'xoxb-test',
+      token_type: 'bot',
+    }, { rateLimiter: testLimiter() });
+
+    // The WebClient talks to Slack over the network; swap its transport for a stub
+    // so the test exercises the limiter around `standardRequest`, not the SDK.
+    (client as unknown as { webClient: { apiCall: (method: string) => Promise<unknown> } }).webClient = {
+      apiCall: async () => {
+        starts.push(Date.now());
+        return { ok: true };
+      },
+    };
+
+    await Promise.all(['U1', 'U2', 'U3'].map((id) => client.getUserInfo(id)));
+
+    expect(starts).toHaveLength(3);
+    for (let i = 1; i < starts.length; i += 1) {
+      expect(starts[i]! - starts[i - 1]!).toBeGreaterThanOrEqual(20);
+    }
+  });
+
+  it('releases the slot when a request fails, so later calls still run', async () => {
+    let call = 0;
+    globalThis.fetch = (async (_input, _init) => {
+      call += 1;
+      if (call === 1) throw new Error('network down');
+      return Response.json({ ok: true, user: { id: 'U2' } });
+    }) as typeof fetch;
+
+    const client = new SlackClient({
+      workspace_id: 'T123',
+      workspace_name: 'Test Workspace',
+      auth_type: 'browser',
+      xoxd_token: 'xoxd-test',
+      xoxc_token: 'xoxc-test',
+      workspace_url: 'https://example.slack.com',
+    }, { rateLimiter: new RateLimiter({ maxConcurrent: 1, minIntervalMs: 0 }) });
+
+    await expect(client.getUserInfo('U1')).rejects.toThrow('network down');
+    await expect(client.getUserInfo('U2')).resolves.toMatchObject({ ok: true });
   });
 });

--- a/src/lib/slack-client.test.ts
+++ b/src/lib/slack-client.test.ts
@@ -246,7 +246,9 @@ describe('SlackClient request throttling', () => {
       starts.push(Date.now());
       inFlight += 1;
       peakConcurrent = Math.max(peakConcurrent, inFlight);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      // Must outlive the limiter's interval, or requests never overlap and the
+      // concurrency assertion below passes vacuously.
+      await new Promise((resolve) => setTimeout(resolve, 60));
       inFlight -= 1;
       return Response.json({ ok: true, user: { id: 'U1' } });
     }) as typeof fetch;
@@ -263,7 +265,7 @@ describe('SlackClient request throttling', () => {
     await Promise.all(['U1', 'U2', 'U3', 'U4'].map((id) => client.getUserInfo(id)));
 
     expect(starts).toHaveLength(4);
-    expect(peakConcurrent).toBeLessThanOrEqual(2);
+    expect(peakConcurrent).toBe(2);
     for (let i = 1; i < starts.length; i += 1) {
       // 5ms of slack for platform timer jitter.
       expect(starts[i]! - starts[i - 1]!).toBeGreaterThanOrEqual(20);
@@ -300,6 +302,9 @@ describe('SlackClient request throttling', () => {
 
   // Slack counts API volume per session, not per client object, so two clients
   // must not be able to double the rate by each holding their own limiter.
+  // This is the one test that leans on the process-wide `slackRateLimiter`; it
+  // asserts a gap between its own two calls, so earlier tests advancing the
+  // singleton's clock cannot affect it.
   it('shares one limiter across clients when none is injected', async () => {
     const starts: number[] = [];
     globalThis.fetch = (async (_input, _init) => {

--- a/src/lib/slack-client.test.ts
+++ b/src/lib/slack-client.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { SlackClient } from './slack-client.ts';
-import { RateLimiter } from './rate-limiter.ts';
+import { RateLimiter, SLACK_MIN_REQUEST_INTERVAL_MS } from './rate-limiter.ts';
 
 class TestSlackClient extends SlackClient {
   public readonly calls: Array<{ method: string; params: Record<string, unknown> }> = [];
@@ -296,6 +296,33 @@ describe('SlackClient request throttling', () => {
     for (let i = 1; i < starts.length; i += 1) {
       expect(starts[i]! - starts[i - 1]!).toBeGreaterThanOrEqual(20);
     }
+  });
+
+  // Slack counts API volume per session, not per client object, so two clients
+  // must not be able to double the rate by each holding their own limiter.
+  it('shares one limiter across clients when none is injected', async () => {
+    const starts: number[] = [];
+    globalThis.fetch = (async (_input, _init) => {
+      starts.push(Date.now());
+      return Response.json({ ok: true, user: { id: 'U1' } });
+    }) as typeof fetch;
+
+    const config = {
+      workspace_id: 'T123',
+      workspace_name: 'Test Workspace',
+      auth_type: 'browser',
+      xoxd_token: 'xoxd-test',
+      xoxc_token: 'xoxc-test',
+      workspace_url: 'https://example.slack.com',
+    } as const;
+
+    const first = new SlackClient({ ...config });
+    const second = new SlackClient({ ...config });
+
+    await Promise.all([first.getUserInfo('U1'), second.getUserInfo('U2')]);
+
+    expect(starts).toHaveLength(2);
+    expect(starts[1]! - starts[0]!).toBeGreaterThanOrEqual(SLACK_MIN_REQUEST_INTERVAL_MS - 5);
   });
 
   it('releases the slot when a request fails, so later calls still run', async () => {

--- a/src/lib/slack-client.ts
+++ b/src/lib/slack-client.ts
@@ -4,18 +4,26 @@ import { readFile, stat } from 'node:fs/promises';
 import type { WorkspaceConfig, SlackAuthTestResponse } from '../types/index.ts';
 import { parseMrkdwn } from './mrkdwn.ts';
 import { extractSlackWorkspaceName } from './curl-parser.ts';
+import { RateLimiter, slackRateLimiter } from './rate-limiter.ts';
 
 interface ExternalUploadUrlResponse {
   upload_url?: string;
   file_id?: string;
 }
 
+export interface SlackClientOptions {
+  /** Overrides the process-wide limiter. Intended for tests. */
+  rateLimiter?: RateLimiter;
+}
+
 export class SlackClient {
   private config: WorkspaceConfig;
   private webClient?: WebClient;
+  private rateLimiter: RateLimiter;
 
-  constructor(config: WorkspaceConfig) {
+  constructor(config: WorkspaceConfig, options: SlackClientOptions = {}) {
     this.config = config;
+    this.rateLimiter = options.rateLimiter ?? slackRateLimiter;
 
     // Only use WebClient for standard auth
     if (config.auth_type === 'standard') {
@@ -24,12 +32,21 @@ export class SlackClient {
   }
 
   // Make API request (handles both auth types)
+  //
+  // Every Slack API call in the codebase funnels through here, so this is where
+  // the traffic is paced: callers like `getUsersInfo()`, `enrichSavedItems()` and
+  // the unread resolver fan out one call per user/channel, and an unthrottled
+  // burst trips Slack's `unexpected_api_call_volume` anomaly detection (#147).
+  // The limiter applies to both auth types — the anomaly is about volume, not
+  // about which transport produced it.
   async request(method: string, params: Record<string, any> = {}): Promise<any> {
-    if (this.config.auth_type === 'standard') {
-      return this.standardRequest(method, params);
-    } else {
-      return this.browserRequest(method, params);
-    }
+    return this.rateLimiter.run(() => {
+      if (this.config.auth_type === 'standard') {
+        return this.standardRequest(method, params);
+      } else {
+        return this.browserRequest(method, params);
+      }
+    });
   }
 
   // Standard token request (using @slack/web-api)


### PR DESCRIPTION
## Linked issue

Closes #147

## Summary

Slack's Enterprise Grid anomaly detection raises [`unexpected_api_call_volume`](https://docs.slack.dev/reference/audit-logs-api/anomalous-events-reference/) when a client produces more API traffic than a browser would, and it can sign the session out — which is what happened to the reporter on browser-session auth. slackcli had no throttling anywhere, and several paths fan out one call per entity with no delay or concurrency cap: `SlackClient.getUsersInfo()` (one `users.info` per user in a tight loop), `enrichSavedItems()` in `saved.ts`, and the unread resolver in `unread.ts`.

**What changed**

- **New `src/lib/rate-limiter.ts`** — a zero-dependency `RateLimiter` combining a concurrency cap with a minimum delay between call *starts*, plus `slackRateLimiter`, the process-wide instance every `SlackClient` shares by default. Defaults live in named constants: `SLACK_MAX_CONCURRENT_REQUESTS = 2`, `SLACK_MIN_REQUEST_INTERVAL_MS = 200`. Hand-rolled rather than `p-limit`/`bottleneck` per constitution §8 — the CLI ships as a `bun build --compile` binary under a 150MB budget and this is ~60 lines with no other consumer.
- **`src/lib/slack-client.ts`** — `request()` now runs its auth-type dispatch inside `this.rateLimiter.run(...)`. Because `request()` is a complete funnel for every Slack API call in the tree, this covers **both** auth paths (`standardRequest` via `@slack/web-api` and `browserRequest` via raw `fetch`) and `saved.ts` / `unread.ts` need no changes. The constructor takes an optional `{ rateLimiter }` so tests can inject a fast one.

Out of scope, as the issue specifies: retry/backoff on HTTP 429, and the raw `fetch()` calls used for file upload/download (single-shot per invocation, not a burst source).

**Tests**

- `src/lib/rate-limiter.test.ts` (11 cases): concurrency cap never exceeded, full serialization at `maxConcurrent: 1`, minimum spacing between starts, no extra wait after an idle period, no delay at `minIntervalMs: 0`, rejection propagates *and* releases the slot, queued tasks keep running after one rejects, FIFO start order, and constructor validation of invalid options (`0`, negative, `NaN`, `Infinity`).
- `src/lib/slack-client.test.ts` (4 cases) proving `request()` is actually gated — pacing *and* a binding concurrency cap on the browser path (stubbed `fetch`, held open longer than the interval so the requests really overlap), pacing on the standard path (stubbed `WebClient.apiCall`), one limiter shared across two clients, and slot release after a failed request. Reverting the `request()` change fails three of them; making the limiter per-instance fails the fourth.

A `[Unreleased]` changelog entry covers the user-visible slowdown.

**Docs**

`docs/development/architecture.md` gains a "Throttling" section and an updated `request()` snippet; `docs/user-guide/troubleshooting.md` and `docs/user-guide/scripting.md` explain the pacing and that the resulting slowness on `saved list` / `conversations unread` is throttling, not a hang (per @shaharia's note on the issue); module tables in `CLAUDE.md` and `docs/development/project-structure.md` list the new module.

## Checklist

- [x] The linked issue is open and carries the `ready-for-pr` label (constitution §1–2)
- [x] Change is focused on the linked issue — no unrelated edits
- [x] Tests added/updated, including edge cases (constitution §4)
- [x] `bun run type-check` and `bun test` pass locally
- [x] Pre-commit hooks are installed and passing — no `--no-verify`, no `SKIP=`
- [x] All commits are signed (constitution §5)
- [x] Documentation in `docs/` updated, added, or deleted as needed (constitution §7)
- [x] No tokens, credentials, or user data handled insecurely

