### PR TITLE
docs: give the user guide pages descriptive titles and link the README to the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ No Slack app to build, no admin approval to wait for.
 [![License](https://img.shields.io/github/license/shaharia-lab/slackcli?style=flat-square)](LICENSE)
 [![Last commit](https://img.shields.io/github/last-commit/shaharia-lab/slackcli?style=flat-square)](https://github.com/shaharia-lab/slackcli/commits/main)
 
-**[Website](https://slackcli.dev) · [Quickstart](#-quickstart) · [What it does](#-what-do-you-want-to-do) · [Commands](#-command-reference) · [Docs](docs/README.md) · [Contributing](#-contributing)**
+**[Website](https://slackcli.dev) · [Quickstart](#-quickstart) · [What it does](#-what-do-you-want-to-do) · [Commands](#-command-reference) · [Docs](https://slackcli.dev/docs/) · [Contributing](#-contributing)**
 
 <br>
 
@@ -44,7 +44,7 @@ https://github.com/user-attachments/assets/90cf1c89-2859-4b84-a731-b0ff3e1172f3
 
 ## ⚡ Quickstart
 
-Three steps, about a minute.
+Three steps, about a minute. Every platform in detail: [installation guide](https://slackcli.dev/docs/user-guide/installation/).
 
 <details open>
 <summary><b>1. Install</b> — pick your platform</summary>
@@ -174,7 +174,8 @@ slackcli messages send --permalink="$LINK" --message="On it 👀"
 
 Every command that returns data speaks `--json`, and so do the commands that write —
 `messages send`, `edit`, and `draft` echo back what they just wrote. SlackCLI drops
-straight into shell pipelines, cron jobs, CI steps, and AI agent toolchains.
+straight into shell pipelines, cron jobs, CI steps, and AI agent toolchains. The
+[scripting guide](https://slackcli.dev/docs/user-guide/scripting/) covers the output contract in full.
 
 ```bash
 # Who is talking about the outage, and when?
@@ -406,7 +407,7 @@ In rough order of usefulness:
 
 ## 📚 Documentation
 
-Everything lives in [`docs/`](docs/README.md).
+Everything is published at [slackcli.dev/docs](https://slackcli.dev/docs/) and lives in [`docs/`](docs/README.md).
 
 <table>
 <tr>

--- a/docs/user-guide/authentication.md
+++ b/docs/user-guide/authentication.md
@@ -1,4 +1,4 @@
-# Authentication
+# Authentication: browser session or Slack app token
 
 SlackCLI supports two kinds of credentials, and four ways to obtain them.
 

--- a/docs/user-guide/canvas.md
+++ b/docs/user-guide/canvas.md
@@ -1,4 +1,4 @@
-# Canvas
+# Read a Slack Canvas as Markdown
 
 `slackcli canvas` lists Slack canvases and reads them as Markdown, which makes
 them usable in a terminal, a diff, or an AI agent's context.

--- a/docs/user-guide/claude-code-plugin.md
+++ b/docs/user-guide/claude-code-plugin.md
@@ -1,4 +1,4 @@
-# Claude Code plugin
+# Slack CLI for Claude Code: plugin and skill
 
 SlackCLI ships a [Claude Code](https://claude.com/claude-code) plugin with one
 skill, `/slackcli`, so an agent can read, post, search, and manage a Slack

--- a/docs/user-guide/conversations.md
+++ b/docs/user-guide/conversations.md
@@ -1,4 +1,4 @@
-# Conversations
+# Read Slack channels, threads and unreads
 
 `slackcli conversations` covers channels, DMs, and group DMs: listing them,
 reading history and threads, fetching one message, and seeing what is unread.

--- a/docs/user-guide/emoji.md
+++ b/docs/user-guide/emoji.md
@@ -1,4 +1,4 @@
-# Emoji
+# List a workspace's custom emoji
 
 `slackcli emoji` reads a workspace's **custom emoji** — the ones an admin or
 member uploaded, not the built-in Unicode set.

--- a/docs/user-guide/files.md
+++ b/docs/user-guide/files.md
@@ -1,4 +1,4 @@
-# Files
+# Inspect, read and download Slack files
 
 `slackcli files` inspects metadata, prints textual content, and downloads
 Slack-hosted files. Every command accepts a file ID or Slack file URL.

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -1,4 +1,4 @@
-# Installation
+# Install SlackCLI on macOS, Linux and Windows
 
 SlackCLI ships as a single self-contained binary. There is no runtime to install
 — you do not need Bun or Node.js to *run* it.

--- a/docs/user-guide/messages.md
+++ b/docs/user-guide/messages.md
@@ -1,4 +1,4 @@
-# Messages
+# Send, reply, edit and react to Slack messages
 
 `slackcli messages` sends, edits, reacts to, and drafts messages.
 

--- a/docs/user-guide/saved.md
+++ b/docs/user-guide/saved.md
@@ -1,4 +1,4 @@
-# Saved items
+# Work through Slack saved items
 
 `slackcli saved list` reads your **Later** / "saved for later" list.
 

--- a/docs/user-guide/scripting.md
+++ b/docs/user-guide/scripting.md
@@ -1,4 +1,4 @@
-# Scripting and JSON output
+# Scripting SlackCLI from shell scripts and AI agents
 
 SlackCLI is built to be driven by scripts, cron jobs, and AI agents as much as by
 hand.

--- a/docs/user-guide/search.md
+++ b/docs/user-guide/search.md
@@ -1,4 +1,4 @@
-# Search
+# Search Slack messages, channels and people
 
 `slackcli search` covers messages, channels, and people. Every subcommand
 accepts `--workspace <id|name>` and `--json`.

--- a/docs/user-guide/team.md
+++ b/docs/user-guide/team.md
@@ -1,4 +1,4 @@
-# Team
+# Workspace and team information
 
 `slackcli team` reads information about the **workspace (team) itself** — its
 name, domain, and ID.

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -1,4 +1,4 @@
-# Troubleshooting
+# Troubleshooting SlackCLI
 
 ## `No workspace configured`
 

--- a/docs/user-guide/usergroups.md
+++ b/docs/user-guide/usergroups.md
@@ -1,4 +1,4 @@
-# User groups
+# Slack user groups from the CLI
 
 `slackcli usergroups` lists, reads, and manages **user groups** — Slack's own
 name for a named, mentionable group of people (also called a "subteam", e.g.

--- a/docs/user-guide/workspaces.md
+++ b/docs/user-guide/workspaces.md
@@ -1,4 +1,4 @@
-# Workspaces and profiles
+# Use several Slack workspaces from one CLI
 
 Every authenticated Slack workspace is stored under a **profile key** in
 `~/.config/slackcli/workspaces.json`. The first workspace you add automatically

--- a/web/docs.manifest.mjs
+++ b/web/docs.manifest.mjs
@@ -57,7 +57,14 @@ export const PAGES = [
   { file: 'user-guide/files.md', slug: 'user-guide/files', label: 'Files', group: 'users' },
   { file: 'user-guide/emoji.md', slug: 'user-guide/emoji', label: 'Emoji', group: 'users' },
   { file: 'user-guide/scripting.md', slug: 'user-guide/scripting', label: 'Scripting and JSON', group: 'users' },
-  { file: 'user-guide/claude-code-plugin.md', slug: 'user-guide/claude-code-plugin', label: 'Claude Code plugin', group: 'users' },
+  {
+    file: 'user-guide/claude-code-plugin.md',
+    slug: 'user-guide/claude-code-plugin',
+    label: 'Claude Code plugin',
+    group: 'users',
+    description:
+      'Install the slackcli plugin in Claude Code and give the agent a skill that reads, searches and replies in Slack from the terminal.',
+  },
   {
     file: 'user-guide/troubleshooting.md',
     slug: 'user-guide/troubleshooting',

--- a/web/src/content/blog/designing-a-cli-an-agent-can-drive.md
+++ b/web/src/content/blog/designing-a-cli-an-agent-can-drive.md
@@ -1,6 +1,6 @@
 ---
 title: Designing a CLI an AI agent can actually drive
-description: "--json on the read commands is the easy half. The rules that make a tool safe for something that cannot read a spinner are stricter than they look, and one of them cost us a bug that only showed up past 64 KiB."
+description: "--json on the read commands is the easy half. The rules that make a tool safe for something that cannot read a spinner are stricter than they look."
 date: 2026-08-28
 author: Shaharia Azam
 tags: ['Design', 'Scripting']

--- a/web/src/content/blog/slack-without-a-slack-app.md
+++ b/web/src/content/blog/slack-without-a-slack-app.md
@@ -1,6 +1,6 @@
 ---
 title: Automating Slack without creating a Slack app
-description: Most Slack tooling dies at the words "ask your workspace admin". SlackCLI takes a second route in, using the session your browser already holds, and this is how that works and what it costs.
+description: Most Slack tooling dies at the words "ask your workspace admin". SlackCLI takes a second route in, using the session your browser already holds.
 date: 2026-08-14
 author: Shaharia Azam
 tags: ['Authentication', 'Design']

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -119,7 +119,7 @@ const schema = [
     license: `${REPO}/blob/main/LICENSE`,
     isAccessibleForFree: true,
     description:
-      'A command-line interface for Slack workspaces. Read channels and threads, send and reply, search, and drive it all from a shell script or an AI agent, using either a Slack app token or your own signed-in browser session.',
+      'The Slack CLI for humans and AI agents. Read, send, search and reply across one or many Slack workspaces from the terminal. No Slack app needed.',
     featureList: [
       'Read channels, DMs, threads and unreads',
       'Send, reply, edit, react, draft and upload files',
@@ -130,6 +130,7 @@ const schema = [
     ],
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
     author: { '@type': 'Organization', name: ORG.name, url: ORG.url },
+    sameAs: [REPO],
   },
   {
     '@context': 'https://schema.org',
@@ -154,7 +155,7 @@ const schema = [
 
 <Page
   title="SlackCLI - the Slack CLI for humans and AI agents"
-  description="Read, send, search and reply across your Slack workspaces from the terminal. One binary, no Slack app to register, no admin approval, and JSON output on every command."
+  description="Read, send, search and reply across your Slack workspaces from the terminal. One binary, no Slack app to register, and JSON output on every command."
 >
   <JsonLd slot="head" schema={schema} />
 
@@ -167,7 +168,7 @@ const schema = [
         <span class="pill pill--plain">No Slack app required</span>
       </div>
 
-      <h1 class="hero__title">Slack, without the <em>tab</em>.</h1>
+      <h1 class="hero__title">The Slack CLI, without the <em>tab</em>.</h1>
 
       <p class="hero__lede">
         SlackCLI is a single binary that reads, sends, searches and replies across one{' '}


### PR DESCRIPTION
## Linked issue

Fixes #166

## Summary

- **User guide titles.** Every `docs/user-guide/*.md` H1 now says what the page lets you do ("Send, reply, edit and react to Slack messages", "Install SlackCLI on macOS, Linux and Windows", "Slack CLI for Claude Code: plugin and skill"). The site takes its page titles from these H1s; sidebar labels come from the manifest and are unchanged. No heading anchors pointed at an H1, and `npm run check:links` passes on all 31 pages.
- **README.** The Docs nav link, the Quickstart, the "Built to be scripted" section and the Documentation section now link to the corresponding pages on slackcli.dev.
- **Landing page.** The H1 names the tool; the summary sentence in the structured data matches the README and repository description; `sameAs` points at the repository; the meta description is trimmed to display in full.
- **Blog and plugin page descriptions** trimmed to display in full.

Documentation and website copy only. No code changes.

## Checklist

- [x] The linked issue is open and carries the `ready-for-pr` label (constitution §1–2)
- [x] Change is focused on the linked issue — no unrelated edits
- [x] Tests added/updated, including edge cases (constitution §4) — not applicable, docs and site copy only
- [x] `bun run type-check` and `bun test` pass locally — not applicable, no code touched; site builds and link check passes
- [x] Pre-commit hooks are installed and passing — no `--no-verify`, no `SKIP=` (constitution §5)
- [x] All commits are signed (constitution §5 — unsigned commits make the PR unmergeable)
- [x] Documentation in `docs/` updated, added, or deleted as needed (constitution §7)
- [x] No tokens, credentials, or user data handled insecurely

https://claude.ai/code/session_01GnfGN1dJ27YRHnMYymVrgs