### PR TITLE
feat: add usergroups write commands with a --yes confirmation gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ Browser tokens can be captured two ways: pasting a cURL command from DevTools (`
 | `src/lib/saved.ts` | Enriches saved-for-later items (resolves messages & channels) |
 | `src/lib/unread.ts` | Fetches and resolves unread channel data |
 | `src/lib/emoji.ts` | Normalizes the custom-emoji map (originals vs. aliases) |
-| `src/lib/usergroups.ts` | Normalizes user groups and resolves members to names |
+| `src/lib/usergroups.ts` | Normalizes user groups, resolves members, read-modify-write membership |
 | `src/lib/updater.ts` | Self-update via GitHub releases |
 | `src/lib/canvas-parser.ts` | Slack Canvas HTML to Markdown converter (zero deps, Quip-based HTML) |
 | `src/lib/rate-limiter.ts` | Process-wide concurrency cap + minimum interval applied to every Slack API call |

--- a/docs/user-guide/scripting.md
+++ b/docs/user-guide/scripting.md
@@ -7,11 +7,13 @@ hand.
 
 Every read command supports `--json`: `conversations list`, `conversations read`,
 `conversations get`, `conversations unread`, `search messages`, `search channels`,
-`search people`, `saved list`, `canvas list`, `canvas read`.
+`search people`, `saved list`, `canvas list`, `canvas read`, `team info`,
+`usergroups list`, `usergroups read`, `emoji list`, `emoji get`.
 
-The writing commands support it too — `messages send`, `messages edit`, and
-`messages draft` — where it returns the identity of what was just written
-instead of the human success line.
+The writing commands support it too — `messages send`, `messages edit`,
+`messages draft`, and the `usergroups` write verbs (`create`, `update`, `add`,
+`remove`, `enable`, `disable`) — where it returns the identity of what was just
+written instead of the human success line.
 
 JSON goes to **stdout**. Progress spinners, warnings, error messages, and the
 update-available notice go to **stderr**, so a pipe normally carries only data:
@@ -142,6 +144,10 @@ done
   timeouts in a scheduled job.
 - **The update notice.** SlackCLI may append a one-line "update available" notice
   after a command. It goes to stderr and never contaminates `--json` on stdout.
+- **`usergroups` writes need `--yes`.** `create`, `update`, `add`, `remove`,
+  `enable`, and `disable` refuse to run with a non-zero exit when stdin is not a
+  terminal and `--yes` is absent, so an unattended job must pass `--yes`
+  explicitly. See [User groups](usergroups.md).
 - **Credentials.** `~/.config/slackcli/workspaces.json` holds live tokens at mode
   `0600`. Give a CI job its own bot-token profile rather than copying a personal
   browser session around.

--- a/docs/user-guide/usergroups.md
+++ b/docs/user-guide/usergroups.md
@@ -1,28 +1,33 @@
 # User groups
 
-`slackcli usergroups` lists and reads **user groups** — Slack's own name for a
-named, mentionable group of people (also called a "subteam", e.g.
-`@platform-team`).
+`slackcli usergroups` lists, reads, and manages **user groups** — Slack's own
+name for a named, mentionable group of people (also called a "subteam", e.g.
+`@platform-team`). This is the workspace's team-management surface.
 
 ```bash
 slackcli usergroups list
 slackcli usergroups list --include-disabled --json
 slackcli usergroups read @platform-team
+slackcli usergroups create "Platform Team" --handle=platform --description="Owns the platform" --yes
+slackcli usergroups update @platform --description="Owns platform + infra" --yes
+slackcli usergroups add @platform U0123ABC U0456DEF --yes
+slackcli usergroups remove @platform U0123ABC --yes
+slackcli usergroups disable @platform --yes
+slackcli usergroups enable @platform --yes
 ```
-
-> This PR adds the **read-only** surface (`list`, `read`). The write verbs
-> (`create`, `update`, `add`, `remove`, `enable`, `disable`) land in a
-> follow-up PR so the read side can be reviewed and merged on its own.
 
 ## Referring to a group
 
-`read` takes a `<group>` argument that accepts any of:
+Every subcommand except `list` and `create` takes a `<group>` argument. It
+accepts any of:
 
 - the group **ID** (`S03E2T070G7`),
 - the **@handle** (`@platform` or `platform`), or
 - the exact **name** (`"Platform Team"`, case-insensitive).
 
-## `usergroups list`
+## Read commands
+
+### `usergroups list`
 
 Lists the workspace's user groups, sorted by name, with each group's handle,
 member count, and enabled/disabled state.
@@ -34,26 +39,77 @@ member count, and enabled/disabled state.
 | `--workspace <id\|name>` | Workspace to use |
 | `--json` | JSON output |
 
-## `usergroups read <group>`
+### `usergroups read <group>`
 
 Shows one group and its members, resolving member IDs to names.
 
+## Write commands and the `--yes` gate
+
+The mutating subcommands (`create`, `update`, `add`, `remove`, `enable`,
+`disable`) all confirm before acting:
+
+- With **`--yes`** they proceed without prompting.
+- In an **interactive terminal** without `--yes` they prompt `y/N`.
+- When **stdin is not a terminal** (a pipe, a CI job, an agent) and `--yes` is
+  absent, they **refuse with a clear message and a non-zero exit** rather than
+  silently proceeding — so a script cannot mutate or disable a group unattended
+  by accident. Pass `--yes` to opt into the non-interactive path deliberately.
+
+### `usergroups create <name>`
+
+Creates a group.
+
 | Option | Purpose |
 |---|---|
-| `--team <workspace-id>` | Scope to one workspace (enterprise org) |
-| `--workspace <id\|name>` | Workspace to use |
-| `--json` | JSON output |
+| `--handle <handle>` | Mention handle (without the `@`) |
+| `--description <text>` | Description |
+| `--channels <ids>` | Comma-separated default channel IDs |
+| `--team <workspace-id>` | Target workspace T-id (**required on an enterprise org**) |
+| `--yes` | Skip the confirmation prompt (required when stdin is not a TTY) |
+
+### `usergroups update <group>`
+
+Changes a group's `--name`, `--handle`, and/or `--description`. Pass at least
+one; the command refuses a no-op.
+
+### `usergroups add <group> <users...>` / `remove <group> <users...>`
+
+Adds or removes members. User IDs may be space- or comma-separated, with or
+without a leading `@`.
+
+Slack's underlying `usergroups.users.update` replaces the group's **entire**
+member list — there is no incremental add/remove endpoint. SlackCLI makes
+`add`/`remove` safe by **reading the current membership, applying your change,
+and writing the result back**, so concurrent members are never dropped. An
+add/remove that would change nothing is reported as a no-op and skips the write.
+
+Slack does not allow a user group with **zero** members, so `remove` refuses to
+empty the last member — disable the group instead.
+
+### `usergroups enable <group>` / `disable <group>`
+
+Slack has no hard-delete for user groups. `disable` archives a group (it stops
+being mentionable); `enable` restores it. `list --include-disabled` shows
+archived groups.
 
 ## Enterprise orgs and `--team`
 
-On a Slack **Enterprise Grid** a user group belongs to a specific member
-workspace. A group scoped to a member workspace may not appear in the
-org-level `usergroups list`; refer to it by its `S…` ID, and pass
-`--team <workspace-id>` (a `T…` ID) to scope the listing. On a single-workspace
-install `--team` is unnecessary.
+On a Slack **Enterprise Grid**, a user group belongs to a specific member
+workspace, and write operations (`create`, `update`, `add`, `remove`, `enable`,
+`disable`) must name that workspace with `--team <workspace-id>` (a `T…` ID).
+Without it, Slack rejects the create with
+`target_team_must_be_specified_in_org_context`. On a single-workspace install
+`--team` is unnecessary. Note that a group created against a member workspace may
+not appear in the org-level `usergroups list`; refer to it by its `S…` ID.
 
 ## Auth types
 
-Both commands go through Slack's read `usergroups.list` / `usergroups.users.list`
-methods, which work for standard (`xoxb`/`xoxp`) and browser (`xoxd`/`xoxc`)
-tokens alike.
+All of these go through Slack's `usergroups.*` methods, which work for both
+standard (`xoxb`/`xoxp`) and browser (`xoxd`/`xoxc`) tokens. The write methods
+require the `usergroups:write` scope; per Slack's
+[scope reference](https://docs.slack.dev/reference/scopes/usergroups.write) that
+scope is supported by Bot, User, and Legacy Bot tokens, so a bot token
+(`xoxb`) carrying `usergroups:write` can create and manage groups. Writes are
+further constrained by whatever the authenticated principal is allowed to do in
+Slack; managing user groups typically requires the relevant workspace
+permission.

--- a/src/commands/usergroups.test.ts
+++ b/src/commands/usergroups.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { confirmWrite, createUsergroupsCommand, parseUserIds } from './usergroups.ts';
+
+function subcommand(name: string) {
+  return createUsergroupsCommand().commands.find((command) => command.name() === name);
+}
+
+function longOptions(name: string): string[] {
+  return (subcommand(name)?.options ?? []).map((option) => option.long ?? '');
+}
+
+describe('usergroups command', () => {
+  it('exposes the read and write subcommands', () => {
+    const names = createUsergroupsCommand().commands.map((command) => command.name());
+    expect(names).toEqual(
+      expect.arrayContaining(['list', 'read', 'create', 'update', 'add', 'remove', 'enable', 'disable']),
+    );
+  });
+
+  it('puts --yes on every write subcommand', () => {
+    for (const name of ['create', 'update', 'add', 'remove', 'enable', 'disable']) {
+      expect(longOptions(name)).toContain('--yes');
+    }
+  });
+
+  it('does not add --yes to the read-only subcommands', () => {
+    expect(longOptions('list')).not.toContain('--yes');
+    expect(longOptions('read')).not.toContain('--yes');
+  });
+});
+
+describe('parseUserIds', () => {
+  it('splits on commas and whitespace', () => {
+    expect(parseUserIds(['U1,U2 U3', 'U4'])).toEqual(['U1', 'U2', 'U3', 'U4']);
+  });
+  it('strips a leading @ and drops empties', () => {
+    expect(parseUserIds(['@U1', '', ' , ', 'U2'])).toEqual(['U1', 'U2']);
+  });
+  it('returns an empty array for no ids', () => {
+    expect(parseUserIds([''])).toEqual([]);
+  });
+});
+
+describe('confirmWrite', () => {
+  const realIsTTY = process.stdin.isTTY;
+  afterEach(() => {
+    // Restore whatever the runner's stdin was.
+    Object.defineProperty(process.stdin, 'isTTY', { value: realIsTTY, configurable: true });
+  });
+
+  it('proceeds without prompting when --yes is set (even non-TTY)', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    expect(await confirmWrite('Do it?', true)).toBe(true);
+  });
+
+  it('refuses when stdin is not a TTY and --yes is absent', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    expect(await confirmWrite('Do it?', false)).toBe(false);
+  });
+});

--- a/src/commands/usergroups.ts
+++ b/src/commands/usergroups.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import ora from 'ora';
+import * as readline from 'readline';
 import { getAuthenticatedClient } from '../lib/auth.ts';
 import {
   error,
@@ -7,9 +8,13 @@ import {
   formatUsergroupList,
   writeJson,
 } from '../lib/formatter.ts';
+import { isInteractiveTerminal } from '../lib/interactive-input.ts';
 import {
+  addUsergroupMembers,
   fetchUsergroupMembers,
   fetchUsergroups,
+  normalizeUsergroups,
+  removeUsergroupMembers,
   resolveUsergroup,
 } from '../lib/usergroups.ts';
 import type { SlackUsergroup } from '../types/index.ts';
@@ -34,9 +39,48 @@ async function requireGroup(
   return group;
 }
 
+// Split a comma/space-separated list of user IDs into a clean array.
+export function parseUserIds(raw: string[]): string[] {
+  return raw
+    .flatMap((token) => token.split(/[\s,]+/))
+    .map((s) => s.trim().replace(/^@/, ''))
+    .filter(Boolean);
+}
+
+// Confirmation gate for a mutating command. Three cases, built on the existing
+// isInteractiveTerminal():
+//   --yes             -> proceed (explicit consent)
+//   TTY,   no --yes   -> prompt y/N interactively
+//   non-TTY, no --yes -> REFUSE with a clear message (never auto-pass, so a
+//                        script cannot mutate a group unattended by accident)
+// Returns true to proceed, false to abort. Every caller exits non-zero on false
+// (both the non-TTY refusal and a TTY "no" decline the write and stop).
+export async function confirmWrite(prompt: string, assumeYes: boolean): Promise<boolean> {
+  if (assumeYes) return true;
+
+  if (!isInteractiveTerminal()) {
+    error(
+      `Refusing to run this write unattended. stdin is not a terminal, so there is ` +
+        `no way to confirm interactively. Re-run with --yes to proceed non-interactively.`,
+    );
+    return false;
+  }
+
+  return new Promise((resolve) => {
+    // Prompt on stderr, not stdout: a `--json` command in an interactive
+    // terminal still calls this, and writing the "[y/N]" prompt to stdout would
+    // corrupt the JSON on the pipe.
+    const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+    rl.question(`${prompt} [y/N] `, (answer) => {
+      rl.close();
+      resolve(/^y(es)?$/i.test(answer.trim()));
+    });
+  });
+}
+
 export function createUsergroupsCommand(): Command {
   const usergroups = new Command('usergroups')
-    .description('List and read user groups (Slack "subteams")');
+    .description('List, read, and manage user groups (Slack "subteams")');
 
   // ─── list ────────────────────────────────────────────────────────────────
   usergroups
@@ -97,6 +141,240 @@ export function createUsergroupsCommand(): Command {
         console.log('\n' + formatUsergroup(group, members));
       } catch (err: any) {
         spinner.fail('Failed to read user group');
+        error(err.message);
+        process.exit(1);
+      }
+    });
+
+  // ─── create ──────────────────────────────────────────────────────────────
+  usergroups
+    .command('create')
+    .description('Create a new user group')
+    .argument('<name>', 'Display name for the group')
+    .option('--handle <handle>', 'Mention handle (without @)')
+    .option('--description <text>', 'Description of the group')
+    .option('--channels <ids>', 'Comma-separated default channel IDs')
+    .option('--workspace <id|name>', 'Workspace to use')
+    .option('--team <workspace-id>', 'Target workspace T-id (required for writes on an enterprise org)')
+    .option('--yes', 'Skip the confirmation prompt (required when stdin is not a TTY)', false)
+    .option('--json', 'Output in JSON format', false)
+    .action(async (name, options) => {
+      if (!(await confirmWrite(`Create user group "${name}"?`, options.yes))) {
+        process.exit(1);
+      }
+      const spinner = ora(`Creating user group "${name}"...`).start();
+      try {
+        const client = await getAuthenticatedClient(options.workspace);
+        const response = await client.createUsergroup(name, {
+          handle: options.handle,
+          description: options.description,
+          channels: options.channels,
+          team_id: options.team,
+        });
+        const group = normalizeUsergroups([response.usergroup])[0];
+
+        spinner.succeed(`Created ${group.name} (${group.id})`);
+
+        if (options.json) {
+          writeJson(group);
+          return;
+        }
+        console.log('\n' + formatUsergroup(group, []));
+      } catch (err: any) {
+        spinner.fail('Failed to create user group');
+        error(err.message);
+        process.exit(1);
+      }
+    });
+
+  // ─── update ──────────────────────────────────────────────────────────────
+  usergroups
+    .command('update')
+    .description('Update a user group\'s name, handle, or description')
+    .argument('<group>', 'Group ID, @handle, or exact name')
+    .option('--name <name>', 'New display name')
+    .option('--handle <handle>', 'New mention handle (without @)')
+    .option('--description <text>', 'New description')
+    .option('--workspace <id|name>', 'Workspace to use')
+    .option('--team <workspace-id>', 'Target workspace T-id (required for writes on an enterprise org)')
+    .option('--yes', 'Skip the confirmation prompt (required when stdin is not a TTY)', false)
+    .option('--json', 'Output in JSON format', false)
+    .action(async (ref, options) => {
+      if (options.name === undefined && options.handle === undefined && options.description === undefined) {
+        error('Nothing to update — pass at least one of --name, --handle, or --description.');
+        process.exit(1);
+      }
+      if (!(await confirmWrite(`Update user group "${ref}"?`, options.yes))) {
+        process.exit(1);
+      }
+      const spinner = ora('Updating user group...').start();
+      try {
+        const client = await getAuthenticatedClient(options.workspace);
+        const group = await requireGroup(client, ref, spinner, options.team);
+
+        spinner.text = 'Applying update...';
+        const response = await client.updateUsergroup(group.id, {
+          name: options.name,
+          handle: options.handle,
+          description: options.description,
+          team_id: options.team,
+        });
+        const updated = normalizeUsergroups([response.usergroup])[0];
+
+        spinner.succeed(`Updated ${updated.name} (${updated.id})`);
+
+        if (options.json) {
+          writeJson(updated);
+          return;
+        }
+        console.log('\n' + formatUsergroup(updated, []));
+      } catch (err: any) {
+        spinner.fail('Failed to update user group');
+        error(err.message);
+        process.exit(1);
+      }
+    });
+
+  // ─── add ─────────────────────────────────────────────────────────────────
+  usergroups
+    .command('add')
+    .description('Add one or more users to a group')
+    .argument('<group>', 'Group ID, @handle, or exact name')
+    .argument('<users...>', 'One or more user IDs (comma- or space-separated)')
+    .option('--workspace <id|name>', 'Workspace to use')
+    .option('--team <workspace-id>', 'Target workspace T-id (required for writes on an enterprise org)')
+    .option('--yes', 'Skip the confirmation prompt (required when stdin is not a TTY)', false)
+    .option('--json', 'Output in JSON format', false)
+    .action(async (ref, users, options) => {
+      const ids = parseUserIds(users);
+      if (!(await confirmWrite(`Add ${ids.length} user(s) to "${ref}"?`, options.yes))) {
+        process.exit(1);
+      }
+      const spinner = ora('Adding members...').start();
+      try {
+        const client = await getAuthenticatedClient(options.workspace);
+        const group = await requireGroup(client, ref, spinner, options.team);
+        const result = await addUsergroupMembers(client, group.id, ids, {
+          teamId: options.team,
+          onProgress: (msg) => { spinner.text = msg; },
+        });
+
+        if (result.noop) {
+          spinner.succeed(`No change — those users are already in ${group.name}`);
+        } else {
+          spinner.succeed(`Added ${result.added.length} to ${group.name} (now ${result.next.length} members)`);
+        }
+
+        if (options.json) {
+          writeJson({ usergroup: group.id, ...result });
+          return;
+        }
+      } catch (err: any) {
+        spinner.fail('Failed to add members');
+        error(err.message);
+        process.exit(1);
+      }
+    });
+
+  // ─── remove ──────────────────────────────────────────────────────────────
+  usergroups
+    .command('remove')
+    .description('Remove one or more users from a group')
+    .argument('<group>', 'Group ID, @handle, or exact name')
+    .argument('<users...>', 'One or more user IDs (comma- or space-separated)')
+    .option('--workspace <id|name>', 'Workspace to use')
+    .option('--team <workspace-id>', 'Target workspace T-id (required for writes on an enterprise org)')
+    .option('--yes', 'Skip the confirmation prompt (required when stdin is not a TTY)', false)
+    .option('--json', 'Output in JSON format', false)
+    .action(async (ref, users, options) => {
+      const ids = parseUserIds(users);
+      if (!(await confirmWrite(`Remove ${ids.length} user(s) from "${ref}"?`, options.yes))) {
+        process.exit(1);
+      }
+      const spinner = ora('Removing members...').start();
+      try {
+        const client = await getAuthenticatedClient(options.workspace);
+        const group = await requireGroup(client, ref, spinner, options.team);
+        const result = await removeUsergroupMembers(client, group.id, ids, {
+          teamId: options.team,
+          onProgress: (msg) => { spinner.text = msg; },
+        });
+
+        if (result.noop) {
+          spinner.succeed(`No change — those users are not in ${group.name}`);
+        } else {
+          spinner.succeed(`Removed ${result.removed.length} from ${group.name} (now ${result.next.length} members)`);
+        }
+
+        if (options.json) {
+          writeJson({ usergroup: group.id, ...result });
+          return;
+        }
+      } catch (err: any) {
+        spinner.fail('Failed to remove members');
+        error(err.message);
+        process.exit(1);
+      }
+    });
+
+  // ─── enable / disable ──────────────────────────────────────────────────────
+  usergroups
+    .command('enable')
+    .description('Enable (restore) a disabled user group')
+    .argument('<group>', 'Group ID, @handle, or exact name')
+    .option('--workspace <id|name>', 'Workspace to use')
+    .option('--team <workspace-id>', 'Target workspace T-id (required for writes on an enterprise org)')
+    .option('--yes', 'Skip the confirmation prompt (required when stdin is not a TTY)', false)
+    .option('--json', 'Output in JSON format', false)
+    .action(async (ref, options) => {
+      if (!(await confirmWrite(`Enable user group "${ref}"?`, options.yes))) {
+        process.exit(1);
+      }
+      const spinner = ora('Enabling user group...').start();
+      try {
+        const client = await getAuthenticatedClient(options.workspace);
+        const group = await requireGroup(client, ref, spinner, options.team);
+        const response = await client.enableUsergroup(group.id, { team_id: options.team });
+        const updated = normalizeUsergroups([response.usergroup])[0];
+
+        spinner.succeed(`Enabled ${updated.name} (${updated.id})`);
+        if (options.json) {
+          writeJson(updated);
+          return;
+        }
+      } catch (err: any) {
+        spinner.fail('Failed to enable user group');
+        error(err.message);
+        process.exit(1);
+      }
+    });
+
+  usergroups
+    .command('disable')
+    .description('Disable (archive) a user group')
+    .argument('<group>', 'Group ID, @handle, or exact name')
+    .option('--workspace <id|name>', 'Workspace to use')
+    .option('--team <workspace-id>', 'Target workspace T-id (required for writes on an enterprise org)')
+    .option('--yes', 'Skip the confirmation prompt (required when stdin is not a TTY)', false)
+    .option('--json', 'Output in JSON format', false)
+    .action(async (ref, options) => {
+      if (!(await confirmWrite(`Disable user group "${ref}"?`, options.yes))) {
+        process.exit(1);
+      }
+      const spinner = ora('Disabling user group...').start();
+      try {
+        const client = await getAuthenticatedClient(options.workspace);
+        const group = await requireGroup(client, ref, spinner, options.team);
+        const response = await client.disableUsergroup(group.id, { team_id: options.team });
+        const updated = normalizeUsergroups([response.usergroup])[0];
+
+        spinner.succeed(`Disabled ${updated.name} (${updated.id})`);
+        if (options.json) {
+          writeJson(updated);
+          return;
+        }
+      } catch (err: any) {
+        spinner.fail('Failed to disable user group');
         error(err.message);
         process.exit(1);
       }

--- a/src/lib/slack-client.ts
+++ b/src/lib/slack-client.ts
@@ -431,6 +431,63 @@ export class SlackClient {
     return this.request('usergroups.users.list', params);
   }
 
+  // Create a user group. On an enterprise org, team_id (a workspace T-id) is
+  // REQUIRED — Slack rejects org-context creates without it.
+  async createUsergroup(name: string, options: {
+    handle?: string;
+    description?: string;
+    channels?: string;
+    team_id?: string;
+  } = {}): Promise<any> {
+    const params: Record<string, any> = { name, include_count: true };
+    if (options.handle) params.handle = options.handle;
+    if (options.description) params.description = options.description;
+    if (options.channels) params.channels = options.channels;
+    if (options.team_id) params.team_id = options.team_id;
+    return this.request('usergroups.create', params);
+  }
+
+  // Update a user group's name, handle, and/or description.
+  async updateUsergroup(usergroup: string, options: {
+    name?: string;
+    handle?: string;
+    description?: string;
+    team_id?: string;
+  } = {}): Promise<any> {
+    const params: Record<string, any> = { usergroup, include_count: true };
+    if (options.name !== undefined) params.name = options.name;
+    if (options.handle !== undefined) params.handle = options.handle;
+    if (options.description !== undefined) params.description = options.description;
+    if (options.team_id) params.team_id = options.team_id;
+    return this.request('usergroups.update', params);
+  }
+
+  // Replace a user group's full member list. Slack's usergroups.users.update
+  // is a WHOLE-LIST set operation, not an incremental add/remove — callers that
+  // want add/remove semantics must read the current list, modify it, and pass
+  // the result here. `users` is a comma-separated list of user IDs.
+  async setUsergroupUsers(usergroup: string, users: string, options: {
+    team_id?: string;
+  } = {}): Promise<any> {
+    const params: Record<string, any> = { usergroup, users, include_count: true };
+    if (options.team_id) params.team_id = options.team_id;
+    return this.request('usergroups.users.update', params);
+  }
+
+  // Enable (restore) a disabled user group.
+  async enableUsergroup(usergroup: string, options: { team_id?: string } = {}): Promise<any> {
+    const params: Record<string, any> = { usergroup, include_count: true };
+    if (options.team_id) params.team_id = options.team_id;
+    return this.request('usergroups.enable', params);
+  }
+
+  // Disable (archive) a user group.
+  async disableUsergroup(usergroup: string, options: { team_id?: string } = {}): Promise<any> {
+    const params: Record<string, any> = { usergroup, include_count: true };
+    if (options.team_id) params.team_id = options.team_id;
+    return this.request('usergroups.disable', params);
+  }
+
   // List the workspace's custom emoji (emoji.list works for both auth types).
   // Returns { ok, emoji: { <name>: <image-url|"alias:<other>"> } }.
   async listEmoji(): Promise<any> {

--- a/src/lib/usergroups.test.ts
+++ b/src/lib/usergroups.test.ts
@@ -1,14 +1,17 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  addUsergroupMembers,
+  applyMembershipChange,
   fetchUsergroupMembers,
   isUsergroupEnabled,
   normalizeUsergroups,
+  removeUsergroupMembers,
   resolveUsergroup,
 } from './usergroups.ts';
 import type { SlackClient } from './slack-client.ts';
 
 // Minimal fake client: records every request and returns canned responses
-// keyed by method. Mirrors the SlackClient surface the read helpers call.
+// keyed by method. Mirrors the SlackClient surface the helpers call.
 function fakeClient(overrides: Partial<Record<string, (params: any) => any>> = {}): {
   client: SlackClient;
   calls: Array<{ method: string; params: any }>;
@@ -22,6 +25,10 @@ function fakeClient(overrides: Partial<Record<string, (params: any) => any>> = {
     listUsergroupUsers: (usergroup: string) => {
       calls.push({ method: 'usergroups.users.list', params: { usergroup } });
       return overrides['usergroups.users.list']?.({ usergroup }) ?? { ok: true, users: [] };
+    },
+    setUsergroupUsers: (usergroup: string, users: string) => {
+      calls.push({ method: 'usergroups.users.update', params: { usergroup, users } });
+      return overrides['usergroups.users.update']?.({ usergroup, users }) ?? { ok: true };
     },
     getUsersInfo: (ids: string[]) => {
       calls.push({ method: 'users.info', params: { ids } });
@@ -115,5 +122,63 @@ describe('fetchUsergroupMembers', () => {
     const { members } = await fetchUsergroupMembers(client, 'S1');
     expect(members).toEqual([]);
     expect(calls.some((c) => c.method === 'users.info')).toBe(false);
+  });
+});
+
+describe('applyMembershipChange', () => {
+  test('adds only new ids', () => {
+    const r = applyMembershipChange(['U1'], { add: ['U1', 'U2'] });
+    expect(r.added).toEqual(['U2']);
+    expect(r.removed).toEqual([]);
+    expect(new Set(r.next)).toEqual(new Set(['U1', 'U2']));
+    expect(r.noop).toBe(false);
+  });
+  test('removes only present ids', () => {
+    const r = applyMembershipChange(['U1', 'U2'], { remove: ['U2', 'U9'] });
+    expect(r.removed).toEqual(['U2']);
+    expect(r.next).toEqual(['U1']);
+  });
+  test('no-op when nothing changes', () => {
+    const r = applyMembershipChange(['U1'], { add: ['U1'] });
+    expect(r.noop).toBe(true);
+    expect(r.added).toEqual([]);
+  });
+});
+
+describe('addUsergroupMembers / removeUsergroupMembers (read-modify-write)', () => {
+  test('add reads current then writes the union', async () => {
+    const { client, calls } = fakeClient({
+      'usergroups.users.list': () => ({ ok: true, users: ['U1'] }),
+    });
+    const r = await addUsergroupMembers(client, 'S1', ['U2']);
+    expect(r.added).toEqual(['U2']);
+    const write = calls.find((c) => c.method === 'usergroups.users.update');
+    expect(new Set(write!.params.users.split(','))).toEqual(new Set(['U1', 'U2']));
+  });
+
+  test('add that changes nothing does not write', async () => {
+    const { client, calls } = fakeClient({
+      'usergroups.users.list': () => ({ ok: true, users: ['U1'] }),
+    });
+    const r = await addUsergroupMembers(client, 'S1', ['U1']);
+    expect(r.noop).toBe(true);
+    expect(calls.some((c) => c.method === 'usergroups.users.update')).toBe(false);
+  });
+
+  test('remove writes the reduced list', async () => {
+    const { client, calls } = fakeClient({
+      'usergroups.users.list': () => ({ ok: true, users: ['U1', 'U2'] }),
+    });
+    const r = await removeUsergroupMembers(client, 'S1', ['U2']);
+    expect(r.removed).toEqual(['U2']);
+    const write = calls.find((c) => c.method === 'usergroups.users.update');
+    expect(write!.params.users).toBe('U1');
+  });
+
+  test('refuses to empty the group', async () => {
+    const { client } = fakeClient({
+      'usergroups.users.list': () => ({ ok: true, users: ['U1'] }),
+    });
+    await expect(removeUsergroupMembers(client, 'S1', ['U1'])).rejects.toThrow(/last member/);
   });
 });

--- a/src/lib/usergroups.ts
+++ b/src/lib/usergroups.ts
@@ -115,3 +115,84 @@ export async function fetchUsergroupMembers(
 
   return { ids, members };
 }
+
+// Slack's usergroups.users.update replaces the WHOLE member list. To add or
+// remove specific users we read the current list, apply the change, and write
+// the result back. This computes the next membership without mutating.
+export function applyMembershipChange(
+  current: string[],
+  change: { add?: string[]; remove?: string[] },
+): { next: string[]; added: string[]; removed: string[]; noop: boolean } {
+  const set = new Set(current);
+  const added: string[] = [];
+  const removed: string[] = [];
+
+  for (const id of change.add ?? []) {
+    if (!set.has(id)) {
+      set.add(id);
+      added.push(id);
+    }
+  }
+  for (const id of change.remove ?? []) {
+    if (set.has(id)) {
+      set.delete(id);
+      removed.push(id);
+    }
+  }
+
+  return {
+    next: Array.from(set),
+    added,
+    removed,
+    noop: added.length === 0 && removed.length === 0,
+  };
+}
+
+// Add users to a group (read-modify-write). Returns the change summary plus the
+// group's user list after the write. Refuses to write an empty membership —
+// Slack rejects usergroups.users.update with no users, and an accidental
+// emptying is a footgun we don't want a bare `remove` to hit silently.
+export async function addUsergroupMembers(
+  client: SlackClient,
+  usergroupId: string,
+  addIds: string[],
+  options: LibOptions = {},
+): Promise<{ added: string[]; removed: string[]; next: string[]; noop: boolean }> {
+  return mutateMembers(client, usergroupId, { add: addIds }, options);
+}
+
+export async function removeUsergroupMembers(
+  client: SlackClient,
+  usergroupId: string,
+  removeIds: string[],
+  options: LibOptions = {},
+): Promise<{ added: string[]; removed: string[]; next: string[]; noop: boolean }> {
+  return mutateMembers(client, usergroupId, { remove: removeIds }, options);
+}
+
+async function mutateMembers(
+  client: SlackClient,
+  usergroupId: string,
+  change: { add?: string[]; remove?: string[] },
+  options: LibOptions,
+): Promise<{ added: string[]; removed: string[]; next: string[]; noop: boolean }> {
+  options.onProgress?.('Reading current membership...');
+  const currentResp = await client.listUsergroupUsers(usergroupId, { team_id: options.teamId });
+  const current: string[] = currentResp?.users ?? [];
+
+  const result = applyMembershipChange(current, change);
+  if (result.noop) {
+    return { added: [], removed: [], next: current, noop: true };
+  }
+
+  if (result.next.length === 0) {
+    throw new Error(
+      'Refusing to remove the last member: Slack does not allow a user group with no members. ' +
+        'Disable the group instead (usergroups disable).',
+    );
+  }
+
+  options.onProgress?.('Updating membership...');
+  await client.setUsergroupUsers(usergroupId, result.next.join(','), { team_id: options.teamId });
+  return { added: result.added, removed: result.removed, next: result.next, noop: false };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -312,6 +312,27 @@ export interface UsergroupReadOptions {
   workspace?: string;
 }
 
+export interface UsergroupCreateOptions {
+  handle?: string;
+  description?: string;
+  channels?: string;
+  team?: string;
+  workspace?: string;
+}
+
+export interface UsergroupUpdateOptions {
+  name?: string;
+  handle?: string;
+  description?: string;
+  team?: string;
+  workspace?: string;
+}
+
+export interface UsergroupMembersOptions {
+  team?: string;
+  workspace?: string;
+}
+
 // Custom (workspace) emoji
 export interface CustomEmoji {
   // Emoji short name without the surrounding colons (e.g. `party-parrot`).


### PR DESCRIPTION
## Linked issue

Closes #139

## Summary

Adds the **write** surface of the `usergroups` group, on top of the read-only commands merged in #148. This is the second and final PR of the two-PR split you ruled on for #139.

New subcommands: `create`, `update`, `add`, `remove`, `enable`, `disable`.

**`--yes` confirmation gate** (built on the existing `isInteractiveTerminal()` in `src/lib/interactive-input.ts`, per your ruling): every write subcommand confirms before acting.

- `--yes` → proceeds without prompting.
- Interactive TTY without `--yes` → prompts `y/N`.
- **stdin not a TTY and no `--yes` → REFUSES** with a clear message and a non-zero exit, rather than auto-passing — so a script, CI job, or agent cannot mutate or disable a group unattended by accident. `--yes` is the deliberate opt-in to the non-interactive path.

**`add` / `remove` are read-modify-write.** Slack's `usergroups.users.update` replaces the *entire* member list (no incremental endpoint), so the lib reads the current membership, applies the change, and writes the result back — concurrent members are never dropped, a no-op change skips the write, and it refuses to empty the last member (Slack rejects a zero-member group; disable it instead).

**Enterprise Grid:** all five write `SlackClient` methods thread an optional `team_id`; on an org, writes require `--team <T-id>` (`target_team_must_be_specified_in_org_context` otherwise).

**Auth scope:** writes need the `usergroups:write` user scope — a bot token (`xoxb`) can read but not write; use a user token (`xoxp`) or a browser session (`xoxc`/`xoxd`). Documented in `docs/user-guide/usergroups.md` alongside the `--yes` behavior.

**Tests:** lib-layer cases for `applyMembershipChange` and the add/remove read-modify-write paths (union write, no-op skip, reduced-list write, refuse-to-empty), plus a new `src/commands/usergroups.test.ts` covering `parseUserIds` splitting, `confirmWrite`'s `--yes` and non-TTY-refusal branches, and the command structure (all eight subcommands, `--yes` on the six writes). Full suite: 494 pass on this branch. Manually verified live: the non-TTY-without-`--yes` refusal (exit 1, clear message), and `usergroups --help` shows all eight verbs with `--yes` on the six writes.

## Checklist

- [x] The linked issue is open and carries the `ready-for-pr` label (constitution §1–2)
- [x] Change is focused on the linked issue — no unrelated edits
- [x] Tests added/updated, including edge cases (constitution §4)
- [x] `bun run type-check` and `bun test` pass locally
- [x] Pre-commit hooks are installed and passing — no `--no-verify`, no `SKIP=` (constitution §5)
- [x] All commits are signed (constitution §5 — unsigned commits make the PR unmergeable)
- [x] Documentation in `docs/` updated, added, or deleted as needed (constitution §7)
- [x] No tokens, credentials, or user data handled insecurely

