### PR TITLE
fix: resolve findBrowser PATH scan with platform-specific path module

### DIFF
--- a/src/lib/browser-launcher.test.ts
+++ b/src/lib/browser-launcher.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, win32 } from 'node:path';
 import { existsSync } from 'node:fs';
 import { mkdir, rm, symlink, writeFile } from 'node:fs/promises';
 import {
@@ -118,21 +118,22 @@ describe('findBrowser on Windows', () => {
   it('scans PATH for .exe names, not POSIX ones', async () => {
     // The regression this guards: PATH_CANDIDATES previously held only
     // extension-less POSIX names ('google-chrome'), which can never match a
-    // Windows executable. Both the path separator and the PATH delimiter come
-    // from the host, so this uses a delimiter-free directory and composes the
-    // expected value with the same join — the assertion is about the
-    // executable *name*, not Windows path syntax.
+    // Windows executable. findBrowser resolves 'win32' paths with the win32
+    // path module regardless of the host OS running the test, so the
+    // expected value here is composed with `win32.join`, not the host's
+    // `join` — the assertion is about the executable *name*, not about
+    // whichever path syntax the test happens to run on.
     const dir = '/tools/chrome';
     process.env.PATH = dir;
     const probed: string[] = [];
     const found = await findBrowser(async (p) => {
       probed.push(p);
-      return p === join(dir, 'chrome.exe');
+      return p === win32.join(dir, 'chrome.exe');
     }, 'win32');
 
-    expect(found).toBe(join(dir, 'chrome.exe'));
+    expect(found).toBe(win32.join(dir, 'chrome.exe'));
     expect(probed.some((p) => p.endsWith('.exe'))).toBe(true);
-    expect(probed).not.toContain(join(dir, 'google-chrome'));
+    expect(probed).not.toContain(win32.join(dir, 'google-chrome'));
   });
 
   it('returns null when no browser is installed', async () => {

--- a/src/lib/browser-launcher.ts
+++ b/src/lib/browser-launcher.ts
@@ -14,7 +14,7 @@
 
 import { spawn, spawnSync, type ChildProcess } from 'child_process';
 import { chmod, lstat, mkdir, readdir, readFile, rm, stat, writeFile } from 'fs/promises';
-import { join, delimiter } from 'path';
+import { join, posix, win32 } from 'path';
 import { homedir } from 'os';
 
 export type BrowserLaunchFailure =
@@ -135,11 +135,19 @@ export async function findBrowser(
   // PATH scan covers installs outside the standard prefixes (Nix, Flatpak
   // shims, distro variants, Scoop/Chocolatey on Windows) without hardcoding
   // every layout.
-  const pathDirs = (process.env.PATH ?? '').split(delimiter).filter(Boolean);
+  //
+  // Use the path module for the *simulated* platform, not the host's. The
+  // top-level `join`/`delimiter` always follow the real host OS, so on a
+  // real Windows machine they silently produce backslash paths even when
+  // `platform` says 'linux' or 'freebsd' (as the tests do). CI runs on
+  // Linux, where the host-OS behavior happens to match posix, so this bug
+  // was invisible there and only surfaces on an actual Windows machine.
+  const platformPath = platform === 'win32' ? win32 : posix;
+  const pathDirs = (process.env.PATH ?? '').split(platformPath.delimiter).filter(Boolean);
   const names = PATH_CANDIDATES[platform] ?? PATH_CANDIDATES.default;
   for (const name of names) {
     for (const dir of pathDirs) {
-      const full = join(dir, name);
+      const full = platformPath.join(dir, name);
       if (await fileExists(full)) return full;
     }
   }


### PR DESCRIPTION
## Linked issue

Fixes #154

## Summary

`findBrowser()` (src/lib/browser-launcher.ts) takes a `platform` parameter
so its PATH-scan behavior can be exercised for every OS from one test run,
but the PATH-scan branch used the top-level `join`/`delimiter` from
`'path'`, which always follow the real host OS rather than the `platform`
argument. `findBrowser` has exactly one production call site, and it never
passes `platform` — so in real usage `platform` is always
`process.platform`, and the host-based `join`/`delimiter` were already
correct. This does not affect `auth login-auto` on a real machine.

What it actually breaks is *simulating* another OS from a different host:
`findBrowser(..., 'linux')` or `findBrowser(..., 'freebsd')` run on an
actual Windows machine produce wrong paths, which is exactly what
`bun test src/lib/browser-launcher.test.ts` exercises — so this blocks the
mandatory pre-commit hook on Windows, without being a user-facing bug.

Fixed by selecting the `win32`/`posix` path module based on the `platform`
argument instead of the host OS, in both the implementation and its own
test, which had the identical bug in how it built its expected value.