### PR TITLE
docs: list every user-guide page in the documentation index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,9 +21,14 @@ Start here if you want to *use* SlackCLI.
 | [Conversations](user-guide/conversations.md) | List channels and DMs, read history, threads, unreads |
 | [Messages](user-guide/messages.md) | Send, reply, edit, react, draft, attach files, Block Kit |
 | [Search](user-guide/search.md) | Search messages, channels, and people |
+| [Team](user-guide/team.md) | Read the workspace's own name, domain, and ID |
+| [User groups](user-guide/usergroups.md) | List and read user groups, and manage them behind `--yes` |
 | [Saved items](user-guide/saved.md) | Read your "saved for later" list |
 | [Canvas](user-guide/canvas.md) | List canvases and read them as Markdown |
+| [Files](user-guide/files.md) | Inspect, read, and download Slack-hosted files |
+| [Emoji](user-guide/emoji.md) | List a workspace's custom emoji and inspect one |
 | [Scripting and JSON output](user-guide/scripting.md) | Piping into `jq`, exit codes, automation patterns |
+| [Claude Code plugin](user-guide/claude-code-plugin.md) | The `/slackcli` skill, so an agent can drive Slack |
 | [Troubleshooting](user-guide/troubleshooting.md) | Auth failures, permissions, update problems |
 
 ## Developer documentation


### PR DESCRIPTION
## Summary

Nightly documentation sync. Scope: one merged PR, **#168 — chore: release v0.11.0**.

**#168 needs no documentation change.** It touches only `package.json` (version bump) and `CHANGELOG.md` (promoting `[Unreleased]` to `## [0.11.0]`). No command, flag, default, output shape or auth path moved, and `docs/` names no version — the one version string in `docs/development/build-and-release.md` is a placeholder in an example `git tag` line and is deliberately not bumped per release.

## What this PR does fix

The audit of `docs/` against the tree turned up a real desync in the top-level index. Five pages exist under `docs/user-guide/` and are listed in `docs/user-guide/README.md`, but were never added to the table in `docs/README.md`:

- `team.md` (#148)
- `usergroups.md` (#148, #156)
- `files.md` (#161)
- `emoji.md` (#149)
- `claude-code-plugin.md` (#163)

Each of those feature PRs shipped its own page and updated the user-guide index, but not the top-level one. That table is not only the GitHub entry point — `web/docs.manifest.mjs` publishes `docs/README.md` as the site's `/docs/` landing page, so five command groups were undiscoverable from it on <https://slackcli.dev> as well.

The rows are inserted in the order `docs/user-guide/README.md` lists them, which is the order `web/docs.manifest.mjs` already follows for the sidebar, so the three stay in step.

## Deliberately not changed

- Nothing for the release itself, per the reasoning above.
- No prose rewrites elsewhere. The rest of the user guide and developer docs were spot-checked against `src/commands/`, `src/lib/workspaces.ts` and the workflows and are accurate.
- No new page. Every command group already has one.

## Verification

- All 26 relative links in `docs/README.md` resolve to real paths.
- `git diff --stat origin/main...HEAD` shows `docs/README.md` only, +5 lines.
- Nothing outside `docs/` is touched, so `type-check` / `bun test` were not required.

---

Opened by the scheduled documentation-sync job. Labelled `no-issue-needed`: the changes being documented were already triaged in the PRs above, so there is no separate feature to propose.