### PR TITLE
docs: align the README banner alt text with the project tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
-<img src="assets/banner.png" alt="SlackCLI — give your AI agent access to Slack. Read, search, and reply from the terminal. No Slack app needed." width="1000">
+<img src="assets/banner.png" alt="SlackCLI — the Slack CLI for humans and AI agents. Read, send, search and reply across one or many Slack workspaces from the terminal. No Slack app needed." width="1000">
 
-### Work with one — or many — Slack workspaces, straight from your terminal.
+### The Slack CLI for humans and AI agents. Read, send, search and reply across one — or many — Slack workspaces, straight from your terminal.
 
 Read channels, send messages, search history, and catch up on what you missed.
 Built to be **AI-agent friendly**, so your scripts and assistants can use Slack too.


### PR DESCRIPTION
## Linked issue

Fixes #159

## Summary

Uses one sentence for both the README banner alt text and the heading under it. Readers with images disabled and screen-reader users now get the same message as everyone else: who the tool is for, what it does, that it spans one or many workspaces, and that no Slack app is needed.

Documentation only. No code changes.

## Checklist

- [x] The linked issue is open and carries the `ready-for-pr` label (constitution §1–2)
- [x] Change is focused on the linked issue — no unrelated edits
- [x] Tests added/updated, including edge cases (constitution §4) — not applicable, README only
- [x] `bun run type-check` and `bun test` pass locally — not applicable, no code touched
- [x] Pre-commit hooks are installed and passing — no `--no-verify`, no `SKIP=` (constitution §5)
- [x] All commits are signed (constitution §5 — unsigned commits make the PR unmergeable)
- [x] Documentation in `docs/` updated, added, or deleted as needed (constitution §7) — no docs/ change needed
- [x] No tokens, credentials, or user data handled insecurely

https://claude.ai/code/session_01GnfGN1dJ27YRHnMYymVrgs